### PR TITLE
fix: remove workspace usage from API and WebSocket urls

### DIFF
--- a/e2e-tests/utils/APIEndpoints.ts
+++ b/e2e-tests/utils/APIEndpoints.ts
@@ -5,23 +5,17 @@ export const hacAPIEndpoints = {
     )}/applications/${applicationName}`,
 
   environments: (envName: string) =>
-    `/api/k8s/workspaces/${Cypress.env(
-      'HAC_WORKSPACE',
-    )}/apis/appstudio.redhat.com/v1alpha1/namespaces/${Cypress.env(
+    `/api/k8s/apis/appstudio.redhat.com/v1alpha1/namespaces/${Cypress.env(
       'HAC_NAMESPACE',
     )}/environments/${envName}`,
 
   pipelinerunsFilter: (applicationName: string, label: string) =>
-    `/api/k8s/workspaces/${Cypress.env(
-      'HAC_WORKSPACE',
-    )}/apis/tekton.dev/v1beta1/namespaces/${Cypress.env(
+    `/api/k8s/apis/tekton.dev/v1beta1/namespaces/${Cypress.env(
       'HAC_NAMESPACE',
     )}/pipelineruns?labelSelector=appstudio.openshift.io/application=${applicationName},${label}&limit=250`,
 
   secrets: (secretName: string) =>
-    `/api/k8s/workspaces/${Cypress.env('HAC_WORKSPACE')}/api/v1/namespaces/${Cypress.env(
-      'HAC_NAMESPACE',
-    )}/secrets/${secretName}`,
+    `/api/k8s/api/v1/namespaces/${Cypress.env('HAC_NAMESPACE')}/secrets/${secretName}`,
 
   resources: (resourceType: string) =>
     `/api/k8s/apis/appstudio.redhat.com/v1beta1/namespaces/${Cypress.env(

--- a/e2e-tests/utils/Common.ts
+++ b/e2e-tests/utils/Common.ts
@@ -30,14 +30,14 @@ export class Common {
   }
 
   static openApplicationURL(applicationName: string) {
-    const workspacePathMatcher = new RegExp(/workspaces\/([^/]+)/);
+    const workspacePathMatcher = new RegExp(/ns\/([^/]+)/);
     cy.url().then((url) => {
-      const [, workspace = ''] = url.match(workspacePathMatcher) || [];
+      const [, namespace = ''] = url.match(workspacePathMatcher) || [];
 
       Common.openURL(
         `${Cypress.env(
           'KONFLUX_BASE_URL',
-        )}/workspaces/${workspace}/applications/${applicationName.replace('.', '-')}`,
+        )}/ns/${namespace}/applications/${applicationName.replace('.', '-')}`,
       );
       Common.verifyPageTitle(applicationName);
       Common.waitForLoad();

--- a/e2e-tests/utils/Login.ts
+++ b/e2e-tests/utils/Login.ts
@@ -37,12 +37,12 @@ export class Login {
     Common.waitForLoad();
     // Wait for https://localhost:8080/ loaded
     GetStartedPage.waitForLoad();
-    // Go to the https://localhost:8080/workspaces
+    // Go to the https://localhost:8080/ns
     Common.navigateTo(NavItem.namespaces);
     Common.verifyPageTitle(pageTitles.namespaces);
     Common.waitForLoad();
     cy.testA11y(`${pageTitles.namespaces}`);
-    // Go to https://localhost:8080/workspaces/your-tenant/applications
+    // Go to https://localhost:8080/ns/your-tenant/applications
     cy.get(
       goToApplicationsPagePo(`${Cypress.env('HAC_NAMESPACE')}`).goToApplicationsPagePo,
     ).click();

--- a/src/AppRoot/__tests__/AppSideBar.spec.tsx
+++ b/src/AppRoot/__tests__/AppSideBar.spec.tsx
@@ -65,20 +65,11 @@ describe('AppSideBar', () => {
 
     expect(screen.getByText('Applications')).toHaveAttribute(
       'href',
-      '/workspaces/test-namespace/applications',
+      '/ns/test-namespace/applications',
     );
-    expect(screen.getByText('Secrets')).toHaveAttribute(
-      'href',
-      '/workspaces/test-namespace/secrets',
-    );
-    expect(screen.getByText('Releases')).toHaveAttribute(
-      'href',
-      '/workspaces/test-namespace/release',
-    );
-    expect(screen.getByText('User Access')).toHaveAttribute(
-      'href',
-      '/workspaces/test-namespace/access',
-    );
+    expect(screen.getByText('Secrets')).toHaveAttribute('href', '/ns/test-namespace/secrets');
+    expect(screen.getByText('Releases')).toHaveAttribute('href', '/ns/test-namespace/release');
+    expect(screen.getByText('User Access')).toHaveAttribute('href', '/ns/test-namespace/access');
   });
 
   it('should not render links for disabled namespace-dependent routes when no namespace is available', () => {
@@ -87,7 +78,7 @@ describe('AppSideBar', () => {
 
     routerRenderer(<AppSideBar isOpen={true} />);
 
-    expect(screen.getByText('Namespaces')).toHaveAttribute('href', '/workspaces');
+    expect(screen.getByText('Namespaces')).toHaveAttribute('href', '/ns');
     expect(screen.getByText('Applications')).toHaveAttribute('href', '/');
     expect(screen.getByText('Secrets')).toHaveAttribute('href', '/');
     expect(screen.getByText('Releases')).toHaveAttribute('href', '/');

--- a/src/components/Activity/__tests__/ActivityTab.spec.tsx
+++ b/src/components/Activity/__tests__/ActivityTab.spec.tsx
@@ -58,7 +58,7 @@ describe('Activity Tab', () => {
       fireEvent.click(plrTab);
     });
     expect(navigateMock).toHaveBeenCalledWith(
-      '/workspaces/test-ws/applications/test-app/activity/pipelineruns',
+      '/ns/test-ws/applications/test-app/activity/pipelineruns',
     );
   });
   it('should display the correct tab', () => {
@@ -106,7 +106,7 @@ describe('Activity Tab', () => {
     localStorage.setItem(ACTIVITY_SECONDARY_TAB_KEY, 'pipelineruns');
     routerRenderer(<ActivityTab />);
     expect(navigateMock).toHaveBeenCalledWith(
-      '/workspaces/test-ws/applications/test-app/activity/pipelineruns',
+      '/ns/test-ws/applications/test-app/activity/pipelineruns',
       { replace: true },
     );
   });

--- a/src/components/ApplicationDetails/tabs/overview/visualization/utils/__tests__/node-utils.spec.ts
+++ b/src/components/ApplicationDetails/tabs/overview/visualization/utils/__tests__/node-utils.spec.ts
@@ -46,13 +46,11 @@ describe('getBuildNodeForComponent', () => {
       componentsGroupElement as unknown as Node<PipelineNodeModel, WorkflowNodeModelData>,
       'test-workspace',
     );
-    expect(elementLinks.elementRef).toBe(
-      '/workspaces/test-workspace/applications/test-app/components',
-    );
+    expect(elementLinks.elementRef).toBe('/ns/test-workspace/applications/test-app/components');
     expect(elementLinks.pipelinesRef).toBe(
-      '/workspaces/test-workspace/applications/test-app/activity/pipelineruns',
+      '/ns/test-workspace/applications/test-app/activity/pipelineruns',
     );
-    expect(elementLinks.appRef).toBe('/workspaces/test-workspace/applications/test-app');
+    expect(elementLinks.appRef).toBe('/ns/test-workspace/applications/test-app');
 
     // Component node
     const componentNodeElement = {
@@ -72,12 +70,12 @@ describe('getBuildNodeForComponent', () => {
       'test-workspace',
     );
     expect(elementLinks.elementRef).toBe(
-      '/workspaces/test-workspace/applications/test-app/components/test-component',
+      '/ns/test-workspace/applications/test-app/components/test-component',
     );
     expect(elementLinks.pipelinesRef).toBe(
-      '/workspaces/test-workspace/applications/test-app/activity/pipelineruns',
+      '/ns/test-workspace/applications/test-app/activity/pipelineruns',
     );
-    expect(elementLinks.appRef).toBe('/workspaces/test-workspace/applications/test-app');
+    expect(elementLinks.appRef).toBe('/ns/test-workspace/applications/test-app');
   });
 
   it('should return correct link data for different build node types', () => {
@@ -97,13 +95,11 @@ describe('getBuildNodeForComponent', () => {
       emptyBuildElement as unknown as Node<PipelineNodeModel, WorkflowNodeModelData>,
       'test-workspace',
     );
-    expect(elementLinks.elementRef).toBe(
-      '/workspaces/test-workspace/applications/test-app/components',
-    );
+    expect(elementLinks.elementRef).toBe('/ns/test-workspace/applications/test-app/components');
     expect(elementLinks.pipelinesRef).toBe(
-      '/workspaces/test-workspace/applications/test-app/activity/pipelineruns',
+      '/ns/test-workspace/applications/test-app/activity/pipelineruns',
     );
-    expect(elementLinks.appRef).toBe('/workspaces/test-workspace/applications/test-app');
+    expect(elementLinks.appRef).toBe('/ns/test-workspace/applications/test-app');
 
     // Build group node
     const buildGroupElement = {
@@ -123,12 +119,12 @@ describe('getBuildNodeForComponent', () => {
       'test-workspace',
     );
     expect(elementLinks.elementRef).toBe(
-      '/workspaces/test-workspace/applications/test-app/activity/pipelineruns',
+      '/ns/test-workspace/applications/test-app/activity/pipelineruns',
     );
     expect(elementLinks.pipelinesRef).toBe(
-      '/workspaces/test-workspace/applications/test-app/activity/pipelineruns',
+      '/ns/test-workspace/applications/test-app/activity/pipelineruns',
     );
-    expect(elementLinks.appRef).toBe('/workspaces/test-workspace/applications/test-app');
+    expect(elementLinks.appRef).toBe('/ns/test-workspace/applications/test-app');
 
     // Build node
     const buildNodeElement = {
@@ -148,11 +144,11 @@ describe('getBuildNodeForComponent', () => {
       'test-workspace',
     );
     expect(elementLinks.elementRef).toBe(
-      '/workspaces/test-workspace/applications/test-app/activity/pipelineruns?name=test-build',
+      '/ns/test-workspace/applications/test-app/activity/pipelineruns?name=test-build',
     );
     expect(elementLinks.pipelinesRef).toBe(
-      '/workspaces/test-workspace/applications/test-app/activity/pipelineruns',
+      '/ns/test-workspace/applications/test-app/activity/pipelineruns',
     );
-    expect(elementLinks.appRef).toBe('/workspaces/test-workspace/applications/test-app');
+    expect(elementLinks.appRef).toBe('/ns/test-workspace/applications/test-app');
   });
 });

--- a/src/components/Applications/__tests__/ApplicationListView.spec.tsx
+++ b/src/components/Applications/__tests__/ApplicationListView.spec.tsx
@@ -138,7 +138,7 @@ describe('Application List', () => {
     screen.getByText('Easily onboard your applications');
     const button = screen.getByText('Create application');
     expect(button).toBeInTheDocument();
-    expect(button.closest('a').href).toBe('http://localhost/workspaces/test-ns/import');
+    expect(button.closest('a').href).toBe('http://localhost/ns/test-ns/import');
   });
 
   it('should render empty state with no card', () => {

--- a/src/components/Applications/switcher/__tests__/ApplicationSwitcher.spec.tsx
+++ b/src/components/Applications/switcher/__tests__/ApplicationSwitcher.spec.tsx
@@ -93,7 +93,7 @@ describe('ContextSwitcher', () => {
 
     expect(screen.getByText('Test Application 2')).toBeInTheDocument();
     act(() => screen.getByText('Test Application 2').click());
-    expect(navigateMock).toHaveBeenCalledWith('/workspaces/test-ns/applications/test-app-2');
+    expect(navigateMock).toHaveBeenCalledWith('/ns/test-ns/applications/test-app-2');
     expect(screen.queryByText('Test Application 2')).toBeNull();
     switcher.unmount();
   });

--- a/src/components/Commits/CommitDetails/tabs/__tests__/CommitsPipelineRunTab.spec.tsx
+++ b/src/components/Commits/CommitDetails/tabs/__tests__/CommitsPipelineRunTab.spec.tsx
@@ -99,7 +99,7 @@ describe('Commit Pipelinerun List', () => {
     const button = screen.getByText('Add component');
     expect(button).toBeInTheDocument();
     expect(button.closest('a').href).toContain(
-      `http://localhost/workspaces/test-ns/import?application=my-test-app`,
+      `http://localhost/ns/test-ns/import?application=my-test-app`,
     );
   });
 

--- a/src/components/Commits/CommitsListPage/__tests__/CommitsListView.spec.tsx
+++ b/src/components/Commits/CommitsListPage/__tests__/CommitsListView.spec.tsx
@@ -89,7 +89,7 @@ describe('CommitsListView', () => {
     const addButton = screen.queryByText('Add component');
     expect(addButton).toBeInTheDocument();
     expect(addButton.closest('a').href).toContain(
-      `http://localhost/workspaces/test-ns/import?application=purple-mermaid-app`,
+      `http://localhost/ns/test-ns/import?application=purple-mermaid-app`,
     );
   });
 

--- a/src/components/ComponentRelation/details-page/__tests__/ComponentNudgesDependencies.spec.tsx
+++ b/src/components/ComponentRelation/details-page/__tests__/ComponentNudgesDependencies.spec.tsx
@@ -68,9 +68,7 @@ describe('ComponentNudgesDependencies', () => {
 
     const links = screen.queryAllByTestId('nudges-cmp-link');
     expect(links.length).toBe(3);
-    expect(links[0].getAttribute('href')).toBe(
-      '/workspaces/test-ns/applications/app1/components/cmp1',
-    );
+    expect(links[0].getAttribute('href')).toBe('/ns/test-ns/applications/app1/components/cmp1');
   });
 });
 
@@ -119,8 +117,6 @@ describe('ComponentNudgesDependencies nudged by', () => {
 
     const links = screen.queryAllByTestId('nudged-by-cmp-link');
     expect(links.length).toBe(2);
-    expect(links[1].getAttribute('href')).toBe(
-      '/workspaces/test-ns/applications/app2/components/cmp2',
-    );
+    expect(links[1].getAttribute('href')).toBe('/ns/test-ns/applications/app2/components/cmp2');
   });
 });

--- a/src/components/Components/ComponentDetails/__tests__/ComponentActivityTab.spec.tsx
+++ b/src/components/Components/ComponentDetails/__tests__/ComponentActivityTab.spec.tsx
@@ -72,7 +72,7 @@ describe('ComponentActivityTab', () => {
 
     await act(() => fireEvent.click(plrTab));
     expect(navigateMock).toHaveBeenCalledWith(
-      '/workspaces/test-ns/applications/my-test-output/components/test-component/activity/pipelineruns',
+      '/ns/test-ns/applications/my-test-output/components/test-component/activity/pipelineruns',
     );
   });
 });

--- a/src/components/Components/ComponentDetails/__tests__/ComponentDetails.spec.tsx
+++ b/src/components/Components/ComponentDetails/__tests__/ComponentDetails.spec.tsx
@@ -108,7 +108,7 @@ describe('ComponentDetailsView', () => {
 
     await act(() => fireEvent.click(activityTab));
     expect(navigateMock).toHaveBeenCalledWith(
-      '/workspaces/test-ns/applications/test-application/components/human-resources/activity',
+      '/ns/test-ns/applications/test-application/components/human-resources/activity',
     );
   });
 });

--- a/src/components/Components/ComponentsListView/__tests__/ComponentListView.spec.tsx
+++ b/src/components/Components/ComponentsListView/__tests__/ComponentListView.spec.tsx
@@ -104,7 +104,7 @@ describe('ComponentListViewPage', () => {
     const button = screen.getByText('Add component');
     expect(button).toBeInTheDocument();
     expect(button.closest('a').href).toBe(
-      'http://localhost/workspaces/test-ns/import?application=test-app',
+      'http://localhost/ns/test-ns/import?application=test-app',
     );
   });
 

--- a/src/components/GithubRedirect/GithubRedirect.tsx
+++ b/src/components/GithubRedirect/GithubRedirect.tsx
@@ -15,7 +15,7 @@ const GithubRedirect: React.FC = () => {
   const application =
     loaded && !error ? pr.metadata.labels[PipelineRunLabel.APPLICATION] : undefined;
 
-  const navigateUrl = `/workspaces/${ns}${
+  const navigateUrl = `/ns/${ns}${
     application && !error
       ? `/applications/${application}${pipelineRunName ? `/pipelineruns/${pipelineRunName}` : ''}${
           isLogsTabSelected ? `/logs` : ''

--- a/src/components/IntegrationTests/IntegrationTestsListView/__tests__/IntegrationTestsListView.spec.tsx
+++ b/src/components/IntegrationTests/IntegrationTestsListView/__tests__/IntegrationTestsListView.spec.tsx
@@ -92,7 +92,7 @@ describe('IntegrationTestsListView', () => {
 
     await waitFor(() =>
       expect(navigateMock).toHaveBeenCalledWith(
-        '/workspaces/test-ns/applications/test-app/integrationtests/add',
+        '/ns/test-ns/applications/test-app/integrationtests/add',
       ),
     );
   });
@@ -105,7 +105,7 @@ describe('IntegrationTestsListView', () => {
 
     await waitFor(() =>
       expect(navigateMock).toHaveBeenCalledWith(
-        '/workspaces/test-ns/applications/test-app/integrationtests/add',
+        '/ns/test-ns/applications/test-app/integrationtests/add',
       ),
     );
   });

--- a/src/components/LogViewer/__tests__/BuildLogViewer.spec.tsx
+++ b/src/components/LogViewer/__tests__/BuildLogViewer.spec.tsx
@@ -41,7 +41,7 @@ describe('BuildLogViewer', () => {
     routerRenderer(<BuildLogViewer component={componentCRMocks[0]} />);
     const plrLink = screen.getByText('basic-node-js-7c8nd');
     expect(plrLink.getAttribute('href')).toBe(
-      '/workspaces//applications/purple-mermaid-app/pipelineruns/basic-node-js-7c8nd',
+      '/ns//applications/purple-mermaid-app/pipelineruns/basic-node-js-7c8nd',
     );
   });
 

--- a/src/components/NamespaceList/__tests__/NamespaceListRow.spec.tsx
+++ b/src/components/NamespaceList/__tests__/NamespaceListRow.spec.tsx
@@ -76,7 +76,7 @@ describe('NamespaceButton', () => {
     routerRenderer(<NamespaceButton namespace="test-namespace" />);
 
     const button = screen.getByText('Go to the namespace');
-    expect(button.closest('a')).toHaveAttribute('href', '/workspaces/test-namespace/applications');
+    expect(button.closest('a')).toHaveAttribute('href', '/ns/test-namespace/applications');
     expect(button.closest('a')).toHaveAttribute('title', 'Go to this namespace');
   });
 

--- a/src/components/PipelineRun/PipelineRunDetailsView/__tests__/PipelineRunEmptyState.spec.tsx
+++ b/src/components/PipelineRun/PipelineRunDetailsView/__tests__/PipelineRunEmptyState.spec.tsx
@@ -18,7 +18,7 @@ describe('PipelineRunEmptyState', () => {
   it('should render correct Link to Application Name', () => {
     render(<PipelineRunEmptyState applicationName="test" />);
     expect(screen.getByRole('link').getAttribute('href')).toBe(
-      '/workspaces/test-ns/import?application=test',
+      '/ns/test-ns/import?application=test',
     );
     screen.getByText('Add component');
   });

--- a/src/components/PipelineRun/PipelineRunListView/__tests__/PipelineRunListView.spec.tsx
+++ b/src/components/PipelineRun/PipelineRunListView/__tests__/PipelineRunListView.spec.tsx
@@ -216,7 +216,7 @@ describe('Pipeline run List', () => {
     const button = screen.queryByText('Add component');
     expect(button).toBeInTheDocument();
     expect(button.closest('a').href).toContain(
-      `http://localhost/workspaces/test-ns/import?application=my-test-app`,
+      `http://localhost/ns/test-ns/import?application=my-test-app`,
     );
   });
 

--- a/src/components/ReleaseService/ReleasePlan/ReleasePlanForm/__tests__/ReleasePlanForm.spec.tsx
+++ b/src/components/ReleaseService/ReleasePlan/ReleasePlanForm/__tests__/ReleasePlanForm.spec.tsx
@@ -38,7 +38,7 @@ describe('ReleasePlanForm', () => {
     expect(result.getByRole('textbox', { name: 'Release plan name' })).toBeVisible();
     const breadcrumbLink = result.getByRole('link', { name: /release/i });
     fireEvent.click(breadcrumbLink);
-    expect(breadcrumbLink).toHaveAttribute('href', '/workspaces/test-ns/release');
+    expect(breadcrumbLink).toHaveAttribute('href', '/ns/test-ns/release');
   });
 
   it('should show edit form if edit flag is provided', () => {

--- a/src/components/ReleaseService/ReleasePlan/ReleasePlanForm/__tests__/ReleasePlanFormPage.spec.tsx
+++ b/src/components/ReleaseService/ReleasePlan/ReleasePlanForm/__tests__/ReleasePlanFormPage.spec.tsx
@@ -64,7 +64,7 @@ describe('ReleasePlanFormPage', () => {
       'test-ns',
     );
     expect(createReleasePlanMock).toHaveBeenCalledTimes(2);
-    expect(navigateMock).toHaveBeenCalledWith(`/workspaces/test-ns/release`);
+    expect(navigateMock).toHaveBeenCalledWith(`/ns/test-ns/release`);
   });
 
   it('should navigate on successful edit', async () => {
@@ -78,7 +78,7 @@ describe('ReleasePlanFormPage', () => {
 
     expect(editReleasePlanMock).toHaveBeenCalled();
     expect(editReleasePlanMock).toHaveBeenCalledTimes(2);
-    expect(navigateMock).toHaveBeenCalledWith(`/workspaces/test-ns/release`);
+    expect(navigateMock).toHaveBeenCalledWith(`/ns/test-ns/release`);
   });
 
   it('should navigate to release list on reset', async () => {
@@ -89,6 +89,6 @@ describe('ReleasePlanFormPage', () => {
 
     await act(() => fireEvent.click(screen.getByRole('button', { name: 'Reset' })));
 
-    expect(navigateMock).toHaveBeenCalledWith(`/workspaces/test-ns/release`);
+    expect(navigateMock).toHaveBeenCalledWith(`/ns/test-ns/release`);
   });
 });

--- a/src/components/ReleaseService/ReleasePlan/ReleasePlanForm/__tests__/form-utils.spec.ts
+++ b/src/components/ReleaseService/ReleasePlan/ReleasePlanForm/__tests__/form-utils.spec.ts
@@ -215,7 +215,7 @@ describe('getReleasePlanFormBreadcrumbs', () => {
 
     expect(breadcrumbs).toEqual([
       {
-        path: `/workspaces/${namespace}/release`,
+        path: `/ns/${namespace}/release`,
         name: 'Releases',
       },
       {
@@ -232,7 +232,7 @@ describe('getReleasePlanFormBreadcrumbs', () => {
 
     expect(breadcrumbs).toEqual([
       {
-        path: `/workspaces/${namespace}/release`,
+        path: `/ns/${namespace}/release`,
         name: 'Releases',
       },
       {

--- a/src/components/ReleaseService/ReleasePlan/TriggerRelease/__tests__/TriggerReleaseFormPage.spec.tsx
+++ b/src/components/ReleaseService/ReleasePlan/TriggerRelease/__tests__/TriggerReleaseFormPage.spec.tsx
@@ -65,9 +65,7 @@ describe('TriggerReleaseFormPage', () => {
       }),
       'test-ns',
     );
-    expect(navigateMock).toHaveBeenCalledWith(
-      '/workspaces/test-ns/applications/app1/releases/newRelease',
-    );
+    expect(navigateMock).toHaveBeenCalledWith('/ns/test-ns/applications/app1/releases/newRelease');
   });
 
   it('should navigate to release list on reset', async () => {
@@ -75,6 +73,6 @@ describe('TriggerReleaseFormPage', () => {
 
     await act(() => fireEvent.click(screen.getByRole('button', { name: 'Reset' })));
 
-    expect(navigateMock).toHaveBeenCalledWith('/workspaces/test-ns/release');
+    expect(navigateMock).toHaveBeenCalledWith('/ns/test-ns/release');
   });
 });

--- a/src/components/ReleaseService/ReleasePlan/__tests__/releaseplan-actions.spec.tsx
+++ b/src/components/ReleaseService/ReleasePlan/__tests__/releaseplan-actions.spec.tsx
@@ -46,7 +46,7 @@ describe('useReleasePlanActions', () => {
       expect.objectContaining({
         label: 'Trigger release plan',
         cta: {
-          href: `/workspaces/test-ns/release/release-plan/trigger/test-release-plan`,
+          href: `/ns/test-ns/release/release-plan/trigger/test-release-plan`,
         },
       }),
     );
@@ -65,7 +65,7 @@ describe('useReleasePlanActions', () => {
       expect.objectContaining({
         label: 'Edit release plan',
         cta: {
-          href: `/workspaces/test-ns/release/release-plan/edit/test-release-plan`,
+          href: `/ns/test-ns/release/release-plan/edit/test-release-plan`,
         },
       }),
     );

--- a/src/components/Releases/__tests__/ReleaseOverviewTab.spec.tsx
+++ b/src/components/Releases/__tests__/ReleaseOverviewTab.spec.tsx
@@ -50,7 +50,7 @@ describe('ReleaseOverviewTab', () => {
 
     expect(screen.getByText('Pipeline Run')).toBeVisible();
     expect(screen.getByRole('link', { name: 'test-pipelinerun' }).getAttribute('href')).toBe(
-      `/workspaces/my-ns/applications/test-app/pipelineruns/test-pipelinerun`,
+      `/ns/my-ns/applications/test-app/pipelineruns/test-pipelinerun`,
     );
   });
 
@@ -58,7 +58,7 @@ describe('ReleaseOverviewTab', () => {
     render(<ReleaseOverviewTab />);
     expect(screen.getByText('Pipeline Run')).toBeVisible();
     expect(screen.getByRole('link', { name: 'test-pipelinerun' }).getAttribute('href')).toBe(
-      `/workspaces/my-ns/applications/test-app/pipelineruns/test-pipelinerun`,
+      `/ns/my-ns/applications/test-app/pipelineruns/test-pipelinerun`,
     );
   });
 });

--- a/src/components/Releases/__tests__/ReleasesListRow.spec.tsx
+++ b/src/components/Releases/__tests__/ReleasesListRow.spec.tsx
@@ -46,7 +46,7 @@ describe('ReleasesListRow', () => {
     expect(cells[0].children[0].innerHTML).toBe(mockRelease.metadata.name);
     expect(cells[3].innerHTML).toBe('test-plan');
     expect(cells[4].innerHTML).toBe(
-      '<a href="/workspaces//applications/test-app/snapshots/test-snapshot">test-snapshot</a>',
+      '<a href="/ns//applications/test-app/snapshots/test-snapshot">test-snapshot</a>',
     );
     expect(status[0].innerHTML).toBe('Succeeded');
   });

--- a/src/components/SnapshotDetails/tabs/__tests__/SnapshotComponentsEmptyState.spec.tsx
+++ b/src/components/SnapshotDetails/tabs/__tests__/SnapshotComponentsEmptyState.spec.tsx
@@ -16,7 +16,7 @@ describe('SnapshotComponentsEmptyState', () => {
   it('should render correct Link to Application Name', () => {
     render(<SnapshotComponentsEmptyState applicationName="test" />);
     expect(screen.getByRole('link').getAttribute('href')).toBe(
-      '/workspaces/test-ns/import?application=test',
+      '/ns/test-ns/import?application=test',
     );
     screen.getByText('Add component');
   });

--- a/src/components/SnapshotDetails/tabs/__tests__/SnapshotComponentsListRow.spec.tsx
+++ b/src/components/SnapshotDetails/tabs/__tests__/SnapshotComponentsListRow.spec.tsx
@@ -62,7 +62,7 @@ describe('SnapshotComponentsListRow', () => {
     const revisionLink = screen.getByText('test-revision');
     expect(revisionLink).toHaveAttribute(
       'href',
-      `/workspaces//applications/${rowData?.application}/commit/test-revision`,
+      `/ns//applications/${rowData?.application}/commit/test-revision`,
     );
   });
   it('should show hyphen when revision is not available ', () => {

--- a/src/components/SnapshotDetails/tabs/__tests__/SnapshotPipelineRunsList.spec.tsx
+++ b/src/components/SnapshotDetails/tabs/__tests__/SnapshotPipelineRunsList.spec.tsx
@@ -192,7 +192,7 @@ describe('SnapshotPipelinerunsTab', () => {
     const button = screen.queryByText('Add component');
     expect(button).toBeInTheDocument();
     expect(button.closest('a').href).toContain(
-      `http://localhost/workspaces/test-ns/import?application=my-test-app`,
+      `http://localhost/ns/test-ns/import?application=my-test-app`,
     );
   });
 

--- a/src/components/SnapshotDetails/tabs/__tests__/SnapshotPipelineRunsTab.spec.tsx
+++ b/src/components/SnapshotDetails/tabs/__tests__/SnapshotPipelineRunsTab.spec.tsx
@@ -170,7 +170,7 @@ describe('SnapshotPipelinerunsTab', () => {
     const button = screen.queryByText('Add component');
     expect(button).toBeInTheDocument();
     expect(button.closest('a').href).toContain(
-      `http://localhost/workspaces/test-ns/import?application=my-test-app`,
+      `http://localhost/ns/test-ns/import?application=my-test-app`,
     );
   });
 

--- a/src/components/UserAccess/__tests__/user-access-actions.spec.ts
+++ b/src/components/UserAccess/__tests__/user-access-actions.spec.ts
@@ -26,7 +26,7 @@ describe('useRBActions', () => {
     disabled: false,
     disabledTooltip: "You don't have permission to edit access",
     cta: {
-      href: `/workspaces/${mockNamespace}/access/edit/user1`,
+      href: `/ns/${mockNamespace}/access/edit/user1`,
     },
   };
   const deletePermissionItem = {
@@ -72,7 +72,7 @@ describe('useRBActions', () => {
         id: 'edit-access-undefined',
         cta: {
           ...editPermissionItem.cta,
-          href: `/workspaces/${mockNamespace}/access/edit/undefined`,
+          href: `/ns/${mockNamespace}/access/edit/undefined`,
         },
       },
       {

--- a/src/hooks/useActiveRouteChecker.ts
+++ b/src/hooks/useActiveRouteChecker.ts
@@ -6,7 +6,7 @@ export function useActiveRouteChecker() {
 
   /**
    * Checks if the given route pattern matches the current location.
-   * @param pattern The route pattern to test, e.g. '/workspaces' or '/workspaces/:namespace/applications/*'
+   * @param pattern The route pattern to test, e.g. '/ns' or '/ns/:namespace/applications/*'
    * @param options Options for matching. If exact is true, only an exact match is considered active.
    * @returns True if the pattern is active, false otherwise.
    */

--- a/src/k8s/k8s-utils.ts
+++ b/src/k8s/k8s-utils.ts
@@ -42,14 +42,8 @@ const getQueryString = (queryParams: QueryParams) =>
     .map(([key, value = '']) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
     .join('&');
 
-const getK8sAPIPath = (
-  { apiGroup = 'core', apiVersion }: K8sModelCommon,
-  activeWorkspace?: string,
-) => {
+const getK8sAPIPath = ({ apiGroup = 'core', apiVersion }: K8sModelCommon) => {
   let path = '';
-  if (activeWorkspace) {
-    path += `/workspaces/${activeWorkspace}`;
-  }
   const isLegacy = apiGroup === 'core' && apiVersion === 'v1';
   path += isLegacy ? `/api/${apiVersion}` : `/apis/${apiGroup}/${apiVersion}`;
   return path;
@@ -207,7 +201,6 @@ export const k8sWatch = (
     resourceVersion?: string;
     ns?: string;
     fieldSelector?: string;
-    ws?: string;
   } = {},
   options: Partial<
     WebSocketOptions & RequestInit & { wsPrefix?: string; pathPrefix?: string }
@@ -217,7 +210,6 @@ export const k8sWatch = (
   const opts: {
     queryParams: QueryParams<Selector>;
     ns?: string;
-    ws?: string;
   } = { queryParams };
   const wsOptionsUpdated: WebSocketOptions = {
     path: '',
@@ -240,10 +232,6 @@ export const k8sWatch = (
 
   if (query.ns) {
     opts.ns = query.ns;
-  }
-
-  if (query.ws || query.ns) {
-    opts.ws = query.ws ?? query.ns;
   }
 
   if (query.resourceVersion) {

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -1,9 +1,9 @@
 import { buildRoute, type RouteDefinition, RouterParams } from './utils';
 
-type NamespacePath = 'workspaces';
+type NamespacePath = 'ns';
 
 /* Namespace/Workspace Paths */
-export const NAMESPACE_LIST_PATH: RouteDefinition<NamespacePath> = buildRoute('workspaces');
+export const NAMESPACE_LIST_PATH: RouteDefinition<NamespacePath> = buildRoute('ns');
 
 export const WORKSPACE_PATH = NAMESPACE_LIST_PATH.extend(`:${RouterParams.workspaceName}`);
 

--- a/src/routes/utils.ts
+++ b/src/routes/utils.ts
@@ -7,6 +7,7 @@ export const RouterParams = {
    * use [useNamespace](../shared/providers/Namespace)
    */
   workspaceName: 'workspaceName',
+  ns: 'ns',
   applicationName: 'applicationName',
   integrationTestName: 'integrationTestName',
   releaseName: 'releaseName',

--- a/src/shared/providers/Namespace/NamespaceSwitcher.tsx
+++ b/src/shared/providers/Namespace/NamespaceSwitcher.tsx
@@ -23,9 +23,7 @@ export const NamespaceSwitcher: React.FC<
 
   const onSelect = (item: ContextMenuItem) => {
     // switch to new workspace but keep the first segment of the URL
-    navigate(
-      pathname.replace(/\/workspaces\/[-a-z0-9]+\/?([-a-z0-9]*).*/, `/workspaces/${item.name}/$1`),
-    );
+    navigate(pathname.replace(/\/ns\/[-a-z0-9]+\/?([-a-z0-9]*).*/, `/ns/${item.name}/$1`));
   };
 
   return namespaces?.length > 0 ? (

--- a/src/shared/providers/Namespace/__tests__/namespace-context.spec.tsx
+++ b/src/shared/providers/Namespace/__tests__/namespace-context.spec.tsx
@@ -110,7 +110,7 @@ describe('NamespaceProvider', () => {
     await waitFor(() => {
       fireEvent.click(screen.getByRole('button', { name: /Go to test-ns namespace/i }));
       expect(mockSetLastUsedNamespace).toHaveBeenCalledWith('test-ns');
-      expect(mockNavigate).toHaveBeenCalledWith('/workspaces/test-ns/applications');
+      expect(mockNavigate).toHaveBeenCalledWith('/ns/test-ns/applications');
     });
   });
 });

--- a/src/shared/providers/Namespace/index.ts
+++ b/src/shared/providers/Namespace/index.ts
@@ -2,8 +2,8 @@ import { LoaderFunction } from 'react-router-dom';
 import { queryNamespaces } from './utils';
 
 export const namespaceLoader: LoaderFunction = async () => {
-  const workspaces = await queryNamespaces();
-  return { data: workspaces };
+  const namespaces = await queryNamespaces();
+  return { data: namespaces };
 };
 
 export { NamespaceProvider } from './namespace-context';

--- a/src/types/k8s.ts
+++ b/src/types/k8s.ts
@@ -156,7 +156,6 @@ export type K8sResourceKindReference = GroupVersionKind;
 export type WatchK8sResource = {
   groupVersionKind: K8sGroupVersionKind;
   name?: string;
-  workspace?: string;
   namespace: string;
   isList?: boolean;
   selector?: Selector;

--- a/src/utils/__tests__/tekton-results.spec.ts
+++ b/src/utils/__tests__/tekton-results.spec.ts
@@ -419,12 +419,12 @@ describe('tekton-results', () => {
       expect(
         createTektonResultsUrl('test-ns', [DataType.PipelineRun, DataType.PipelineRun_v1beta1]),
       ).toEqual(
-        '/plugins/tekton-results/workspaces/test-ns/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=30&filter=data_type+in+%5B%22tekton.dev%2Fv1.PipelineRun%22%2C%22tekton.dev%2Fv1beta1.PipelineRun%22%5D',
+        '/plugins/tekton-results/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=30&filter=data_type+in+%5B%22tekton.dev%2Fv1.PipelineRun%22%2C%22tekton.dev%2Fv1beta1.PipelineRun%22%5D',
       );
       expect(
         createTektonResultsUrl('test-ns', [DataType.TaskRun, DataType.TaskRun_v1beta1]),
       ).toEqual(
-        '/plugins/tekton-results/workspaces/test-ns/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=30&filter=data_type+in+%5B%22tekton.dev%2Fv1.TaskRun%22%2C%22tekton.dev%2Fv1beta1.TaskRun%22%5D',
+        '/plugins/tekton-results/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=30&filter=data_type+in+%5B%22tekton.dev%2Fv1.TaskRun%22%2C%22tekton.dev%2Fv1beta1.TaskRun%22%5D',
       );
     });
 
@@ -448,7 +448,7 @@ describe('tekton-results', () => {
           'foo=bar',
         ),
       ).toEqual(
-        '/plugins/tekton-results/workspaces/test-ns/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=30&filter=data_type+in+%5B%22tekton.dev%2Fv1.PipelineRun%22%2C%22tekton.dev%2Fv1beta1.PipelineRun%22%5D+%26%26+foo%3Dbar',
+        '/plugins/tekton-results/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=30&filter=data_type+in+%5B%22tekton.dev%2Fv1.PipelineRun%22%2C%22tekton.dev%2Fv1beta1.PipelineRun%22%5D+%26%26+foo%3Dbar',
       );
     });
 
@@ -505,7 +505,7 @@ describe('tekton-results', () => {
           sampleOptions,
         ),
       ).toContain(
-        '/plugins/tekton-results/workspaces/test-ns/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=30&filter=data_type+in+%5B%22tekton.dev%2Fv1.PipelineRun%22%2C%22tekton.dev%2Fv1beta1.PipelineRun%22%5D+%26%26+foo%3Dbar+%26%26+data.metadata.labels%5B%22test%22%5D+%3D%3D+%22a%22+%26%26+data.metadata.labels%5B%22mtest%22%5D+%3D%3D+%22ma%22+%26%26+count+%3E+1',
+        '/plugins/tekton-results/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=30&filter=data_type+in+%5B%22tekton.dev%2Fv1.PipelineRun%22%2C%22tekton.dev%2Fv1beta1.PipelineRun%22%5D+%26%26+foo%3Dbar+%26%26+data.metadata.labels%5B%22test%22%5D+%3D%3D+%22a%22+%26%26+data.metadata.labels%5B%22mtest%22%5D+%3D%3D+%22ma%22+%26%26+count+%3E+1',
       );
     });
   });
@@ -598,7 +598,7 @@ describe('tekton-results', () => {
     it('should query tekton results with options', async () => {
       await getPipelineRuns('test-ns', sampleOptions, 'test-token');
       expect(commonFetchJSONMock).toHaveBeenCalledWith(
-        '/plugins/tekton-results/workspaces/test-ns/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=30&page_token=test-token&filter=data_type+in+%5B%22tekton.dev%2Fv1.PipelineRun%22%2C%22tekton.dev%2Fv1beta1.PipelineRun%22%5D+%26%26+data.metadata.labels%5B%22test%22%5D+%3D%3D+%22a%22+%26%26+data.metadata.labels%5B%22mtest%22%5D+%3D%3D+%22ma%22+%26%26+count+%3E+1',
+        '/plugins/tekton-results/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=30&page_token=test-token&filter=data_type+in+%5B%22tekton.dev%2Fv1.PipelineRun%22%2C%22tekton.dev%2Fv1beta1.PipelineRun%22%5D+%26%26+data.metadata.labels%5B%22test%22%5D+%3D%3D+%22a%22+%26%26+data.metadata.labels%5B%22mtest%22%5D+%3D%3D+%22ma%22+%26%26+count+%3E+1',
       );
     });
   });
@@ -612,7 +612,7 @@ describe('tekton-results', () => {
     it('should query tekton results with options', async () => {
       await getTaskRuns('test-ns', sampleOptions, 'test-token');
       expect(commonFetchJSONMock).toHaveBeenCalledWith(
-        '/plugins/tekton-results/workspaces/test-ns/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=30&page_token=test-token&filter=data_type+in+%5B%22tekton.dev%2Fv1.TaskRun%22%2C%22tekton.dev%2Fv1beta1.TaskRun%22%5D+%26%26+data.metadata.labels%5B%22test%22%5D+%3D%3D+%22a%22+%26%26+data.metadata.labels%5B%22mtest%22%5D+%3D%3D+%22ma%22+%26%26+count+%3E+1',
+        '/plugins/tekton-results/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/-/records?order_by=create_time+desc&page_size=30&page_token=test-token&filter=data_type+in+%5B%22tekton.dev%2Fv1.TaskRun%22%2C%22tekton.dev%2Fv1beta1.TaskRun%22%5D+%26%26+data.metadata.labels%5B%22test%22%5D+%3D%3D+%22a%22+%26%26+data.metadata.labels%5B%22mtest%22%5D+%3D%3D+%22ma%22+%26%26+count+%3E+1',
       );
     });
   });
@@ -624,7 +624,7 @@ describe('tekton-results', () => {
       expect(await getTaskRunLog('test-ns', 'test-id', 'pipelinerun-uid')).toEqual('sample log');
       expect(commonFetchTextMock.mock.calls).toEqual([
         [
-          '/plugins/tekton-results/workspaces/test-ns/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/pipelinerun-uid/logs/test-id',
+          '/plugins/tekton-results/apis/results.tekton.dev/v1alpha2/parents/test-ns/results/pipelinerun-uid/logs/test-id',
         ],
       ]);
     });

--- a/src/utils/tekton-results.ts
+++ b/src/utils/tekton-results.ts
@@ -14,8 +14,7 @@ import {
 // REST API spec
 // https://github.com/tektoncd/results/blob/main/docs/api/rest-api-spec.md
 
-const _WORKSPACE_ = '<_workspace_>';
-const URL_PREFIX = `/plugins/tekton-results/workspaces/${_WORKSPACE_}/apis/results.tekton.dev/v1alpha2/parents`;
+const URL_PREFIX = `/plugins/tekton-results/apis/results.tekton.dev/v1alpha2/parents`;
 
 const MINIMUM_PAGE_SIZE = 5;
 const MAXIMUM_PAGE_SIZE = 10000;
@@ -207,8 +206,6 @@ export const clearCache = () => {
 };
 const InFlightStore: { [key: string]: boolean } = {};
 
-const getTRUrlPrefix = (namespace: string): string => URL_PREFIX.replace(_WORKSPACE_, namespace);
-
 export const createTektonResultsUrl = (
   namespace: string,
   dataTypes: DataType[],
@@ -216,7 +213,7 @@ export const createTektonResultsUrl = (
   options?: TektonResultsOptions,
   nextPageToken?: string,
 ): string =>
-  `${getTRUrlPrefix(namespace)}/${namespace}/results/-/records?${new URLSearchParams({
+  `${URL_PREFIX}/${namespace}/results/-/records?${new URLSearchParams({
     // default sort should always be by `create_time desc`
     ['order_by']: 'create_time desc',
     ['page_size']: `${Math.max(
@@ -366,9 +363,9 @@ export const getTaskRuns = (
 //   commonFetchText(`${getTRUrlPrefix(workspace)}/${taskRunPath.replace('/records/', '/logs/')}`);
 
 export const getTaskRunLog = (namespace: string, taskRunID: string, pid: string): Promise<string> =>
-  commonFetchText(
-    `${getTRUrlPrefix(namespace)}/${namespace}/results/${pid}/logs/${taskRunID}`,
-  ).catch(() => throw404());
+  commonFetchText(`${URL_PREFIX}/${namespace}/results/${pid}/logs/${taskRunID}`).catch(() =>
+    throw404(),
+  );
 
 export const createTektonResultsQueryKeys = (
   model: K8sModelCommon,


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/KFLUXUI-378

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Replaced `workspaces` with `ns` in UI routes.

Old routes:
`https://<domain>.com/workspaces/<workspace-name>/....`

New routes:
`https://<domain>.com/ns/<namespace-name>/....`

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
No visual changes

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->
Test different UI routes to make sure navigation and page reloads are working as expected.

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->