### PR TITLE
chore(KFLUXUI-279): replace Workspace by Namespace only in the UI

### DIFF
--- a/src/components/ImportForm/SecretSection/SecretSection.tsx
+++ b/src/components/ImportForm/SecretSection/SecretSection.tsx
@@ -59,7 +59,7 @@ const SecretSection = () => {
         label="Build time secret"
         addLabel="Add secret"
         placeholder="Secret"
-        helpText="Keep your data secure by defining a build time secret. Secrets are stored at a workspace level so applications within workspace will have access to these secrets."
+        helpText="Keep your data secure by defining a build time secret. Secrets are stored at a namespace level so applications within namespace will have access to these secrets."
         noFooter
         isReadOnly
         onChange={(v) =>

--- a/src/components/PageAccess/NoAccessState.tsx
+++ b/src/components/PageAccess/NoAccessState.tsx
@@ -48,7 +48,7 @@ const NoAccessState: React.FC<React.PropsWithChildren<NoAccessStateProps>> = ({
       />
       <EmptyStateBody>
         {body ||
-          `Ask the administrator or the owner of the ${workspace} workspace for access permissions.`}
+          `Ask the administrator or the owner of the ${workspace} namespace for access permissions.`}
       </EmptyStateBody>
       <EmptyStateFooter>
         {children || (

--- a/src/components/PageAccess/__tests__/NoAccessState.spec.tsx
+++ b/src/components/PageAccess/__tests__/NoAccessState.spec.tsx
@@ -36,7 +36,7 @@ describe('NoAccessState', () => {
     screen.getByTestId('no-access-state');
     screen.getByText(`Let's get you access`);
     screen.getByText(
-      `Ask the administrator or the owner of the test-ws workspace for access permissions.`,
+      `Ask the administrator or the owner of the test-ws namespace for access permissions.`,
     );
     screen.getByText('Go to Overview page');
   });

--- a/src/components/ReleaseService/ReleasePlan/TriggerRelease/TriggerReleaseForm.tsx
+++ b/src/components/ReleaseService/ReleasePlan/TriggerRelease/TriggerReleaseForm.tsx
@@ -76,14 +76,14 @@ export const TriggerReleaseForm: React.FC<Props> = ({
         <Form style={{ maxWidth: '70%' }}>
           <ReleasePlanDropdown
             name="releasePlan"
-            helpText="The release you want to release to the environments in your target workspace."
+            helpText="The release you want to release to the environments in your target namespace."
             releasePlans={releasePlans}
             loaded={loaded}
             required
           />
           <SnapshotDropdown
             name="snapshot"
-            helpText="The release you want to release to the environments in your target workspace."
+            helpText="The release you want to release to the environments in your target namespace."
             required
             applicationName={applicationName}
           />

--- a/src/components/ReleaseService/ReleasePlanAdmission/ReleasePlanAdmissionListHeader.tsx
+++ b/src/components/ReleaseService/ReleasePlanAdmission/ReleasePlanAdmissionListHeader.tsx
@@ -17,7 +17,7 @@ const ReleasePlanAdmissionListHeader = () => {
       props: { className: releasesPlanAdmissionTableColumnClasses.application },
     },
     {
-      title: 'Source Workspace',
+      title: 'Source Namespace',
       props: { className: releasesPlanAdmissionTableColumnClasses.source },
     },
     {

--- a/src/components/ReleaseService/ReleaseService.tsx
+++ b/src/components/ReleaseService/ReleaseService.tsx
@@ -16,7 +16,7 @@ export const ReleaseService: React.FC<React.PropsWithChildren<unknown>> = () => 
         data-test="release-service-test-id"
         title="Releases"
         headTitle="Releases"
-        description="Manage all your releases in this workspace."
+        description="Manage all your releases in this namespace."
         actions={[
           {
             key: 'create-release-plan',

--- a/src/components/Secrets/SecretsListPage.tsx
+++ b/src/components/Secrets/SecretsListPage.tsx
@@ -17,7 +17,7 @@ const SecretsListPage: React.FC = () => {
       description={
         <>
           Manage your secrets and their related configurations. You can add a secret at the
-          workspace level.
+          namespace level.
           <br /> All secrets are stored using AWS Secrets Manager to keep your data private.{' '}
           <ExternalLink href="https://konflux-ci.dev/docs/how-tos/configuring/creating-secrets/">
             Learn more

--- a/src/components/UserAccess/UserAccessForm/EditAccessPage.tsx
+++ b/src/components/UserAccess/UserAccessForm/EditAccessPage.tsx
@@ -24,7 +24,7 @@ const EditAccessPage: React.FC<React.PropsWithChildren<unknown>> = () => {
     ? [{ model: SpaceBindingRequestModel, verb: 'update' }]
     : [{ model: SpaceBindingRequestModel, verb: 'create' }];
 
-  useDocumentTitle(`Edit access to workspace, ${workspace} | ${FULL_APPLICATION_TITLE}`);
+  useDocumentTitle(`Edit access to namespace, ${workspace} | ${FULL_APPLICATION_TITLE}`);
 
   const [existingSBR, loaded, loadErr] = useSpaceBindingRequest(
     binding.namespace,

--- a/src/components/UserAccess/UserAccessForm/UserAccessForm.tsx
+++ b/src/components/UserAccess/UserAccessForm/UserAccessForm.tsx
@@ -29,12 +29,12 @@ export const UserAccessForm: React.FC<React.PropsWithChildren<Props>> = ({
   return (
     <PageLayout
       title={
-        edit ? `Edit access to workspace, ${workspace}` : `Grant access to workspace, ${workspace}`
+        edit ? `Edit access to namespace, ${workspace}` : `Grant access to namespace, ${workspace}`
       }
       description={
         edit
           ? 'Change permissions for this user by adding a role or removing a current role.'
-          : 'Invite users to collaborate with you by granting them access to your workspace.'
+          : 'Invite users to collaborate with you by granting them access to your namespace.'
       }
       breadcrumbs={[
         ...breadcrumbs,

--- a/src/components/UserAccess/UserAccessForm/UsernameSection.tsx
+++ b/src/components/UserAccess/UserAccessForm/UsernameSection.tsx
@@ -70,7 +70,7 @@ export const UsernameSection: React.FC<React.PropsWithChildren<Props>> = ({ disa
           <HelpPopover
             aria-label="Usernames in Konflux"
             headerContent="Usernames in Konflux"
-            bodyContent="Your username is the name of your default workspace. To find a list of your workspaces, navigate to the Applications pane and select the options icon in the breadcrumb navigation."
+            bodyContent="Your username is the name of your default namespace. To find a list of your namespaces, navigate to the Applications pane and select the options icon in the breadcrumb navigation."
           />
         }
         isRequired

--- a/src/components/UserAccess/UserAccessForm/__tests__/UserAccessForm.spec.tsx
+++ b/src/components/UserAccess/UserAccessForm/__tests__/UserAccessForm.spec.tsx
@@ -27,10 +27,10 @@ describe('UserAccessForm', () => {
     const values = { usernames: [], role: null };
     const props = { values } as FormikProps<UserAccessFormValues>;
     formikRenderer(<UserAccessForm {...props} />, values);
-    expect(screen.getByText('Grant access to workspace, test-ws')).toBeVisible();
+    expect(screen.getByText('Grant access to namespace, test-ws')).toBeVisible();
     expect(
       screen.getByText(
-        'Invite users to collaborate with you by granting them access to your workspace.',
+        'Invite users to collaborate with you by granting them access to your namespace.',
       ),
     ).toBeVisible();
     expect(screen.getByRole('button', { name: 'Grant access' })).toBeVisible();
@@ -41,7 +41,7 @@ describe('UserAccessForm', () => {
     const values = { usernames: [], role: null };
     const props = { values } as FormikProps<UserAccessFormValues>;
     formikRenderer(<UserAccessForm {...props} edit />, values);
-    expect(screen.getByText('Edit access to workspace, test-ws')).toBeVisible();
+    expect(screen.getByText('Edit access to namespace, test-ws')).toBeVisible();
     expect(
       screen.getByText(
         'Change permissions for this user by adding a role or removing a current role.',

--- a/src/components/UserAccess/UserAccessForm/__tests__/UserAccessFormPage.spec.tsx
+++ b/src/components/UserAccess/UserAccessForm/__tests__/UserAccessFormPage.spec.tsx
@@ -53,7 +53,7 @@ describe('UserAccessFormPage', () => {
       workspace: 'test-ws',
       workspaceResource: {} as Workspace,
     });
-    expect(screen.getByText('Grant access to workspace, test-ws')).toBeVisible();
+    expect(screen.getByText('Grant access to namespace, test-ws')).toBeVisible();
     await act(() => fireEvent.input(screen.getByRole('searchbox'), { target: { value: 'user1' } }));
     // act(() => jest.runAllTimers());
     await act(() => fireEvent.click(screen.getByText('Select role')));
@@ -73,7 +73,7 @@ describe('UserAccessFormPage', () => {
       workspace: 'test-ws',
       workspaceResource: {} as Workspace,
     });
-    expect(screen.getByText('Edit access to workspace, test-ws')).toBeVisible();
+    expect(screen.getByText('Edit access to namespace, test-ws')).toBeVisible();
     expect(screen.getByRole('searchbox')).toBeDisabled();
     await act(() => fireEvent.click(screen.getByText('Select role')));
     await act(() => fireEvent.click(screen.getByText('maintainer')));

--- a/src/components/UserAccess/UserAccessListPage.tsx
+++ b/src/components/UserAccess/UserAccessListPage.tsx
@@ -20,7 +20,7 @@ const UserAccessPage: React.FunctionComponent = () => {
   return (
     <PageLayout
       title="User access"
-      description="Invite users to collaborate with you by granting them access to your workspace."
+      description="Invite users to collaborate with you by granting them access to your namespace."
       breadcrumbs={[
         ...breadcrumbs,
         {
@@ -33,7 +33,7 @@ const UserAccessPage: React.FunctionComponent = () => {
           id: 'grant-access',
           label: 'Grant access',
           disabled: !canCreateSBR,
-          disabledTooltip: 'You cannot grant access in this workspace',
+          disabledTooltip: 'You cannot grant access in this namespace',
           cta: {
             href: `/workspaces/${workspace}/access/grant`,
           },

--- a/src/components/UserAccess/UserAccessListView.tsx
+++ b/src/components/UserAccess/UserAccessListView.tsx
@@ -43,14 +43,14 @@ const UserAccessEmptyState: React.FC<
       title="Grant user access"
     >
       <EmptyStateBody>
-        See a list of all the users that have access to your workspace.
+        See a list of all the users that have access to your namespace.
       </EmptyStateBody>
       <EmptyStateActions>
         <ButtonWithAccessTooltip
           variant="primary"
           component={(props) => <Link {...props} to={`/workspaces/${workspace}/access/grant`} />}
           isDisabled={!canCreateSBR}
-          tooltip="You cannot grant access in this workspace"
+          tooltip="You cannot grant access in this namespace"
           analytics={{
             link_name: 'grant-access',
             workspace,
@@ -120,7 +120,7 @@ export const UserAccessListView: React.FC<React.PropsWithChildren<unknown>> = ()
                   <Link {...props} to={`/workspaces/${workspace}/access/grant`} />
                 )}
                 isDisabled={!canCreateSBR}
-                tooltip="You cannot grant access in this workspace"
+                tooltip="You cannot grant access in this namespace"
                 analytics={{
                   link_name: 'grant-access',
                   workspace,

--- a/src/utils/breadcrumb-utils.tsx
+++ b/src/utils/breadcrumb-utils.tsx
@@ -10,7 +10,7 @@ export const useWorkspaceBreadcrumbs = () => {
 
   return [
     <BreadcrumbItem key="workspace-label" component="div">
-      <span>Workspaces</span>
+      <span>Namespaces</span>
     </BreadcrumbItem>,
     <BreadcrumbItem key="workspace-link" to="#" component="div" showDivider>
       <Link className="pf-v5-c-breadcrumb__link" to={`/workspaces/${workspace}/applications`}>

--- a/src/utils/pipeline-utils.ts
+++ b/src/utils/pipeline-utils.ts
@@ -19,9 +19,9 @@ export const COMPONENT_DESC =
   'A component is an image built from code in a source repository. Applications are sets of components that run together on environments.';
 export const BUILD_DESC = `Every component requires a build to release. We’ll automatically trigger a single build. Subsequent builds will need to be manually requested.`;
 export const TESTS_DESC = `Catch functional regressions from code changes by adding integration tests. Integration tests run in parallel, validating each new component build with the latest version of all other application components.`;
-export const STATIC_ENV_DESC = `A static environment is a set of compute resources bundled together. Use static environments for developing, testing, and staging before releasing your application. You can share static environments across all applications within the workspace.`;
+export const STATIC_ENV_DESC = `A static environment is a set of compute resources bundled together. Use static environments for developing, testing, and staging before releasing your application. You can share static environments across all applications within the namespace.`;
 export const RELEASE_DESC = `After pushing your application to release, your application goes through a series of tests through the release pipeline to ensure the application complies with the  release policy set on the release target, also known as the "managed environment".`;
-export const MANAGED_ENV_DESC = `A managed environment is your application release target. This release target is an external environment, set up in an external workspace, and managed by another team. It is set for each application and not automatically shared among applications within the workspace.`;
+export const MANAGED_ENV_DESC = `A managed environment is your application release target. This release target is an external environment, set up in an external namespace, and managed by another team. It is set for each application and not automatically shared among applications within the namespace.`;
 
 export enum runStatus {
   Succeeded = 'Succeeded',


### PR DESCRIPTION
## Fixes 
[KFLUXUI-279](https://issues.redhat.com/browse/KFLUXUI-279)


## Description
Replace all occurrences of `Workspace` in UI by `Namespace`


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
Current
![image](https://github.com/user-attachments/assets/0146f5ea-a49a-47ba-93c6-3e07f5e9261e)


After change
![image](https://github.com/user-attachments/assets/13bbca9f-bd6c-4a01-815d-d2c60bfb6514)



<!--## How to test or reproduce?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->