### PR TITLE
fix: websocket connection to the k8s api

### DIFF
--- a/src/k8s/k8s-utils.ts
+++ b/src/k8s/k8s-utils.ts
@@ -237,6 +237,7 @@ export const k8sWatch = (
   const path = getK8sResourceURL(kind, undefined, opts);
   wsOptionsUpdated.path = `/wss/k8s${path}`;
   wsOptionsUpdated.host = 'auto';
+  wsOptionsUpdated.subProtocols = ['base64.binary.k8s.io'];
 
   return new WebSocketFactory(path, wsOptionsUpdated);
 };


### PR DESCRIPTION
When connecting to the k8s api using a websocket
the "base64.binary.k8s.io" subprotocol should be mentioned.