### PR TITLE
fix(KFLUXUI-185): only suggest branches

### DIFF
--- a/src/components/ImportForm/ComponentSection/GitOptions.tsx
+++ b/src/components/ImportForm/ComponentSection/GitOptions.tsx
@@ -14,7 +14,7 @@ const GitOptions: React.FC<React.PropsWithChildren<unknown>> = () => {
           <InputField
             name="source.git.revision"
             label="Git reference"
-            helperText="Optional branch, tag or commit."
+            helperText="Optional branch."
             data-test="git-reference"
           />
 


### PR DESCRIPTION
Using a tag or commit can have unintended consequences. Lets only recommend that users use a branch when setting up their components.

Backport of https://github.com/openshift/hac-dev/pull/1004
