### PR TITLE
fix: handle null items response

### DIFF
--- a/src/k8s/k8s-fetch.ts
+++ b/src/k8s/k8s-fetch.ts
@@ -73,11 +73,13 @@ export const k8sListResource = <TResource extends K8sResourceCommon>({
     true,
   ).then((result) => ({
     ...result,
-    items: result.items.map((i) => ({
-      ...i,
-      apiVersion: result.apiVersion,
-      kind: model.kind,
-    })),
+    items: result.items
+      ? result.items.map((i) => ({
+          ...i,
+          apiVersion: result.apiVersion,
+          kind: model.kind,
+        }))
+      : [],
   }));
 
 export const K8sListResourceItems = <TResource extends K8sResourceCommon>(


### PR DESCRIPTION


## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
None on file.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
If you have access to zero workspaces, then it is possible for the /workspaces query to return `null` for the items instead of `[]`.

This change handles that to return `[]` onto the call.

The app fails later where there is undefined behavior if the user cannot land on a workspace, but will deal with that in a later change.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
None.

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

Try to use the UI pointed at the stage cluster, but with a user with no access to workspaces there.

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->