### PR TITLE
Fix documentation links

### DIFF
--- a/src/components/ComponentRelation/cr-modals.tsx
+++ b/src/components/ComponentRelation/cr-modals.tsx
@@ -53,7 +53,7 @@ export const DefineComponentRelationModal: React.FC<DefineComponentRelationModal
       description={
         <>
           Nudging references another component by digest.{' '}
-          <ExternalLink href="https://konflux-ci.dev/docs/how-tos/configuring/component-nudges/">
+          <ExternalLink href="https://konflux-ci.dev/docs/building/component-nudges/">
             Learn more about nudging.
           </ExternalLink>
         </>

--- a/src/components/ImportForm/ImportForm.tsx
+++ b/src/components/ImportForm/ImportForm.tsx
@@ -16,7 +16,7 @@ const ImportForm: React.FC = () => {
       description={
         <>
           An application is one or more components that run together.{' '}
-          <ExternalLink href="https://konflux-ci.dev/docs/how-tos/creating/">
+          <ExternalLink href="https://konflux-ci.dev/docs/building/creating/">
             Learn more
           </ExternalLink>
         </>

--- a/src/components/ReleaseService/ReleaseServiceEmptyState.tsx
+++ b/src/components/ReleaseService/ReleaseServiceEmptyState.tsx
@@ -12,7 +12,7 @@ export const ReleaseServiceEmptyState: React.FC<
 > = ({ title }) => {
   return (
     <AppEmptyState emptyStateImg={emptyStateImgUrl} title={title}>
-      <ExternalLink href="https://konflux-ci.dev/docs/advanced-how-tos/releasing/">
+      <ExternalLink href="https://konflux-ci.dev/docs/releasing/">
         Learn more about setting up release services
       </ExternalLink>
     </AppEmptyState>

--- a/src/components/Releases/ReleasesEmptyState.tsx
+++ b/src/components/Releases/ReleasesEmptyState.tsx
@@ -11,7 +11,7 @@ const ReleasesEmptyState: React.FC<React.PropsWithChildren<unknown>> = () => (
         A release object represents a deployed snapshot of your application components. To view your
         releases, set up a release plan for your application.
       </Text>
-      <ExternalLink href="https://konflux-ci.dev/docs/advanced-how-tos/releasing/">
+      <ExternalLink href="https://konflux-ci.dev/docs/releasing/">
         Learn more about setting up release plans
       </ExternalLink>
     </EmptyStateBody>

--- a/src/components/Secrets/SecretsForm/AddSecretForm.tsx
+++ b/src/components/Secrets/SecretsForm/AddSecretForm.tsx
@@ -66,7 +66,7 @@ const AddSecretForm: React.FC = () => {
           description={
             <>
               Add a secret that will be stored using AWS Secret Manager to keep your data private.{' '}
-              <ExternalLink href="https://konflux-ci.dev/docs/how-tos/configuring/creating-secrets/">
+              <ExternalLink href="https://konflux-ci.dev/docs/building/creating-secrets/">
                 Learn more
               </ExternalLink>
             </>

--- a/src/components/Secrets/SecretsListPage.tsx
+++ b/src/components/Secrets/SecretsListPage.tsx
@@ -16,7 +16,7 @@ const SecretsListPage: React.FC = () => {
           Manage your secrets and their related configurations. You can add a secret at the
           namespace level.
           <br /> All secrets are stored using AWS Secrets Manager to keep your data private.{' '}
-          <ExternalLink href="https://konflux-ci.dev/docs/how-tos/configuring/creating-secrets/">
+          <ExternalLink href="https://konflux-ci.dev/docs/building/creating-secrets/">
             Learn more
           </ExternalLink>
         </>

--- a/src/components/WhatsNext/useWhatsNextItems.ts
+++ b/src/components/WhatsNext/useWhatsNextItems.ts
@@ -48,7 +48,7 @@ export const useWhatsNextItems = (applicationName: string) => {
           namespace,
         },
       },
-      helpLink: 'https://konflux-ci.dev/docs/how-tos/creating/',
+      helpLink: 'https://konflux-ci.dev/docs/building/creating/',
     },
     {
       title: 'Add integration tests',
@@ -68,7 +68,7 @@ export const useWhatsNextItems = (applicationName: string) => {
           namespace,
         },
       },
-      helpLink: 'https://konflux-ci.dev/docs/how-tos/testing/integration/adding/',
+      helpLink: 'https://konflux-ci.dev/docs/testing/integration/adding/',
     },
     {
       title: 'Create a release plan',
@@ -88,7 +88,7 @@ export const useWhatsNextItems = (applicationName: string) => {
           namespace,
         },
       },
-      helpLink: 'https://konflux-ci.dev/docs/advanced-how-tos/releasing/',
+      helpLink: 'https://konflux-ci.dev/docs/releasing/',
     },
     {
       title: 'Install our GitHub app',
@@ -105,7 +105,7 @@ export const useWhatsNextItems = (applicationName: string) => {
           namespace,
         },
       },
-      helpLink: 'https://konflux-ci.dev/docs/how-tos/creating/',
+      helpLink: 'https://konflux-ci.dev/docs/building/creating/',
     },
     {
       title: 'Make a code change',
@@ -121,7 +121,7 @@ export const useWhatsNextItems = (applicationName: string) => {
           namespace,
         },
       },
-      helpLink: 'https://konflux-ci.dev/docs/how-tos/creating/',
+      helpLink: 'https://konflux-ci.dev/docs/building/creating/',
     },
     {
       title: 'Manage build pipelines',
@@ -141,7 +141,7 @@ export const useWhatsNextItems = (applicationName: string) => {
           namespace,
         },
       },
-      helpLink: 'https://konflux-ci.dev/docs/how-tos/configuring/customizing-the-build/',
+      helpLink: 'https://konflux-ci.dev/docs/building/customizing-the-build/',
     },
   ];
   return whatsNextItems;


### PR DESCRIPTION
In https://github.com/konflux-ci/docs/pull/258 we flattened directory structures which resulted in breaking the links in the Konflux UI. This PR is updating those to be accurate again.


## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->