### PR TITLE
feat: display release duration in the release list

### DIFF
--- a/src/components/Releases/ReleasesListHeader.tsx
+++ b/src/components/Releases/ReleasesListHeader.tsx
@@ -3,7 +3,8 @@ import { HeaderFunc } from '../../shared/components/table/Table';
 
 export const releasesTableColumnClasses = {
   name: 'pf-m-width-30 pf-m-width-20-on-xl wrap-column',
-  created: 'pf-m-width-30 pf-m-width-20-on-xl',
+  created: 'pf-m-width-20 pf-m-width-20-on-xl',
+  duration: 'pf-m-hidden pf-m-width-20 pf-m-visible-on-xl',
   status: 'pf-m-width-20',
   releasePlan: 'pf-m-width-25',
   releaseSnapshot: 'pf-m-hidden pf-m-width-25 pf-m-visible-on-xl',
@@ -42,6 +43,10 @@ const getReleasesListHeader: CreateHeader = (activeIndex, activeDirection, onSor
         className: releasesTableColumnClasses.created,
         sort: getSortParams(SortableHeaders.created),
       },
+    },
+    {
+      title: 'Duration',
+      props: { className: releasesTableColumnClasses.duration },
     },
     {
       title: 'Status',

--- a/src/components/Releases/ReleasesListRow.tsx
+++ b/src/components/Releases/ReleasesListRow.tsx
@@ -7,6 +7,7 @@ import { RowFunctionArgs, TableData } from '../../shared/components/table';
 import { Timestamp } from '../../shared/components/timestamp/Timestamp';
 import { useNamespace } from '../../shared/providers/Namespace';
 import { ReleaseKind } from '../../types';
+import { calculateDuration } from '../../utils/pipeline-utils';
 import { StatusIconWithText } from '../StatusIcon/StatusIcon';
 import { releasesTableColumnClasses } from './ReleasesListHeader';
 
@@ -31,6 +32,14 @@ const ReleasesListRow: React.FC<
       </TableData>
       <TableData className={releasesTableColumnClasses.created}>
         <Timestamp timestamp={obj.metadata.creationTimestamp} />
+      </TableData>
+      <TableData className={releasesTableColumnClasses.duration}>
+        {obj.status?.startTime != null
+          ? calculateDuration(
+              typeof obj.status?.startTime === 'string' ? obj.status?.startTime : '',
+              typeof obj.status?.completionTime === 'string' ? obj.status?.completionTime : '',
+            )
+          : '-'}
       </TableData>
       <TableData className={releasesTableColumnClasses.status}>
         <StatusIconWithText dataTestAttribute="release-status" status={status} />

--- a/src/components/Releases/__tests__/ReleasesListRow.spec.tsx
+++ b/src/components/Releases/__tests__/ReleasesListRow.spec.tsx
@@ -25,7 +25,23 @@ const mockRelease = {
         type: ReleaseCondition.Released,
       },
     ],
+    startTime: '2023-01-20T15:00:00Z',
+    completionTime: '2023-01-20T16:30:00Z',
   },
+};
+
+const mockPendingRelease = {
+  apiVersion: 'appstudio.redhat.com/v1alpha1',
+  kind: 'Release',
+  metadata: {
+    name: 'test-pending-release',
+    creationTimestamp: '2023-01-20T14:13:29Z',
+  },
+  spec: {
+    releasePlan: 'test-plan',
+    snapshot: 'test-snapshot',
+  },
+  status: {},
 };
 
 describe('ReleasesListRow', () => {
@@ -44,10 +60,29 @@ describe('ReleasesListRow', () => {
     const status = wrapper.getAllByTestId('release-status');
 
     expect(cells[0].children[0].innerHTML).toBe(mockRelease.metadata.name);
-    expect(cells[3].innerHTML).toBe('test-plan');
-    expect(cells[4].innerHTML).toBe(
+    expect(cells[2].innerHTML).toBe('1 hour 30 minutes');
+    expect(cells[4].innerHTML).toBe('test-plan');
+    expect(cells[5].innerHTML).toBe(
       '<a href="/workspaces//applications/test-app/snapshots/test-snapshot">test-snapshot</a>',
     );
     expect(status[0].innerHTML).toBe('Succeeded');
+  });
+
+  it('should present pending releases appropriately', () => {
+    const wrapper = render(
+      <ReleasesListRow
+        obj={mockPendingRelease}
+        columns={[]}
+        customData={{ applicationName: 'test-app' }}
+      />,
+      {
+        container: document.createElement('tr'),
+      },
+    );
+    const cells = wrapper.container.getElementsByTagName('td');
+
+    expect(cells[0].children[0].innerHTML).toBe(mockPendingRelease.metadata.name);
+    // The release is pending, so there's no reasonable duration
+    expect(cells[2].innerHTML).toBe('-');
   });
 });

--- a/src/components/Releases/__tests__/ReleasesListView.spec.tsx
+++ b/src/components/Releases/__tests__/ReleasesListView.spec.tsx
@@ -157,7 +157,7 @@ describe('ReleasesListView', () => {
     fireEvent.input(screen.getByRole('textbox'), { target: { value: 'test-plan-2' } });
     const rows = screen.getAllByRole('row');
     expect(rows.length).toBe(2);
-    expect(rows[1].children[3]).toHaveTextContent('test-plan-2');
+    expect(rows[1].children[4]).toHaveTextContent('test-plan-2');
   });
 
   it('should allow filtering by release snapshot', () => {
@@ -168,6 +168,6 @@ describe('ReleasesListView', () => {
     fireEvent.input(screen.getByRole('textbox'), { target: { value: 'test-snapshot-2' } });
     const rows = screen.getAllByRole('row');
     expect(rows.length).toBe(2);
-    expect(rows[1].children[4]).toHaveTextContent('test-snapshot-2');
+    expect(rows[1].children[5]).toHaveTextContent('test-snapshot-2');
   });
 });


### PR DESCRIPTION

## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
No issue associated with this that I'm aware of.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This change adds release duration to the list view of releases.

As a user, I want to quickly see how long my most recent releases are taking in the list so I can compare them with each other. If they're taking longer and longer, I have a problem I need to deal with.

We happen to have a lot of real estate in the release list right now.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
None.

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->