### PR TITLE
fix: prepend https scheme to repository url

### DIFF
--- a/src/components/ImportForm/ComponentSection/SourceSection.tsx
+++ b/src/components/ImportForm/ComponentSection/SourceSection.tsx
@@ -49,7 +49,7 @@ export const SourceSection = () => {
         let parsed: GitUrlParse.GitUrl;
         try {
           parsed = GitUrlParse(event.target?.value ?? '');
-          await setFieldValue('gitURLAnnotation', parsed?.resource);
+          await setFieldValue('gitURLAnnotation', `https://${parsed?.resource}`);
         } catch {
           await setFieldValue('gitURLAnnotation', '');
         }

--- a/src/components/ImportForm/ComponentSection/__tests__/ComponentSection.spec.tsx
+++ b/src/components/ImportForm/ComponentSection/__tests__/ComponentSection.spec.tsx
@@ -62,7 +62,9 @@ describe('ComponentSection', () => {
     await user.tab();
     await waitFor(() =>
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-      expect((screen.getByTestId('url-annotation') as HTMLInputElement).value).toBe('gitlab.com'),
+      expect((screen.getByTestId('url-annotation') as HTMLInputElement).value).toBe(
+        'https://gitlab.com',
+      ),
     );
   });
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
I think Pipelines As Code fails to process incoming webhooks for gitlab repos if the scheme prefix is not presented to it.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Try to onboard a gitlab.com repo.

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->