### PR TITLE
fix(KONFLUX-5759): quotes added in finally in stop and cancel buttons

### DIFF
--- a/src/components/PipelineRun/PipelineRunListView/pipelinerun-actions.tsx
+++ b/src/components/PipelineRun/PipelineRunListView/pipelinerun-actions.tsx
@@ -134,7 +134,7 @@ export const usePipelinerunActions = (pipelineRun: PipelineRunKind): Action[] =>
       cta: () => pipelineRunCancel(pipelineRun),
       id: 'pipelinerun-cancel',
       label: 'Cancel',
-      tooltip: 'Interrupt any executing non finally tasks, then execute "finally" tasks',
+      tooltip: 'Interrupt any executing non "finally" tasks, then execute "finally" tasks',
       disabled: !(pipelineRunStatus(pipelineRun) === runStatus.Running) || !canPatchPipelineRun,
       disabledTooltip: !canPatchPipelineRun
         ? "You don't have access to cancel this pipeline"

--- a/src/components/PipelineRun/PipelineRunListView/pipelinerun-actions.tsx
+++ b/src/components/PipelineRun/PipelineRunListView/pipelinerun-actions.tsx
@@ -124,7 +124,7 @@ export const usePipelinerunActions = (pipelineRun: PipelineRunKind): Action[] =>
       cta: () => pipelineRunStop(pipelineRun),
       id: 'pipelinerun-stop',
       label: 'Stop',
-      tooltip: 'Let the running tasks complete, then execute finally tasks',
+      tooltip: 'Let the running tasks complete, then execute "finally" tasks',
       disabled: !(pipelineRunStatus(pipelineRun) === runStatus.Running) || !canPatchPipelineRun,
       disabledTooltip: !canPatchPipelineRun
         ? "You don't have access to stop this pipeline"
@@ -134,7 +134,7 @@ export const usePipelinerunActions = (pipelineRun: PipelineRunKind): Action[] =>
       cta: () => pipelineRunCancel(pipelineRun),
       id: 'pipelinerun-cancel',
       label: 'Cancel',
-      tooltip: 'Interrupt any executing non finally tasks, then execute finally tasks',
+      tooltip: 'Interrupt any executing non finally tasks, then execute "finally" tasks',
       disabled: !(pipelineRunStatus(pipelineRun) === runStatus.Running) || !canPatchPipelineRun,
       disabledTooltip: !canPatchPipelineRun
         ? "You don't have access to cancel this pipeline"


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/KONFLUX-5759


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
In the "Stop" and "Cancel" options in the pipeline run view, there are references to the finally tasks, added quotes to finally.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
Stop Button:
<img width="1151" alt="image" src="https://github.com/user-attachments/assets/0863c34b-691b-49be-8a87-6aa1d32dd34a" />

<br/>

Cancel Button:
<img width="1211" alt="image" src="https://github.com/user-attachments/assets/7e791baf-0e9f-4b66-b0cf-4595148f20c3" />





<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->