### PR TITLE
fix(KFLUXUI-339): releases of application details page can be shown well

### DIFF
--- a/src/routes/page-routes/release.tsx
+++ b/src/routes/page-routes/release.tsx
@@ -1,14 +1,24 @@
-import { releaseListViewTabLoader } from '../../components/Releases';
-import ReleasesListView from '../../components/Releases/ReleasesListView';
-import { APPLICATION_RELEASE_LIST_PATH } from '../paths';
+import {
+  ReleaseDetailsLayout,
+  releaseListViewTabLoader,
+  ReleaseOverviewTab,
+} from '../../components/Releases';
+import { APPLICATION_RELEASE_DETAILS_PATH } from '../paths';
 import { RouteErrorBoundry } from '../RouteErrorBoundary';
 
 const releaseRoutes = [
+  // details page
   {
-    path: APPLICATION_RELEASE_LIST_PATH.path,
+    path: APPLICATION_RELEASE_DETAILS_PATH.path,
     loader: releaseListViewTabLoader,
     errorElement: <RouteErrorBoundry />,
-    element: <ReleasesListView />,
+    element: <ReleaseDetailsLayout />,
+    children: [
+      {
+        index: true,
+        element: <ReleaseOverviewTab />,
+      },
+    ],
   },
 ];
 


### PR DESCRIPTION
## Fixes 
[KFLUXUI-339](https://issues.redhat.com/browse/KFLUXUI-339)


## Description
During the release namespace migration, there is one regression. The release page of application details page is incorrect. The patch fixes the regression. 

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

![Screenshot 2025-03-03 at 08 58 35](https://github.com/user-attachments/assets/aa6bfc7c-6804-434e-8483-1991e0466b5f)
![Screenshot 2025-03-03 at 08 58 51](https://github.com/user-attachments/assets/2000a09f-1fb8-4f74-aba8-24ffe3d792ca)


## How to test or reproduce?
1. visit the detail page of one application
2. visit the release tab of it
3. visit the integration tab of it
Releases of application can be shown well and we can move to integration tests easily by click the 'Integration tests' tab on the details page after we click the 'Releases'.

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->