### PR TITLE
fix: add subprotocol for logs websocket

### DIFF
--- a/src/k8s/k8s-utils.ts
+++ b/src/k8s/k8s-utils.ts
@@ -188,6 +188,18 @@ export const getK8sResourceURL = (
   return resourcePath;
 };
 
+/**
+ * returns websocket subprotocol, host with added prefix to path
+ * @param path {String}
+ */
+export const getWebsocketSubProtocolAndPathPrefix = (path) => {
+  return {
+    path: `/wss/k8s${path}`,
+    host: 'auto',
+    subProtocols: ['base64.binary.k8s.io'],
+  };
+};
+
 export const k8sWatch = (
   kind: K8sModelCommon,
   query: {
@@ -239,11 +251,11 @@ export const k8sWatch = (
   }
 
   const path = getK8sResourceURL(kind, undefined, opts);
-  wsOptionsUpdated.path = `/wss/k8s${path}`;
-  wsOptionsUpdated.host = 'auto';
-  wsOptionsUpdated.subProtocols = ['base64.binary.k8s.io'];
 
-  return new WebSocketFactory(path, wsOptionsUpdated);
+  return new WebSocketFactory(path, {
+    ...wsOptionsUpdated,
+    ...getWebsocketSubProtocolAndPathPrefix(path),
+  });
 };
 
 /**

--- a/src/shared/components/pipeline-run-logs/logs/Logs.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/Logs.tsx
@@ -4,7 +4,7 @@ import { Alert } from '@patternfly/react-core';
 import { Base64 } from 'js-base64';
 import { useWorkspaceInfo } from '../../../../components/Workspace/useWorkspaceInfo';
 import { commonFetchText } from '../../../../k8s';
-import { getK8sResourceURL } from '../../../../k8s/k8s-utils';
+import { getK8sResourceURL, getWebsocketSubProtocolAndPathPrefix } from '../../../../k8s/k8s-utils';
 import { WebSocketFactory } from '../../../../k8s/web-socket/WebSocketFactory';
 import { PodModel } from '../../../../models/pod';
 import { ContainerSpec, PodKind } from '../../types';
@@ -107,9 +107,7 @@ const Logs: React.FC<React.PropsWithChildren<LogsProps>> = ({
           onCompleteRef.current(name);
         });
     } else {
-      const wsOpts = {
-        path: watchURL,
-      };
+      const wsOpts = getWebsocketSubProtocolAndPathPrefix(watchURL);
       ws = new WebSocketFactory(watchURL, wsOpts);
       ws.onMessage((msg) => {
         if (loaded) return;

--- a/src/shared/components/pipeline-run-logs/logs/LogsWrapperComponent.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/LogsWrapperComponent.tsx
@@ -32,7 +32,7 @@ const LogsWrapperComponent: React.FC<React.PropsWithChildren<LogsWrapperComponen
     data: obj,
     isLoading,
     error,
-  } = useK8sWatchResource<PodKind>(resource, PodModel, { retry: false });
+  } = useK8sWatchResource<PodKind>({ ...resource, watch: true }, PodModel, { retry: false });
   const [isFullscreen, fullscreenRef, fullscreenToggle] = useFullscreen<HTMLDivElement>();
   const [downloadAllStatus, setDownloadAllStatus] = React.useState(false);
   const currentLogGetterRef = React.useRef<() => string>();


### PR DESCRIPTION
Add missing prefix and subprotocol for the logs WebSocket

![image](https://github.com/user-attachments/assets/324db974-61cc-4450-8a0a-396e7e7777f5)
