### PR TITLE
test(fix): fix check for author to be part of an org

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -2,30 +2,25 @@ name: PR Check Test
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   check-org-membership:
     runs-on: ubuntu-latest
-    outputs:
-      org-member: ${{ steps.org-check.outputs.org-member }}
     steps:
       - name: Check if PR author is a member of the organization
-        continue-on-error: true
-        id: org-check
         run: |
           ORG="${{ github.repository_owner }}"
-          AUTHOR="${{ github.event.pull_request.user.login }}"
-          if ! gh api /orgs/$ORG/members/$AUTHOR; then
-            echo '### ❌ PR author is not a member of GitHub organization' >> $GITHUB_STEP_SUMMARY
-            exit 1
+          PR_AUTHOR=$(jq --raw-output .pull_request.user.login $GITHUB_EVENT_PATH)
+          
+          if gh api "/orgs/$ORG/members/$PR_AUTHOR"; then
+            echo "PR author is a member of $ORG GitHub organization, skipping further checks"
+            exit 0
           fi
-          echo "org-member=true" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.HAC_TEST_GH_TOKEN }}
 
   e2e-test:
-    if: ${{ (needs.check-org-membership.outputs.org-member == 'true') || (github.event.pull_request.user.login == 'renovate[bot]') || contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     needs: check-org-membership
     runs-on: ubuntu-latest    
     steps:


### PR DESCRIPTION
Currently, the PR check fails due to validation that the author of the PR is part of an org. 
Trying to use the same approach as Konflux QE job.

Part of https://issues.redhat.com/browse/KFLUXUI-338