### PR TITLE
fix(KONFLUX-7308): don't expand/collapse advanced git options while typing url

### DIFF
--- a/e2e-tests/support/pageObjects/createApplication-po.ts
+++ b/e2e-tests/support/pageObjects/createApplication-po.ts
@@ -5,6 +5,7 @@ export const addComponentPagePO = {
   verifiedSource: '[class="pf-v5-c-form-control pf-m-success"]',
   gitOptions: 'Git options',
   gitReference: '[data-test="git-reference"]',
+  hideAdvancedGitOptions: 'Hide advanced Git options',
   contextDir: '[data-test="context-dir"]',
   next: 'button[type=submit]',
   cancel: 'button[type=reset]',

--- a/e2e-tests/utils/Applications.ts
+++ b/e2e-tests/utils/Applications.ts
@@ -1,4 +1,5 @@
 import { pageTitles, FULL_APPLICATION_TITLE } from '../support/constants/PageTitle';
+import { addComponentPagePO } from '../support/pageObjects/createApplication-po';
 import { actions, breadcrumb } from '../support/pageObjects/global-po';
 import {
   actionsDropdown,
@@ -83,6 +84,8 @@ export class Applications {
 
     addComponent.setSource(publicGitRepo);
     this.configureComponentsStep(componentName, pipeline, applicationName, dockerfilePath, secret);
+    // make sure advanced git options is closed, so the repo validation icon is in the viewport
+    cy.contains('button', 'Hide advanced Git options').click();
     addComponent.waitRepoValidated();
     if (isPrivate) {
       addComponent.setPrivate();

--- a/src/components/ImportForm/ComponentSection/SourceSection.tsx
+++ b/src/components/ImportForm/ComponentSection/SourceSection.tsx
@@ -12,7 +12,7 @@ import GitOptions from './GitOptions';
 
 export const SourceSection = () => {
   const [, { touched, error }] = useField('source.git.url');
-  const [isGitAdvancedOpen, setGitAdvancedOpen] = React.useState<boolean>(false);
+  const [isGitAdvancedOpen, setGitAdvancedOpen] = React.useState<boolean>(true);
   const { touched: touchedValues, setFieldValue } = useFormikContext<ImportFormValues>();
   const validated = touched
     ? touched && !error
@@ -36,15 +36,12 @@ export const SourceSection = () => {
         const gitType = detectGitType(event.target?.value as string);
         if (gitType !== GitProvider.GITHUB && gitType !== GitProvider.GITLAB) {
           await setFieldValue('gitProviderAnnotation', '');
-          setGitAdvancedOpen(true);
         }
         if (gitType === GitProvider.GITHUB) {
           await setFieldValue('gitProviderAnnotation', GIT_PROVIDER_ANNOTATION_VALUE.GITHUB);
-          setGitAdvancedOpen(false);
         }
         if (gitType === GitProvider.GITLAB) {
           await setFieldValue('gitProviderAnnotation', GIT_PROVIDER_ANNOTATION_VALUE.GITLAB);
-          setGitAdvancedOpen(false);
         }
 
         let parsed: GitUrlParse.GitUrl;

--- a/src/components/ImportForm/ComponentSection/__tests__/ComponentSection.spec.tsx
+++ b/src/components/ImportForm/ComponentSection/__tests__/ComponentSection.spec.tsx
@@ -15,7 +15,7 @@ describe('ComponentSection', () => {
     expect(screen.queryByTestId('git-reference')).not.toBeInTheDocument();
   });
 
-  it('should render git options if source url is valid', async () => {
+  it('should render git options by default', async () => {
     formikRenderer(<ComponentSection />, {
       source: { git: { url: '' } },
     });
@@ -23,18 +23,6 @@ describe('ComponentSection', () => {
     const source = screen.getByPlaceholderText('Enter your source');
 
     await user.type(source, 'https://github.com/abcd/repo.git');
-    await user.tab();
-    await waitFor(() => screen.getByText('Show advanced Git options'));
-  });
-
-  it('should expand git options if source url is others', async () => {
-    formikRenderer(<ComponentSection />, {
-      source: { git: { url: '' } },
-    });
-    const user = userEvent.setup();
-    const source = screen.getByPlaceholderText('Enter your source');
-
-    await user.type(source, 'https://bitbucket.com/abcd/repo.git');
     await user.tab();
     await waitFor(() => screen.getByText('Hide advanced Git options'));
   });


### PR DESCRIPTION
## Fixes 
[KONFLUX-7308](https://issues.redhat.com/browse/KONFLUX-7308)


## Description
When the user inputs the git repo URL, the advanced git options would open/close in a not very intuitive way. Now, the section is closed by default and can be opened only by the user clicking the open button. 


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [X] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Open the form to create an application, add a component, and input a git repo URL. The advanced git section won't open, no matter the input.

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [X] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->