### PR TITLE
fix(KFLUXUI-190): use status.managedProcessing to get the pipelineRun for Release

### DIFF
--- a/src/components/Releases/ReleaseOverviewTab.tsx
+++ b/src/components/Releases/ReleaseOverviewTab.tsx
@@ -17,16 +17,22 @@ import { useReleaseStatus } from '../../hooks/useReleaseStatus';
 import { useWorkspaceResource } from '../../hooks/useWorkspaceResource';
 import { RouterParams } from '../../routes/utils';
 import { Timestamp } from '../../shared/components/timestamp/Timestamp';
+import { ReleaseKind } from '../../types/release';
 import { calculateDuration } from '../../utils/pipeline-utils';
 import MetadataList from '../MetadataList';
 import { StatusIconWithText } from '../StatusIcon/StatusIcon';
 import { useWorkspaceInfo } from '../Workspace/useWorkspaceInfo';
 
+const getPipelineRunFromRelease = (release: ReleaseKind): string => {
+  // backward compatibility until https://issues.redhat.com/browse/RELEASE-1109 is released.
+  return release.status?.processing?.pipelineRun ?? release.status?.managedProcessing?.pipelineRun;
+};
+
 const ReleaseOverviewTab: React.FC = () => {
   const { releaseName } = useParams<RouterParams>();
   const { namespace, workspace } = useWorkspaceInfo();
   const [release] = useRelease(workspace, namespace, releaseName);
-  const [pipelineRun, prWorkspace] = useWorkspaceResource(release.status?.processing?.pipelineRun);
+  const [pipelineRun, prWorkspace] = useWorkspaceResource(getPipelineRunFromRelease(release));
   const [releasePlan, releasePlanLoaded] = useReleasePlan(
     namespace,
     workspace,
@@ -126,12 +132,6 @@ const ReleaseOverviewTab: React.FC = () => {
                 <DescriptionListTerm>Release Target</DescriptionListTerm>
                 <DescriptionListDescription>
                   <>{release.status?.target ?? '-'}</>
-                </DescriptionListDescription>
-              </DescriptionListGroup>
-              <DescriptionListGroup>
-                <DescriptionListTerm>Release Strategy</DescriptionListTerm>
-                <DescriptionListDescription>
-                  {release.status?.processing?.releaseStrategy?.split('/')[1] ?? '-'}
                 </DescriptionListDescription>
               </DescriptionListGroup>
               <DescriptionListGroup>

--- a/src/components/Releases/__tests__/ReleaseOverviewTab.spec.tsx
+++ b/src/components/Releases/__tests__/ReleaseOverviewTab.spec.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { createK8sWatchResourceMock, createUseWorkspaceInfoMock } from '../../../utils/test-utils';
-import { mockReleases } from '../__data__/mock-release-data';
+import { mockReleases, mockReleaseWithManagedProcessing } from '../__data__/mock-release-data';
 import ReleaseOverviewTab from '../ReleaseOverviewTab';
 
 jest.mock('react-router-dom', () => ({
@@ -50,6 +50,14 @@ describe('ReleaseOverviewTab', () => {
     expect(screen.getByText('Release Target')).toBeVisible();
     expect(screen.getByText('test-target')).toBeVisible();
 
+    expect(screen.getByText('Pipeline Run')).toBeVisible();
+    expect(screen.getByRole('link', { name: 'test-pipelinerun' }).getAttribute('href')).toBe(
+      '/workspaces/target-ws/applications/test-app/pipelineruns/test-pipelinerun',
+    );
+  });
+
+  it('should render correct details if managedProcessing', () => {
+    render(<ReleaseOverviewTab release={mockReleaseWithManagedProcessing} />);
     expect(screen.getByText('Pipeline Run')).toBeVisible();
     expect(screen.getByRole('link', { name: 'test-pipelinerun' }).getAttribute('href')).toBe(
       '/workspaces/target-ws/applications/test-app/pipelineruns/test-pipelinerun',

--- a/src/types/release.ts
+++ b/src/types/release.ts
@@ -15,6 +15,13 @@ export type ReleaseKind = K8sResourceCommon & {
     startTime?: string;
     completionTime?: string;
     automated?: boolean;
+    managedProcessing?: {
+      completionTime?: string;
+      pipelineRun?: string;
+      startTime?: string;
+      roleBinding?: string;
+    };
+    // keep this for backward compatibility
     processing?: {
       target?: string;
       pipelineRun?: string;


### PR DESCRIPTION
Backports KFLUXBUGS-1683