### PR TITLE
feat(KFLUXUI-266): Replaced GitHub mentions with Git 

### DIFF
--- a/e2e-tests/support/pages/tabs/IntegrationTestsTabPage.ts
+++ b/e2e-tests/support/pages/tabs/IntegrationTestsTabPage.ts
@@ -6,7 +6,7 @@ import { integrationTestsTabPO, addIntegrationTestStepPO } from '../../pageObjec
 
 type integrationTableRow = {
   name: string;
-  githubURL: string;
+  gitURL: string;
   optionalForRelease: string;
   revision: string;
 };
@@ -27,14 +27,14 @@ export class IntegrationTestsTabPage {
 
   addIntegrationTest(
     integrationTestName: string,
-    githubURL: string,
+    gitURL: string,
     revision: string,
     pathInRepository: string,
     markOptionalForRelease?: string,
   ) {
     this.verifySaveChangesIsDisabled();
     UIhelper.inputValueInTextBoxByLabelName('Integration test name', integrationTestName);
-    UIhelper.inputValueInTextBoxByLabelName('Git URL', githubURL);
+    UIhelper.inputValueInTextBoxByLabelName('Git URL', gitURL);
     UIhelper.inputValueInTextBoxByLabelName('Revision', revision);
     UIhelper.inputValueInTextBoxByLabelName('Path in repository', pathInRepository);
     if (markOptionalForRelease === 'uncheck') {
@@ -47,12 +47,12 @@ export class IntegrationTestsTabPage {
     Common.waitForLoad();
   }
 
-  editIntegrationTest(githubURL: string, markOptionalForRelease?: string) {
+  editIntegrationTest(gitURL: string, markOptionalForRelease?: string) {
     this.verifyIntegrationNameIsDisabled();
     this.verifySaveChangesIsDisabled();
 
-    if (githubURL) {
-      UIhelper.inputValueInTextBoxByLabelName('Git URL', githubURL);
+    if (gitURL) {
+      UIhelper.inputValueInTextBoxByLabelName('Git URL', gitURL);
     }
 
     if (markOptionalForRelease === 'uncheck')
@@ -78,7 +78,7 @@ export class IntegrationTestsTabPage {
 
   verifyRowInIntegrationTestsTable(rowDetails: integrationTableRow) {
     UIhelper.verifyRowInTable('Integration tests', rowDetails.name, [
-      new RegExp(rowDetails.githubURL),
+      new RegExp(rowDetails.gitURL),
       new RegExp(`^\\s*${rowDetails.optionalForRelease}\\s*$`),
       new RegExp(`^\\s*${rowDetails.revision}\\s*$`),
     ]);

--- a/e2e-tests/support/pages/tabs/IntegrationTestsTabPage.ts
+++ b/e2e-tests/support/pages/tabs/IntegrationTestsTabPage.ts
@@ -34,7 +34,7 @@ export class IntegrationTestsTabPage {
   ) {
     this.verifySaveChangesIsDisabled();
     UIhelper.inputValueInTextBoxByLabelName('Integration test name', integrationTestName);
-    UIhelper.inputValueInTextBoxByLabelName('GitHub URL', githubURL);
+    UIhelper.inputValueInTextBoxByLabelName('Git URL', githubURL);
     UIhelper.inputValueInTextBoxByLabelName('Revision', revision);
     UIhelper.inputValueInTextBoxByLabelName('Path in repository', pathInRepository);
     if (markOptionalForRelease === 'uncheck') {
@@ -52,7 +52,7 @@ export class IntegrationTestsTabPage {
     this.verifySaveChangesIsDisabled();
 
     if (githubURL) {
-      UIhelper.inputValueInTextBoxByLabelName('GitHub URL', githubURL);
+      UIhelper.inputValueInTextBoxByLabelName('Git URL', githubURL);
     }
 
     if (markOptionalForRelease === 'uncheck')

--- a/src/components/IntegrationTests/IntegrationTestDetails/tabs/__tests__/IntegrationTestOverviewTab.spec.tsx
+++ b/src/components/IntegrationTests/IntegrationTestDetails/tabs/__tests__/IntegrationTestOverviewTab.spec.tsx
@@ -59,7 +59,7 @@ describe('IntegrationTestOverviewTab', () => {
     routerRenderer(<IntegrationTestOverviewTab />);
     screen.getByText('test-app-test-1'); // name
     screen.getByText('test-namespace'); // namespace
-    screen.getByText('GitHub URL'); // url
+    screen.getByText('Git URL'); // url
     screen.getByText('Path in repository'); // Path in Repo
     screen.getByText('Revision'); // revision
     screen.getByText('Optional'); // optional for release

--- a/src/components/IntegrationTests/IntegrationTestForm/IntegrationTestSection.tsx
+++ b/src/components/IntegrationTests/IntegrationTestForm/IntegrationTestSection.tsx
@@ -52,7 +52,7 @@ const IntegrationTestSection: React.FC<React.PropsWithChildren<Props>> = ({ isIn
           name="integrationTest.url"
           placeholder="Enter your source"
           validated={validated}
-          label="GitHub URL"
+          label="Git URL"
           required
           data-test="git-url-input"
         />

--- a/src/components/IntegrationTests/IntegrationTestForm/__tests__/IntegrationTestView.spec.tsx
+++ b/src/components/IntegrationTests/IntegrationTestForm/__tests__/IntegrationTestView.spec.tsx
@@ -96,7 +96,7 @@ describe('IntegrationTestView', () => {
     fireEvent.input(wrapper.getByLabelText(/Integration test name/), {
       target: { value: 'new-test-name' },
     });
-    fireEvent.input(wrapper.getByLabelText(/GitHub URL/), {
+    fireEvent.input(wrapper.getByLabelText(/Git URL/), {
       target: { value: 'quay.io/kpavic/test-bundle:pipeline' },
     });
     fireEvent.input(wrapper.getByLabelText(/Revision/), {
@@ -115,7 +115,7 @@ describe('IntegrationTestView', () => {
     expect(wrapper).toBeTruthy();
 
     wrapper.getByLabelText(/Integration test name/);
-    wrapper.getByLabelText(/GitHub URL/);
+    wrapper.getByLabelText(/Git URL/);
     wrapper.getByLabelText(/Revision/);
     wrapper.getByLabelText(/Path in repository/);
     wrapper.getByRole('button', { name: 'Add integration test' });
@@ -167,7 +167,7 @@ describe('IntegrationTestView', () => {
     expect(wrapper.getByLabelText(/Integration test name/).getAttribute('value')).toBe(
       'test-app-test-2',
     );
-    expect(wrapper.getByLabelText(/GitHub URL/).getAttribute('value')).toEqual('test-url2');
+    expect(wrapper.getByLabelText(/Git URL/).getAttribute('value')).toEqual('test-url2');
     expect(wrapper.getByLabelText(/Revision/).getAttribute('value')).toEqual('main2');
 
     expect(wrapper.getByLabelText(/Path in repository/).getAttribute('value')).toEqual(

--- a/src/components/IntegrationTests/IntegrationTestForm/utils/__tests__/create-utils.spec.ts
+++ b/src/components/IntegrationTests/IntegrationTestForm/utils/__tests__/create-utils.spec.ts
@@ -147,7 +147,7 @@ describe('Create Utils', () => {
 
   it('Should return correct labels for params', () => {
     const resource = MockIntegrationTestsWithGit[0];
-    expect(getLabelForParam(resource.spec.resolverRef.params[0].name)).toBe('GitHub URL');
+    expect(getLabelForParam(resource.spec.resolverRef.params[0].name)).toBe('Git URL');
     expect(getLabelForParam(resource.spec.resolverRef.params[1].name)).toBe('Revision');
     expect(getLabelForParam(resource.spec.resolverRef.params[2].name)).toBe('Path in repository');
     expect(getLabelForParam('test-param' as ResolverRefParams)).toBe('Test-param');

--- a/src/components/IntegrationTests/IntegrationTestForm/utils/create-utils.ts
+++ b/src/components/IntegrationTests/IntegrationTestForm/utils/create-utils.ts
@@ -216,7 +216,7 @@ export const getURLForParam = (params: ResolverParam[], paramName: string): stri
 
 export const getLabelForParam = (paramName: string): string => {
   if (paramName === ResolverRefParams.URL) {
-    return 'GitHub URL';
+    return 'Git URL';
   }
   if (paramName === ResolverRefParams.PATH) {
     return 'Path in repository';

--- a/src/components/IntegrationTests/IntegrationTestsListView/IntegrationTestListHeader.ts
+++ b/src/components/IntegrationTests/IntegrationTestsListView/IntegrationTestListHeader.ts
@@ -13,7 +13,7 @@ export const IntegrationTestListHeader = () => {
       props: { className: integrationListTableColumnClasses.name },
     },
     {
-      title: 'GitHub URL',
+      title: 'Git URL',
       props: { className: integrationListTableColumnClasses.containerImage },
     },
     {

--- a/src/components/IntegrationTests/IntegrationTestsListView/IntegrationTestsListView.tsx
+++ b/src/components/IntegrationTests/IntegrationTestsListView/IntegrationTestsListView.tsx
@@ -45,8 +45,8 @@ const IntegrationTestsEmptyState: React.FC<
         Integration tests run in parallel, validating each new component build with the latest
         version of all other application components.
         <br />
-        To add an integration test, link to a GitHub repository containing code that can test how
-        your application components work together.
+        To add an integration test, link to a Git repository containing code that can test how your
+        application components work together.
       </EmptyStateBody>
       <EmptyStateActions>
         <ButtonWithAccessTooltip

--- a/src/components/ReleaseService/ReleasePlan/ReleasePlanForm/RunReleasePipelineSection.tsx
+++ b/src/components/ReleaseService/ReleasePlan/ReleasePlanForm/RunReleasePipelineSection.tsx
@@ -13,9 +13,9 @@ const GitOptions: React.FC<{ required?: boolean }> = ({ required = false }) => {
     <>
       <InputField
         name="git.url"
-        label="GitHub URL for the release pipeline"
+        label="Git URL for the release pipeline"
         placeholder="Example, https://github.com/tektoncd/catalog"
-        helperText="The GitHub repository that contains the YAML definition of the pipeline run for your release service."
+        helperText="The Git repository that contains the YAML definition of the pipeline run for your release service."
         required={required}
       />
       <ExpandableSection

--- a/src/components/ReleaseService/ReleasePlan/ReleasePlanForm/__tests__/RunReleasePipelineSection.spec.tsx
+++ b/src/components/ReleaseService/ReleasePlan/ReleasePlanForm/__tests__/RunReleasePipelineSection.spec.tsx
@@ -19,9 +19,7 @@ describe('RunReleasePipelineSection', () => {
     expect(
       result.queryByRole('button', { name: 'Git options for the release pipeline' }),
     ).toBeNull();
-    expect(
-      result.queryByRole('textbox', { name: 'GitHub URL for the release pipeline' }),
-    ).toBeNull();
+    expect(result.queryByRole('textbox', { name: 'Git URL for the release pipeline' })).toBeNull();
     expect(result.queryByRole('textbox', { name: 'Revision' })).toBeNull();
     expect(result.queryByRole('textbox', { name: 'Path in repository' })).toBeNull();
     expect(
@@ -36,9 +34,7 @@ describe('RunReleasePipelineSection', () => {
     expect(
       result.getByRole('button', { name: 'Git options for the release pipeline' }),
     ).toBeVisible();
-    expect(
-      result.getByRole('textbox', { name: 'GitHub URL for the release pipeline' }),
-    ).toBeVisible();
+    expect(result.getByRole('textbox', { name: 'Git URL for the release pipeline' })).toBeVisible();
     expect(result.getByRole('textbox', { name: 'Revision' })).toBeVisible();
     expect(result.getByRole('textbox', { name: 'Path in repository' })).toBeVisible();
     expect(
@@ -53,9 +49,7 @@ describe('RunReleasePipelineSection', () => {
     expect(
       result.getByRole('button', { name: 'Git options for the release pipeline' }),
     ).toBeVisible();
-    expect(
-      result.getByRole('textbox', { name: 'GitHub URL for the release pipeline' }),
-    ).toBeVisible();
+    expect(result.getByRole('textbox', { name: 'Git URL for the release pipeline' })).toBeVisible();
     expect(result.getByRole('textbox', { name: 'Revision' })).toBeVisible();
     expect(result.getByRole('textbox', { name: 'Path in repository' })).toBeVisible();
     expect(


### PR DESCRIPTION
https://issues.redhat.com/browse/KFLUXUI-266

Add/Edit Release Plan Page:
<img width="1009" alt="image" src="https://github.com/user-attachments/assets/7fdc9ba8-a1cc-49d4-926e-90d14722f246" />

Add/Edit Integration Test Page:
<img width="1118" alt="image" src="https://github.com/user-attachments/assets/dd776cdf-94db-4965-a286-b1453008deec" />

Integration Tests List:
<img width="1430" alt="image" src="https://github.com/user-attachments/assets/9d482984-bc02-445d-ba41-5d59fb61aad7" />



Replace GitHub mentions with Git in:
1. Add and edit release plan pages.
2. Add and edit integration test pages.
3. Page that lists releases(NA)