### PR TITLE
chore(KFLUXUI-330): replace deprecated Dropdown with compatible select component

### DIFF
--- a/src/components/ReleaseService/ReleasePlan/TriggerRelease/AddIssueSection/__tests__/CVEFormContent.spec.tsx
+++ b/src/components/ReleaseService/ReleasePlan/TriggerRelease/AddIssueSection/__tests__/CVEFormContent.spec.tsx
@@ -67,10 +67,7 @@ describe('CVEFormContent', () => {
     });
     expect(screen.queryByTestId('component-0')).toBeInTheDocument();
     expect(screen.queryByTestId('component-1')).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId('component-0').getElementsByClassName('pf-v5-c-dropdown__toggle-text')[0]
-        .innerHTML,
-    ).toBe('b');
+    expect(screen.queryByTestId('component-0').firstChild.lastChild.textContent).toBe('b');
   });
 
   it('should have disabled Submit button when ID not there', () => {

--- a/src/components/ReleaseService/ReleasePlan/TriggerRelease/AddIssueSection/__tests__/ComponentField.spec.tsx
+++ b/src/components/ReleaseService/ReleasePlan/TriggerRelease/AddIssueSection/__tests__/ComponentField.spec.tsx
@@ -34,15 +34,9 @@ describe('ComponentField', () => {
     expect(addCmpBtn).toBeInTheDocument();
 
     expect(screen.queryByTestId('component-0')).toBeInTheDocument();
-    expect(
-      screen.queryByTestId('component-0').getElementsByClassName('pf-v5-c-dropdown__toggle-text')[0]
-        .innerHTML,
-    ).toBe('a');
+    expect(screen.queryByTestId('component-0').firstChild.lastChild.textContent).toBe('a');
     expect(screen.queryByTestId('component-1')).toBeInTheDocument();
-    expect(
-      screen.queryByTestId('component-1').getElementsByClassName('pf-v5-c-dropdown__toggle-text')[0]
-        .innerHTML,
-    ).toBe('b');
+    expect(screen.queryByTestId('component-1').firstChild.lastChild.textContent).toBe('b');
   });
 
   it('should show disabled remove button when only one component', () => {
@@ -61,18 +55,14 @@ describe('ComponentField', () => {
 
     expect(screen.queryByTestId('remove-component-0')).toBeInTheDocument();
     expect(screen.queryByTestId('component-0')).toBeInTheDocument();
-    expect(
-      screen.queryByTestId('component-0').getElementsByClassName('pf-v5-c-dropdown__toggle-text')[0]
-        .innerHTML,
-    ).toBe('remove-component');
+    expect(screen.queryByTestId('component-0').firstChild.lastChild.textContent).toBe(
+      'remove-component',
+    );
 
     act(() => {
       fireEvent.click(screen.queryByTestId('remove-component-0'));
     });
-    expect(
-      screen.queryByTestId('component-0').getElementsByClassName('pf-v5-c-dropdown__toggle-text')[0]
-        .innerHTML,
-    ).toBe('cmp2');
+    expect(screen.queryByTestId('component-0').firstChild.lastChild.textContent).toBe('cmp2');
   });
 
   it('should show packages', () => {

--- a/src/components/ReleaseService/ReleasePlan/TriggerRelease/AddIssueSection/__tests__/StatusDropdown.spec.tsx
+++ b/src/components/ReleaseService/ReleasePlan/TriggerRelease/AddIssueSection/__tests__/StatusDropdown.spec.tsx
@@ -1,13 +1,15 @@
-import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { formikRenderer } from '../../../../../../utils/test-utils';
 import StatusDropdown from '../StatusDropdown';
 
 describe('StatusDropdown', () => {
+  const user = userEvent.setup();
   beforeEach(() => {});
 
   it('should show dropdown options', async () => {
     formikRenderer(<StatusDropdown name="status" />);
-    await act(() => fireEvent.click(screen.getByRole('button')));
+    await user.click(screen.getByText('Select status of isssue'));
     expect(screen.getByRole('menuitem', { name: 'Resolved' })).toBeVisible();
     expect(screen.getByRole('menuitem', { name: 'Unresolved' })).toBeVisible();
   });
@@ -16,17 +18,10 @@ describe('StatusDropdown', () => {
     formikRenderer(<StatusDropdown name="status" />, {
       targets: { application: 'app' },
     });
-    expect(screen.queryByRole('button')).toBeInTheDocument();
-
-    await act(() => fireEvent.click(screen.getByRole('button')));
-
+    await user.click(screen.getByText('Select status of isssue'));
+    await user.click(screen.getByText('Unresolved'));
     await waitFor(() => {
-      expect(screen.getByRole('menu')).toBeInTheDocument();
-      screen.getByText('Unresolved');
-    });
-    await act(() => fireEvent.click(screen.getByText('Unresolved')));
-    await waitFor(() => {
-      expect(screen.getByText('Unresolved'));
+      expect(screen.getByTestId('dropdown-toggle').textContent).toEqual('Unresolved');
     });
   });
 });

--- a/src/components/ReleaseService/ReleasePlan/TriggerRelease/__tests__/ReleasePlanDropdown.spec.tsx
+++ b/src/components/ReleaseService/ReleasePlan/TriggerRelease/__tests__/ReleasePlanDropdown.spec.tsx
@@ -28,10 +28,11 @@ describe('ReleasePlanDropdown', () => {
     formikRenderer(
       <ReleasePlanDropdown name="releasePlan" releasePlans={releasePlans} loaded={loaded} />,
     );
-    await act(() => fireEvent.click(screen.getByRole('button')));
-
-    expect(screen.getByRole('menuitem', { name: 'rp1' })).toBeVisible();
-    expect(screen.getByRole('menuitem', { name: 'rp2' })).toBeVisible();
+    await act(() => fireEvent.click(screen.getByTestId('dropdown-toggle')));
+    await waitFor(() => {
+      expect(screen.getByRole('menuitem', { name: 'rp1' })).toBeVisible();
+      expect(screen.getByRole('menuitem', { name: 'rp2' })).toBeVisible();
+    });
   });
 
   it('should select current releasePlan by default', () => {
@@ -58,18 +59,15 @@ describe('ReleasePlanDropdown', () => {
         targets: { application: 'app' },
       },
     );
-    expect(screen.queryByRole('button')).toBeInTheDocument();
-
-    await act(() => fireEvent.click(screen.getByRole('button')));
-
+    await act(() => fireEvent.click(screen.getByTestId('dropdown-toggle')));
     await waitFor(() => {
-      expect(screen.getByRole('menu')).toBeInTheDocument();
-      expect(screen.getByLabelText('Select release plan'));
-      screen.getByText('rp2');
+      expect(screen.getByTestId('dropdown-toggle').textContent).toBe('Select release plan');
+      expect(screen.getAllByRole('menuitem').length).toEqual(2);
     });
+
     await act(() => fireEvent.click(screen.getByText('rp2')));
     await waitFor(() => {
-      expect(screen.getByText('rp2'));
+      expect(screen.getByTestId('dropdown-toggle').textContent).toEqual('rp2');
     });
   });
 });

--- a/src/components/ReleaseService/ReleasePlan/TriggerRelease/__tests__/SnapshotDropdown.spec.tsx
+++ b/src/components/ReleaseService/ReleasePlan/TriggerRelease/__tests__/SnapshotDropdown.spec.tsx
@@ -32,10 +32,11 @@ describe('SnapshotDropdown', () => {
     formikRenderer(<SnapshotDropdown applicationName="app" name="snapshot" />, {
       targets: { application: 'app' },
     });
-    await act(() => fireEvent.click(screen.getByRole('button')));
-
-    expect(screen.getByRole('menuitem', { name: 'snapshot1' })).toBeVisible();
-    expect(screen.getByRole('menuitem', { name: 'snapshot2' })).toBeVisible();
+    await act(() => fireEvent.click(screen.getByTestId('dropdown-toggle')));
+    await waitFor(() => {
+      expect(screen.getByRole('menuitem', { name: 'snapshot1' })).toBeVisible();
+      expect(screen.getByRole('menuitem', { name: 'snapshot2' })).toBeVisible();
+    });
   });
 
   it('should only show dropdowns related to the correct application', async () => {
@@ -46,10 +47,12 @@ describe('SnapshotDropdown', () => {
     formikRenderer(<SnapshotDropdown applicationName="app" name="snapshot" />, {
       targets: { application: 'app' },
     });
-    await act(() => fireEvent.click(screen.getByRole('button')));
+    await act(() => fireEvent.click(screen.getByTestId('dropdown-toggle')));
 
-    expect(screen.getByRole('menuitem', { name: 'snapshot1' })).toBeVisible();
-    expect(screen.queryByRole('menuitem', { name: 'snapshot2' })).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole('menuitem', { name: 'snapshot1' })).toBeVisible();
+      expect(screen.queryByRole('menuitem', { name: 'snapshot2' })).not.toBeInTheDocument();
+    });
   });
 
   it('should change the Snapshot dropdown value', async () => {
@@ -64,15 +67,7 @@ describe('SnapshotDropdown', () => {
     formikRenderer(<SnapshotDropdown applicationName="app" name="snapshot" />, {
       targets: { application: 'app' },
     });
-    expect(screen.queryByRole('button')).toBeInTheDocument();
-
-    await act(() => fireEvent.click(screen.getByRole('button')));
-
-    await waitFor(() => {
-      expect(screen.getByRole('menu')).toBeInTheDocument();
-      expect(screen.getByLabelText('Select snapshot'));
-      screen.getByText('snapshot1');
-    });
+    await act(() => fireEvent.click(screen.getByTestId('dropdown-toggle')));
     await act(() => fireEvent.click(screen.getByText('snapshot2')));
     await waitFor(() => {
       expect(screen.getByText('snapshot2'));
@@ -109,17 +104,12 @@ describe('SnapshotDropdown', () => {
       },
     );
 
-    // Snapshot select toggle
-    expect(screen.queryByRole('button')).toBeInTheDocument();
-
     // Click the snapshot select toggle
-    await act(() => fireEvent.click(screen.getByRole('button')));
+    await act(() => fireEvent.click(screen.getByTestId('dropdown-toggle')));
 
     await waitFor(() => {
-      // Snapshot dropdown menu
-      expect(screen.getByRole('menu')).toBeInTheDocument();
       // Placeholder text
-      expect(screen.getByLabelText('Select snapshot'));
+      expect(screen.getByTestId('dropdown-toggle').textContent).toEqual('Select snapshot');
     });
     await act(() =>
       // Select a snapshot value

--- a/src/components/Secrets/__tests___/ApplicationDropdown.spec.tsx
+++ b/src/components/Secrets/__tests___/ApplicationDropdown.spec.tsx
@@ -18,18 +18,17 @@ describe('ApplicationDropdown', () => {
     expect(screen.getByText('Loading applications...')).toBeVisible();
   });
 
-  it('should show dropdown if applications are loaded', () => {
+  it('should show dropdown if applications are loaded', async () => {
     useApplicationsMock.mockReturnValue([
       [{ metadata: { name: 'app1' } }, { metadata: { name: 'app2' } }],
       true,
     ]);
     formikRenderer(<ApplicationDropdown name="app" />);
-    act(() => {
-      fireEvent.click(screen.getByRole('button'));
+    await act(() => fireEvent.click(screen.getByTestId('dropdown-toggle')));
+    await waitFor(() => {
+      expect(screen.getByRole('menuitem', { name: 'app1' })).toBeVisible();
+      expect(screen.getByRole('menuitem', { name: 'app2' })).toBeVisible();
     });
-
-    expect(screen.getByRole('menuitem', { name: 'app1' })).toBeVisible();
-    expect(screen.getByRole('menuitem', { name: 'app2' })).toBeVisible();
   });
 
   it('should change the application dropdown value', async () => {
@@ -41,12 +40,16 @@ describe('ApplicationDropdown', () => {
     formikRenderer(<ApplicationDropdown name="targets.application" />, {
       targets: { application: 'app' },
     });
-    expect(screen.queryByRole('button')).toBeInTheDocument();
+    await act(() => fireEvent.click(screen.getByTestId('dropdown-toggle')));
 
-    await act(() => fireEvent.click(screen.getByRole('button')));
-    expect(screen.getByRole('menu')).toBeInTheDocument();
-    screen.getByText('app2');
+    await waitFor(() => {
+      const menuItems = screen.getAllByRole('menuitem');
+      expect(menuItems.length).toEqual(2);
+      screen.getByText('app2');
+    });
     await act(() => fireEvent.click(screen.getByText('app2')));
-    await waitFor(() => expect(screen.getByText('app2')));
+    await waitFor(() => {
+      expect(screen.getByTestId('dropdown-toggle').textContent).toEqual('app2');
+    });
   });
 });

--- a/src/components/Secrets/__tests___/ImagePullSecretForm.spec.tsx
+++ b/src/components/Secrets/__tests___/ImagePullSecretForm.spec.tsx
@@ -14,7 +14,8 @@ describe('ImagePullSecretForm', () => {
     expect(screen.getByText('Authentication type')).toBeVisible();
 
     act(() => {
-      fireEvent.click(screen.getByRole('button', { name: 'Image registry credentials' }));
+      expect(screen.getByTestId('dropdown-toggle').textContent).toBe('Image registry credentials');
+      fireEvent.click(screen.getByTestId('dropdown-toggle'));
     });
 
     act(() => {

--- a/src/components/Secrets/__tests___/SecretTypeSelector.spec.tsx
+++ b/src/components/Secrets/__tests___/SecretTypeSelector.spec.tsx
@@ -38,7 +38,8 @@ describe('SecretForm', () => {
       initialValues,
     );
 
-    const dropdown = screen.getByRole('button', { name: 'Key/value secret' });
+    const dropdown = screen.getByTestId('dropdown-toggle');
+    expect(dropdown.textContent).toBe('Key/value secret');
 
     act(() => {
       fireEvent.click(dropdown);

--- a/src/components/Secrets/__tests___/SecretTypeSubForm.spec.tsx
+++ b/src/components/Secrets/__tests___/SecretTypeSubForm.spec.tsx
@@ -48,10 +48,9 @@ describe('SecretTypeSubForm', () => {
 
   it('should render subforms correctly for specified targets', async () => {
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Key/value secret' })).toBeEnabled();
+      expect(screen.getByTestId('dropdown-toggle').textContent).toEqual('Key/value secret');
+      fireEvent.click(screen.getByTestId('dropdown-toggle'));
     });
-
-    fireEvent.click(screen.getByRole('button', { name: 'Key/value secret' }));
     fireEvent.click(screen.getByText('Image pull secret'));
     expect(screen.getByText('Image pull sub form')).toBeVisible();
   });

--- a/src/components/Secrets/__tests___/SourceSecretForm.spec.tsx
+++ b/src/components/Secrets/__tests___/SourceSecretForm.spec.tsx
@@ -16,7 +16,8 @@ describe('SourceSecretForm', () => {
     expect(screen.getByText('Password')).toBeVisible();
 
     act(() => {
-      fireEvent.click(screen.getByRole('button', { name: 'Basic authentication' }));
+      expect(screen.getByTestId('dropdown-toggle').textContent).toEqual('Basic authentication');
+      fireEvent.click(screen.getByTestId('dropdown-toggle'));
     });
 
     act(() => {

--- a/src/components/UserAccess/UserAccessForm/__tests__/RoleSection.spec.tsx
+++ b/src/components/UserAccess/UserAccessForm/__tests__/RoleSection.spec.tsx
@@ -23,7 +23,7 @@ describe('RoleSection', () => {
     formikRenderer(<RoleSection />, { role: '' });
     expect(screen.getByText('Loading...')).toBeVisible();
     const dropdownButton = screen.getByTestId('dropdown-toggle');
-    expect(dropdownButton).toBeDisabled();
+    expect(dropdownButton).toHaveAttribute('aria-disabled', 'true');
   });
 
   it('should not render permissions if role is not selected', () => {

--- a/src/shared/components/dropdown/BasicDropdown.scss
+++ b/src/shared/components/dropdown/BasicDropdown.scss
@@ -1,20 +1,5 @@
-.basic-dropdown {
-  min-width: 100%;
-  button {
-    min-width: 100%;
-  }
-
-  &[aria-invalid=true] {
-    --pf-v5-c-dropdown__toggle--before--BorderBottomColor: var(--pf-v5-global--danger-color--100);
-    --pf-v5-c-dropdown__toggle--hover--before--BorderBottomColor: var(--pf-v5-global--danger-color--100);
-    --pf-v5-c-dropdown__toggle--focus--before--BorderBottomColor: var(--pf-v5-global--danger-color--100);
-    --pf-v5-c-dropdown__toggle--active--before--BorderBottomColor: var(--pf-v5-global--danger-color--100);
-    --pf-v5-c-dropdown--m-expanded__toggle--before--BorderBottomColor: var(--pf-v5-global--danger-color--100);
-
-    button {
-      &::before {
-        border-bottom-width: var(--pf-v5-global--BorderWidth--md);
-      }
-    }
-  }
+.dropdown-item-description {
+  font-size: var(--pf-v5-global--FontSize--sm);
+  color: var(--pf-v5-global--Color--200);
+  margin-top: var(--pf-v5-global--spacer--sm);
 }

--- a/src/shared/components/formik-fields/__tests__/DropdownField.spec.tsx
+++ b/src/shared/components/formik-fields/__tests__/DropdownField.spec.tsx
@@ -54,10 +54,8 @@ describe('DropdownField', () => {
         <DropdownField name={fieldName} label="label" helpText="helpText" items={items} />
       </Wrapper>,
     );
-    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
     fireEvent.click(screen.getByText(initialValues.dropdownValue));
     await waitFor(() => {
-      expect(screen.getByRole('menu')).toBeInTheDocument();
       const menuItems = screen.getAllByRole('menuitem');
       const isItemExist = (item) =>
         menuItems.some((mi) => mi.firstChild.textContent === item.value);
@@ -74,16 +72,13 @@ describe('DropdownField', () => {
     expect(screen.getByTestId('dropdown-toggle').firstChild).toHaveTextContent(
       initialValues.dropdownValue,
     );
-    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
     fireEvent.click(screen.getByText(initialValues.dropdownValue));
     await waitFor(() => {
-      expect(screen.queryByRole('menu')).toBeInTheDocument();
       const menuItem = screen.getByText(items[1].value);
       fireEvent.click(menuItem);
     });
     await waitFor(() => {
       expect(screen.getByTestId('dropdown-toggle').firstChild).toHaveTextContent(items[1].value);
-      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
     });
   });
 
@@ -103,10 +98,8 @@ describe('DropdownField', () => {
     expect(screen.getByTestId('dropdown-toggle').firstChild).toHaveTextContent(
       initialValues.dropdownValue,
     );
-    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
     fireEvent.click(screen.getByText(initialValues.dropdownValue));
     await waitFor(() => {
-      expect(screen.queryByRole('menu')).toBeInTheDocument();
       const menuItem = screen.getByText(items[1].value);
       fireEvent.click(menuItem);
     });
@@ -124,25 +117,22 @@ describe('DropdownField', () => {
     );
     expect(screen.getByText('label')).toBeInTheDocument();
     expect(screen.getByText('helpText')).toBeInTheDocument();
-    expect(screen.getByTestId('dropdown-toggle').firstChild).toHaveTextContent('');
+    expect(screen.getByTestId('dropdown-toggle')).toHaveTextContent('');
   });
 
   it('renders empty dropdown menu if items is empty', async () => {
-    render(
+    const { container } = render(
       <Wrapper initialValues={initialValues} onSubmit={jest.fn()}>
         <DropdownField name={fieldName} label="label" helpText="helpText" items={[]} />
       </Wrapper>,
     );
-    const dropdownDivContainer = screen.getByTestId('dropdown');
     expect(screen.getByTestId('dropdown-toggle').firstChild).toHaveTextContent(
       initialValues.dropdownValue,
     );
-    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
-    expect(dropdownDivContainer.children).toHaveLength(1);
+    expect(container.children).toHaveLength(1);
     fireEvent.click(screen.getByText(initialValues.dropdownValue));
     await waitFor(() => {
-      expect(dropdownDivContainer.children).toHaveLength(2);
-      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      expect(container.querySelectorAll('.dropdown-item').length).toEqual(0);
     });
   });
 });


### PR DESCRIPTION
## Fixes 
[KFLUXUI-330](https://issues.redhat.com/browse/KFLUXUI-330)


## Description
Components of Patterfly are interdependent. To ensure the compatible, let us replace the deprecated dropdown with the dropdown matched with the current Patternfly version.

The current dropdown removed the usage of DropdownToggle and DropdownButton and support the value for 'onSelect' function. In our BasicDropdown, we define our DropdownToggle component by ourselves.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 


https://github.com/user-attachments/assets/f192e9ca-a95c-4cec-8597-1607a92f884b






## How to test or reproduce?
Visit the pages and try the dropdown to ensure they work as before.

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->