### PR TITLE
feat(KFLUXUI-272): remove validateUsername and add alert for it

### DIFF
--- a/src/components/UserAccess/UserAccessForm/__tests__/UserAccessForm.spec.tsx
+++ b/src/components/UserAccess/UserAccessForm/__tests__/UserAccessForm.spec.tsx
@@ -51,4 +51,11 @@ describe('UserAccessForm', () => {
     expect(screen.getByRole('button', { name: 'Save changes' })).toBeDisabled();
     expect(screen.getByRole('searchbox')).toBeDisabled();
   });
+
+  it('should report error when selecting role for empty username', () => {
+    const values = { usernames: [], role: 'admin' };
+    const props = { values } as FormikProps<UserAccessFormValues>;
+    formikRenderer(<UserAccessForm {...props} />, values);
+    expect(screen.getByText('Username not validated')).toBeVisible();
+  });
 });

--- a/src/components/UserAccess/UserAccessForm/__tests__/UsernameSection.spec.tsx
+++ b/src/components/UserAccess/UserAccessForm/__tests__/UsernameSection.spec.tsx
@@ -1,92 +1,70 @@
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { formikRenderer } from '../../../../utils/test-utils';
-import { validateUsername } from '../form-utils';
 import { UsernameSection } from '../UsernameSection';
 
-jest.mock('../form-utils', () => ({
-  validateUsername: jest.fn(),
-}));
+const errorMsg =
+  'Must be 2 to 45 characters long and can only contain lowercase letters from a to z, numbers from 0 to 9, underscores( _ ), hyphens( - ), or periods( . ).';
 
-const validateMock = validateUsername as jest.Mock;
+const testUsernameInput = async (inputValue: string, expectedError: string | null) => {
+  await act(() =>
+    fireEvent.input(screen.getByRole('searchbox'), { target: { value: inputValue } }),
+  );
+
+  if (expectedError) {
+    await waitFor(() => {
+      expect(screen.getByText(expectedError)).toBeVisible();
+    });
+  } else {
+    await waitFor(() => {
+      expect(screen.getByRole('list', { name: 'Chip group category' })).toBeVisible();
+      expect(screen.getByText(inputValue)).toBeVisible();
+    });
+  }
+};
 
 describe('UsernameSection', () => {
   it('should show usernames field', () => {
     formikRenderer(<UsernameSection />, { usernames: [] });
+    expect(
+      screen.getByText(
+        'Konflux is not currently validating usernames, so make sure that usernames you enter are accurate.',
+      ),
+    ).toBeVisible();
     expect(screen.getByText('Add users')).toBeVisible();
     expect(screen.getByText('Enter usernames')).toBeVisible();
     expect(screen.getByRole('searchbox')).toBeVisible();
   });
 
   it('should add username chip when entered', async () => {
-    validateMock.mockResolvedValue(true);
     formikRenderer(<UsernameSection />, { usernames: [] });
-    await act(() => fireEvent.input(screen.getByRole('searchbox'), { target: { value: 'user1' } }));
-    await waitFor(() =>
-      expect(screen.getByRole('list', { name: 'Chip group category' })).toBeVisible(),
-    );
-    expect(screen.getByText('user1')).toBeVisible();
-
+    await testUsernameInput('user1', null);
     await act(() => fireEvent.click(screen.getByRole('button', { name: 'Remove user1' })));
     expect(screen.queryByText('user1')).not.toBeInTheDocument();
-
-    validateMock.mockResolvedValue(true);
-    await act(() => fireEvent.input(screen.getByRole('searchbox'), { target: { value: 'user2' } }));
-    await waitFor(() => expect(screen.getByText('user2')).toBeVisible());
-    expect(screen.getByText('user2')).toBeVisible();
+    await testUsernameInput('user2', null);
   });
 
   it('should show correct field status while entering', async () => {
-    validateMock.mockResolvedValue(false);
     formikRenderer(<UsernameSection />, { usernames: [] });
     expect(
       screen.getByText('Provide Konflux usernames for the users you want to invite.'),
     ).toBeVisible();
-    await act(() =>
-      fireEvent.input(screen.getByRole('searchbox'), { target: { value: 'user!@#' } }),
-    );
-    await waitFor(() => expect(screen.getByText('Invalid username format.')).toBeVisible());
-
-    await act(() =>
-      fireEvent.input(screen.getByRole('searchbox'), { target: { value: 'myuser' } }),
-    );
-    await waitFor(() => expect(screen.getByText('Username not found.')).toBeVisible());
-
-    validateMock.mockResolvedValue(true);
-    await act(() => fireEvent.input(screen.getByRole('searchbox'), { target: { value: 'user1' } }));
-    await waitFor(() => expect(screen.getByText('Validated')).toBeVisible());
-    await waitFor(() =>
-      expect(screen.getByRole('list', { name: 'Chip group category' })).toBeVisible(),
-    );
-    expect(screen.getByText('user1')).toBeVisible();
+    await testUsernameInput('user!@#', errorMsg);
+    await testUsernameInput('myuser', null);
   });
 
   it('should not add username again if entry already exists', async () => {
-    validateMock.mockResolvedValue(true);
     formikRenderer(<UsernameSection />, { usernames: [] });
-    await act(() => fireEvent.input(screen.getByRole('searchbox'), { target: { value: 'user1' } }));
-    await waitFor(() =>
-      expect(screen.getByRole('list', { name: 'Chip group category' })).toBeVisible(),
-    );
-    expect(screen.getByText('user1')).toBeVisible();
+    await testUsernameInput('user1', null);
 
     await act(() => fireEvent.input(screen.getByRole('searchbox'), { target: { value: 'user1' } }));
     expect(screen.getAllByText('user1')).toHaveLength(1);
   });
 
   it('should validate username format', async () => {
-    validateMock.mockResolvedValue(true);
     formikRenderer(<UsernameSection />, { usernames: [] });
-    await act(() =>
-      fireEvent.input(screen.getByRole('searchbox'), { target: { value: 'user-12.3' } }),
-    );
-    await waitFor(() => expect(screen.getByText('Validated')).toBeVisible());
-
-    await act(() =>
-      fireEvent.input(screen.getByRole('searchbox'), { target: { value: 'user1!@#' } }),
-    );
-    await waitFor(() => expect(screen.getByText('Invalid username format.')).toBeVisible());
-
-    await act(() => fireEvent.input(screen.getByRole('searchbox'), { target: { value: '1test' } }));
-    await waitFor(() => expect(screen.getByText('Validated')).toBeVisible());
+    await testUsernameInput('user-12_.3', null);
+    await testUsernameInput('user1!@#', errorMsg);
+    await testUsernameInput('1', errorMsg);
+    await testUsernameInput('11111111111111111111111111111111111111111111111', errorMsg);
   });
 });

--- a/src/components/UserAccess/UserAccessForm/__tests__/form-utils.spec.ts
+++ b/src/components/UserAccess/UserAccessForm/__tests__/form-utils.spec.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import { createK8sUtilMock } from '../../../../utils/test-utils';
-import { createSBRs, editSBR, validateUsername } from '../form-utils';
+import { createSBRs, editSBR } from '../form-utils';
 
 const k8sCreateMock = createK8sUtilMock('K8sQueryCreateResource');
 const k8sPatchMock = createK8sUtilMock('K8sQueryPatchResource');
@@ -50,41 +50,5 @@ describe('editSBR', () => {
         patches: [{ op: 'replace', path: '/spec/spaceRole', value: 'contributor' }],
       }),
     );
-  });
-});
-
-describe('validateUsername', () => {
-  const mockFetch = jest.fn();
-  beforeAll(() => {
-    window.fetch = mockFetch;
-  });
-
-  it('should return true if username is valid', async () => {
-    mockFetch.mockResolvedValue({
-      json: () => [
-        {
-          username: 'user1',
-        },
-      ],
-    });
-    const result = await validateUsername('user1');
-    expect(mockFetch).toHaveBeenCalledWith('/api/k8s/registration/api/v1/usernames/user1');
-    expect(result).toBe(true);
-  });
-
-  it('should return false if returned username is not the same', async () => {
-    mockFetch.mockResolvedValue({
-      json: () => {
-        'user';
-      },
-    });
-    const result = await validateUsername('user1');
-    expect(result).toBe(false);
-  });
-
-  it('should return false if api call fails', async () => {
-    mockFetch.mockRejectedValue(null);
-    const result = await validateUsername('user1');
-    expect(result).toBe(false);
   });
 });

--- a/src/components/UserAccess/UserAccessForm/form-utils.ts
+++ b/src/components/UserAccess/UserAccessForm/form-utils.ts
@@ -8,16 +8,6 @@ export type UserAccessFormValues = {
   role: WorkspaceRole;
 };
 
-export const validateUsername = async (username: string) => {
-  try {
-    const res = await fetch(`/api/k8s/registration/api/v1/usernames/${username}`);
-    const [data]: [{ username: string }] = await res.json();
-    return data.username === username;
-  } catch {
-    return false;
-  }
-};
-
 export const userAccessFormSchema = yup.object({
   usernames: yup
     .array()

--- a/src/utils/validation-utils.ts
+++ b/src/utils/validation-utils.ts
@@ -1,5 +1,13 @@
 import * as yup from 'yup';
 
+export const KONFLUX_USERNAME_REGEX = /^[-_a-z0-9.]{2,45}$/;
+export const KONFLUX_USERNAME_REGEX_MGS =
+  'Must be 2 to 45 characters long and can only contain lowercase letters from a to z, numbers from 0 to 9, underscores( _ ), hyphens( - ), or periods( . ).';
+export const konfluxUsernameYupValidation = yup
+  .string()
+  .matches(KONFLUX_USERNAME_REGEX, KONFLUX_USERNAME_REGEX_MGS)
+  .required('Required');
+
 export const GIT_URL_REGEX =
   /^((((ssh|git|https?:?):\/\/:?)(([^\s@]+@|[^@]:?)[-\w.]+(:\d\d+:?)?(\/[-\w.~/?[\]!$&'()*+,;=:@%]*:?)?:?))|([^\s@]+@[-\w.]+:[-\w.~/?[\]!$&'()*+,;=:@%]*?:?))$/;
 


### PR DESCRIPTION
## Fixes 
[KFLUXUI-272](https://issues.redhat.com/browse/KFLUXUI-272)

## Description
We are migrating off the SpaceBindingRequest, the validateUsername is useless. The patch removes it and adds notice to users that we do not validate whether the username is a valid Konflux user.


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
![Screenshot 2025-02-12 at 19 08 12](https://github.com/user-attachments/assets/c6470470-bca3-4a9e-9cd4-32d236a2ce41)


## How to test or reproduce?
Test Steps and result:
1. navigate to the 'access' of the konflux
2. try to grant users
3. on the grant user page, you would see the notice is shown 
5. try to input valid and invalid username
6. for the invalid username, you would see the warning.

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [x] Code follows the style guidelines
- [x] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->