### PR TITLE
fix(KONFLUX-5721): change workspace to namespace for release and do not  append suffix to namespace

### DIFF
--- a/src/components/ReleaseService/ReleasePlan/ReleasePlanForm/ReleasePlanForm.tsx
+++ b/src/components/ReleaseService/ReleasePlan/ReleasePlanForm/ReleasePlanForm.tsx
@@ -65,7 +65,7 @@ export const ReleasePlanForm: React.FC<Props> = ({
           />
           <ApplicationDropdown
             name="application"
-            helpText="The application you want to release to the environments in your target workspace."
+            helpText="The application you want to release to the environments in your target namespace."
             required
           />
           <RunReleasePipelineSection />

--- a/src/components/ReleaseService/ReleasePlan/ReleasePlanForm/RunReleasePipelineSection.tsx
+++ b/src/components/ReleaseService/ReleasePlan/ReleasePlanForm/RunReleasePipelineSection.tsx
@@ -48,7 +48,7 @@ const GitOptions: React.FC<{ required?: boolean }> = ({ required = false }) => {
 export const RunReleasePipelineSection: React.FC = () => {
   const [{ value: pipelineLocation }] =
     useField<ReleasePipelineLocation>('releasePipelineLocation');
-  const { workspace } = useWorkspaceInfo();
+  const { namespace } = useWorkspaceInfo();
 
   return (
     <>
@@ -58,9 +58,9 @@ export const RunReleasePipelineSection: React.FC = () => {
         options={[
           {
             value: ReleasePipelineLocation.current,
-            label: `In this workspace: ${workspace}`,
+            label: `In this namespace: ${namespace}`,
           },
-          { value: ReleasePipelineLocation.target, label: 'In a target workspace' },
+          { value: ReleasePipelineLocation.target, label: 'In a target namespace' },
         ]}
         required
       />
@@ -110,12 +110,12 @@ export const RunReleasePipelineSection: React.FC = () => {
         <>
           <InputField
             name="target"
-            label="Target workspace"
-            helperText="Type the workspace name that you would like the selected application to be released to"
+            label="Target namespace"
+            helperText="Type the namespace name that you would like the selected application to be released to."
             labelIcon={
               <HelpPopover
-                headerContent="Target workspace"
-                bodyContent="Your application will be released to the environments in this workspace."
+                headerContent="Target namespace"
+                bodyContent="Your application will be released to the environments in this namespace."
               />
             }
             required

--- a/src/components/ReleaseService/ReleasePlan/ReleasePlanForm/__tests__/ReleasePlanForm.spec.tsx
+++ b/src/components/ReleaseService/ReleasePlan/ReleasePlanForm/__tests__/ReleasePlanForm.spec.tsx
@@ -28,8 +28,8 @@ describe('ReleasePlanForm', () => {
     expect(result.getByRole('heading', { name: 'Create release plan' })).toBeVisible();
     expect(result.getByRole('button', { name: 'Create' })).toBeVisible();
     expect(result.getByRole('button', { name: 'Create' })).toBeVisible();
-    expect(result.getByRole('radio', { name: 'In this workspace: test-ws' })).toBeVisible();
-    expect(result.getByRole('radio', { name: 'In a target workspace' })).toBeVisible();
+    expect(result.getByRole('radio', { name: 'In this namespace: test-ns' })).toBeVisible();
+    expect(result.getByRole('radio', { name: 'In a target namespace' })).toBeVisible();
     expect(result.getByRole('checkbox', { name: 'Auto release' })).toBeVisible();
     expect(result.getByRole('checkbox', { name: 'Standing attribution' })).toBeVisible();
     expect(result.getByRole('textbox', { name: 'Release plan name' })).toBeVisible();

--- a/src/components/ReleaseService/ReleasePlan/ReleasePlanForm/__tests__/RunReleasePipelineSection.spec.tsx
+++ b/src/components/ReleaseService/ReleasePlan/ReleasePlanForm/__tests__/RunReleasePipelineSection.spec.tsx
@@ -61,7 +61,7 @@ describe('RunReleasePipelineSection', () => {
     expect(
       result.getByRole('region', { name: 'Git options for the release pipeline' }),
     ).toBeVisible();
-    expect(result.getByRole('textbox', { name: 'Target workspace' })).toBeVisible();
+    expect(result.getByRole('textbox', { name: 'Target namespace' })).toBeVisible();
     expect(result.getByRole('textbox', { name: 'Data' })).toBeVisible();
   });
 });

--- a/src/components/ReleaseService/ReleasePlan/ReleasePlanForm/__tests__/form-utils.spec.ts
+++ b/src/components/ReleaseService/ReleasePlan/ReleasePlanForm/__tests__/form-utils.spec.ts
@@ -18,7 +18,7 @@ describe('createReleasePlan', () => {
     k8sUpdateMock.mockImplementation((obj) => obj.resource);
   });
 
-  it('should use active workspace for current release pipeline location', async () => {
+  it('should use active namespace for current release pipeline location', async () => {
     const result = await createReleasePlan(
       {
         name: 'test-plan',
@@ -32,8 +32,8 @@ describe('createReleasePlan', () => {
           path: '/',
         },
       },
-      'test-ns',
-      'test-ws',
+      'test-ns-tenant',
+      'test-ws-tenant',
     );
     expect(result).toEqual(
       expect.objectContaining({
@@ -43,7 +43,7 @@ describe('createReleasePlan', () => {
             'release.appstudio.openshift.io/standing-attribution': 'false',
           },
           name: 'test-plan',
-          namespace: 'test-ns',
+          namespace: 'test-ns-tenant',
         },
         spec: {
           application: 'test-app',
@@ -64,7 +64,7 @@ describe('createReleasePlan', () => {
             ],
             resolver: 'git',
           },
-          target: 'test-ws-tenant',
+          target: 'test-ns-tenant',
         },
       }),
     );
@@ -75,7 +75,7 @@ describe('createReleasePlan', () => {
       {
         name: 'test-plan',
         application: 'test-app',
-        target: 'target-ws',
+        target: 'target-ws-tenant',
         releasePipelineLocation: ReleasePipelineLocation.target,
         labels: [],
         params: [],
@@ -85,8 +85,8 @@ describe('createReleasePlan', () => {
           path: '/',
         },
       },
-      'test-ns',
-      'test-ws',
+      'test-ns-tenant',
+      'test-ws-tenant',
     );
     expect(result).toEqual(
       expect.objectContaining({
@@ -131,8 +131,8 @@ describe('createReleasePlan', () => {
           path: '/',
         },
       },
-      'test-ns',
-      'test-ws',
+      'test-ns-tenant',
+      'test-ws-tenant',
     );
     expect(result.metadata.labels).toEqual({
       'release.appstudio.openshift.io/auto-release': 'true',
@@ -154,8 +154,8 @@ describe('createReleasePlan', () => {
           path: '/',
         },
       },
-      'test-ns',
-      'test-ws',
+      'test-ns-tenant',
+      'test-ws-tenant',
     );
     expect(result.metadata.labels).toEqual({
       'release.appstudio.openshift.io/auto-release': 'true',
@@ -182,7 +182,7 @@ describe('editReleasePlan', () => {
           path: '/',
         },
       },
-      'my-ws',
+      'my-ws-tenant',
     );
 
     expect(result.spec.target).toBe('my-ws-tenant');

--- a/src/components/ReleaseService/ReleasePlan/ReleasePlanForm/form-utils.ts
+++ b/src/components/ReleaseService/ReleasePlan/ReleasePlanForm/form-utils.ts
@@ -15,8 +15,6 @@ export enum ReleasePipelineLocation {
   target,
 }
 
-const WORKSPACE_SUFFIX = 'tenant';
-
 export type ReleasePlanFormValues = {
   name: string;
   application: string;
@@ -88,7 +86,7 @@ export const createReleasePlan = async (
     autoRelease,
     standingAttribution,
   } = values;
-  const targetWs = releasePipelineLocation === ReleasePipelineLocation.current ? workspace : target;
+  const targetNs = releasePipelineLocation === ReleasePipelineLocation.current ? namespace : target;
   const labels = labelPairs
     .filter((l) => !!l.key)
     .reduce((acc, o) => ({ ...acc, [o.key]: o.value }), {} as Record<string, string>);
@@ -110,7 +108,7 @@ export const createReleasePlan = async (
       application,
       ...(data ? { data } : {}),
       serviceAccount,
-      target: `${targetWs}-${WORKSPACE_SUFFIX}`,
+      target: `${targetNs}`,
       pipelineRef: {
         resolver: ResolverType.GIT,
         params: [
@@ -152,7 +150,7 @@ export const editReleasePlan = async (
     autoRelease,
     standingAttribution,
   } = values;
-  const targetWs = releasePipelineLocation === ReleasePipelineLocation.current ? workspace : target;
+  const targetNs = releasePipelineLocation === ReleasePipelineLocation.current ? workspace : target;
   const labels = labelPairs
     .filter((l) => !!l.key)
     .reduce((acc, o) => ({ ...acc, [o.key]: o.value }), {} as Record<string, string>);
@@ -175,7 +173,7 @@ export const editReleasePlan = async (
       application,
       ...(data ? { data } : {}),
       serviceAccount,
-      target: `${targetWs}-${WORKSPACE_SUFFIX}`,
+      target: `${targetNs}`,
       pipelineRef: {
         resolver: ResolverType.GIT,
         params: [

--- a/src/components/ReleaseService/ReleasePlan/ReleasePlanListHeader.tsx
+++ b/src/components/ReleaseService/ReleasePlan/ReleasePlanListHeader.tsx
@@ -20,7 +20,7 @@ const ReleasePlanListHeader = () => {
       props: { className: releasesPlanTableColumnClasses.application },
     },
     {
-      title: 'Target Workspace',
+      title: 'Target Namespace',
       props: { className: releasesPlanTableColumnClasses.target },
     },
     {


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/KONFLUX-5721


## Description
1. We change the workspace to namespace in konflux release section.
2. When users create/edit the release plan, konflux ui do not append the suffix '-tenant' to the input target namespace automatically.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
1. releases page
![Screenshot 2025-01-09 at 16 33 31](https://github.com/user-attachments/assets/031bcb22-36a6-4a47-9d5d-a2cdf9d0060b)
2. create release page
![Screenshot 2025-01-09 at 16 34 08](https://github.com/user-attachments/assets/d37eabe3-a551-4e5e-96fe-e3d3b1c5a2e7)
3. edit release plan
![Screenshot 2025-01-09 at 16 35 28](https://github.com/user-attachments/assets/1b25ecdb-296f-4cac-bd6d-e6911e7ebc83)

## How to test or reproduce?
1. Navigate to 'Releases'. 
2. Create one RPA 
3. Create one release
4. edit the release

Excepted Results: 
All pages show 'target namespace' and when we change the target namespace, there is no '-tenant' appended by UI.


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
