### PR TITLE
chore(KFLUXUI-268): revision data on snapshot page is now clickable& directs to commit detail page

### DIFF
--- a/src/components/SnapshotDetails/tabs/SnapshotComponentsListRow.tsx
+++ b/src/components/SnapshotDetails/tabs/SnapshotComponentsListRow.tsx
@@ -36,7 +36,11 @@ const SnapshotComponentsListRow: React.FC<
         </TableData>
       )}
       <TableData className={commitsTableColumnClasses.revision}>
-        <span data-test="snapshot-component-revision">{obj.source?.git?.revision}</span>
+        <Link
+          to={`/workspaces/${workspace}/applications/${obj.application}/commit/${obj.source?.git?.revision}`}
+        >
+          <span data-test="snapshot-component-revision">{obj.source?.git?.revision}</span>
+        </Link>
       </TableData>
     </>
   );

--- a/src/components/SnapshotDetails/tabs/SnapshotComponentsListRow.tsx
+++ b/src/components/SnapshotDetails/tabs/SnapshotComponentsListRow.tsx
@@ -36,12 +36,16 @@ const SnapshotComponentsListRow: React.FC<
         </TableData>
       )}
       <TableData className={commitsTableColumnClasses.revision}>
-        <Link
-          to={`/workspaces/${workspace}/applications/${obj.application}/commit/${obj.source?.git?.revision}`}
-          data-test="snapshot-component-revision"
-        >
-          {obj.source?.git?.revision}
-        </Link>
+        {obj.source?.git?.revision ? (
+          <Link
+            to={`/workspaces/${workspace}/applications/${obj.application}/commit/${obj.source?.git?.revision}`}
+            data-test="snapshot-component-revision"
+          >
+            {obj.source?.git?.revision}
+          </Link>
+        ) : (
+          '-'
+        )}
       </TableData>
     </>
   );

--- a/src/components/SnapshotDetails/tabs/SnapshotComponentsListRow.tsx
+++ b/src/components/SnapshotDetails/tabs/SnapshotComponentsListRow.tsx
@@ -38,8 +38,9 @@ const SnapshotComponentsListRow: React.FC<
       <TableData className={commitsTableColumnClasses.revision}>
         <Link
           to={`/workspaces/${workspace}/applications/${obj.application}/commit/${obj.source?.git?.revision}`}
+          data-test="snapshot-component-revision"
         >
-          <span data-test="snapshot-component-revision">{obj.source?.git?.revision}</span>
+          {obj.source?.git?.revision}
         </Link>
       </TableData>
     </>

--- a/src/components/SnapshotDetails/tabs/SnapshotComponentsListRow.tsx
+++ b/src/components/SnapshotDetails/tabs/SnapshotComponentsListRow.tsx
@@ -38,7 +38,7 @@ const SnapshotComponentsListRow: React.FC<
       <TableData className={commitsTableColumnClasses.revision}>
         <Link
           to={`/workspaces/${workspace}/applications/${obj.application}/commit/${obj.source?.git?.revision}`}
-          // data-test="snapshot-component-revision"
+          data-test="snapshot-component-revision"
         >
           {obj.source?.git?.revision}
         </Link>

--- a/src/components/SnapshotDetails/tabs/SnapshotComponentsListRow.tsx
+++ b/src/components/SnapshotDetails/tabs/SnapshotComponentsListRow.tsx
@@ -38,7 +38,7 @@ const SnapshotComponentsListRow: React.FC<
       <TableData className={commitsTableColumnClasses.revision}>
         <Link
           to={`/workspaces/${workspace}/applications/${obj.application}/commit/${obj.source?.git?.revision}`}
-          data-test="snapshot-component-revision"
+          // data-test="snapshot-component-revision"
         >
           {obj.source?.git?.revision}
         </Link>

--- a/src/components/SnapshotDetails/tabs/__tests__/SnapshotComponentsListRow.spec.tsx
+++ b/src/components/SnapshotDetails/tabs/__tests__/SnapshotComponentsListRow.spec.tsx
@@ -60,7 +60,6 @@ describe('SnapshotComponentsListRow', () => {
       />,
     );
     const revisionLink = screen.getByText('test-revision');
-    expect(revisionLink).toBeInTheDocument();
     expect(revisionLink).toHaveAttribute(
       'href',
       `/workspaces//applications/${rowData?.application}/commit/test-revision`,

--- a/src/components/SnapshotDetails/tabs/__tests__/SnapshotComponentsListRow.spec.tsx
+++ b/src/components/SnapshotDetails/tabs/__tests__/SnapshotComponentsListRow.spec.tsx
@@ -46,8 +46,24 @@ describe('SnapshotComponentsListRow', () => {
         }}
       />,
     );
-    const revisionLink = screen.queryByTestId('snapshot-component-revision');
-    expect(revisionLink).toBeInTheDocument();
     expect(screen.getByText('test-revision')).toBeInTheDocument();
+  });
+
+  it('should list Revision as a link ', () => {
+    render(
+      <SnapshotComponentsListRow
+        columns={null}
+        obj={{
+          ...rowData,
+          source: { git: { ...rowData?.source?.git, revision: 'test-revision' } },
+        }}
+      />,
+    );
+    const revisionLink = screen.getByText('test-revision');
+    expect(revisionLink).toBeInTheDocument();
+    expect(revisionLink).toHaveAttribute(
+      'href',
+      `/workspaces//applications/${rowData?.application}/commit/test-revision`,
+    );
   });
 });

--- a/src/components/SnapshotDetails/tabs/__tests__/SnapshotComponentsListRow.spec.tsx
+++ b/src/components/SnapshotDetails/tabs/__tests__/SnapshotComponentsListRow.spec.tsx
@@ -35,4 +35,19 @@ describe('SnapshotComponentsListRow', () => {
     const githubLink = screen.queryByTestId('snapshot-component-git-url');
     expect(githubLink).toBeNull();
   });
+
+  it('should list Revision correctly ', () => {
+    render(
+      <SnapshotComponentsListRow
+        columns={null}
+        obj={{
+          ...rowData,
+          source: { git: { ...rowData?.source?.git, revision: 'test-revision' } },
+        }}
+      />,
+    );
+    const revisionLink = screen.queryByTestId('snapshot-component-revision');
+    expect(revisionLink).toBeInTheDocument();
+    expect(screen.getByText('test-revision')).toBeInTheDocument();
+  });
 });

--- a/src/components/SnapshotDetails/tabs/__tests__/SnapshotComponentsListRow.spec.tsx
+++ b/src/components/SnapshotDetails/tabs/__tests__/SnapshotComponentsListRow.spec.tsx
@@ -65,4 +65,16 @@ describe('SnapshotComponentsListRow', () => {
       `/workspaces//applications/${rowData?.application}/commit/test-revision`,
     );
   });
+  it('should show hyphen when revision is not available ', () => {
+    render(
+      <SnapshotComponentsListRow
+        columns={null}
+        obj={{
+          ...rowData,
+          source: { git: { ...rowData?.source?.git, revision: null } },
+        }}
+      />,
+    );
+    expect(screen.getByText('-')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION

## Fixes 
https://issues.redhat.com/browse/KFLUXUI-268


## Description
The Revision reference on a Snapshot detail page is clickable and take the user to that particular commit detail page.


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Snapshot Detail Page:

<img width="1309" alt="image" src="https://github.com/user-attachments/assets/58c859aa-5917-4a6e-aaa7-c95010755c07" />

Commit Details Page:

<img width="1438" alt="image" src="https://github.com/user-attachments/assets/81f68923-d8f2-4b8a-8468-9e2aab62686a" />

