### PR TITLE
feat(KFLUXUI-377): enter, tab and losing focus would input username

### DIFF
--- a/src/components/UserAccess/UserAccessForm/UserAccessForm.tsx
+++ b/src/components/UserAccess/UserAccessForm/UserAccessForm.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Form, PageSection, PageSectionVariants } from '@patternfly/react-core';
-import { FormikProps } from 'formik';
+import { FormikProps, useFormikContext } from 'formik';
 import isEmpty from 'lodash/isEmpty';
 import PageLayout from '../../../components/PageLayout/PageLayout';
 import { FormFooter } from '../../../shared';
@@ -17,12 +17,21 @@ export const UserAccessForm: React.FC<React.PropsWithChildren<Props>> = ({
   edit,
   isSubmitting,
   dirty,
-  errors,
+  errors, // The errors is caculated by formik automatically.
   status,
   handleSubmit,
   handleReset,
 }) => {
   const namespace = useNamespace();
+  const { values } = useFormikContext<{ usernames: string[] }>();
+  // After we add 'enter' to input usernames, when users select roles and then input username with enter,
+  // errors about empty usernames would be returned. This makes submit button disabled.
+  // We prevent the enter default behaviour in UsernameSection but not for the form here.
+  // Entering username would also bring default submit behavior.
+  // Add the customErrors here to avoid unexpected disabled button. While when the submit buttion is
+  // active, it is saying there is no hidden submit.
+  const customErrors =
+    errors?.usernames === '' && values?.usernames.length > 0 ? undefined : errors;
 
   return (
     <PageLayout
@@ -38,9 +47,10 @@ export const UserAccessForm: React.FC<React.PropsWithChildren<Props>> = ({
         <FormFooter
           submitLabel={edit ? 'Save changes' : 'Grant access'}
           handleCancel={handleReset}
+          // Customizing the handleSubmit is useless to hanle the submit button status
           handleSubmit={handleSubmit}
           isSubmitting={isSubmitting}
-          disableSubmit={!dirty || !isEmpty(errors) || isSubmitting}
+          disableSubmit={!dirty || !isEmpty(customErrors) || isSubmitting}
           errorMessage={status?.submitError}
         />
       }

--- a/src/components/UserAccess/UserAccessForm/UsernameSection.tsx
+++ b/src/components/UserAccess/UserAccessForm/UsernameSection.tsx
@@ -51,18 +51,27 @@ export const UsernameSection: React.FC<React.PropsWithChildren<Props>> = ({ disa
     }, [setError, username]),
   );
 
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    // Only trigger on Enter key press
-    if (event.key === 'Enter' && username.trim() !== '' && !usernames.includes(username)) {
-      void debouncedValidate(); // Trigger validation before adding to the list
+  const handleAddUsername = () => {
+    if (username.trim() !== '' && !usernames.includes(username)) {
+      void debouncedValidate();
       if (!error) {
-        // Only add the username if there is no validation error
-        if (!usernames.includes(username)) {
-          void setValue([...usernames, username]);
-        }
-        setUsername(''); // Clear input after adding the username
+        void setValue([...usernames, username]);
+        setUsername(''); // only clean username when there is no error.
       }
     }
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    // for enter and tab
+    if ((event.key === 'Enter' || event.key === 'Tab') && username.trim() !== '') {
+      event.preventDefault();
+      handleAddUsername();
+    }
+  };
+
+  // for lose focus
+  const handleBlur = () => {
+    handleAddUsername();
   };
 
   return (
@@ -95,6 +104,7 @@ export const UsernameSection: React.FC<React.PropsWithChildren<Props>> = ({ disa
               void debouncedValidate(); // Trigger validation on input change
             }}
             onKeyDown={handleKeyDown}
+            onBlur={handleBlur}
           >
             <ChipGroup>
               {usernames?.map((name) => (


### PR DESCRIPTION
## Fixes 
[KFLUXUI-377](https://issues.redhat.com/browse/KFLUXUI-377)

## Description
Previously, when users grant user access, they input the username and the username would become inputted username chip automatically. During the SpaceBindingRequest migration, we did one improvement to ensure users need to enter 'username'.  It changes the old behavior then users would feel bad for entering.

With the current patch, users do not have to enter usernames,  losing focus and tabbing out also work. 

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
We tried to select roles and then input usernames and vise verse. 
and more, entering, tabbing and losing focus all works well.

https://github.com/user-attachments/assets/5fe2e062-2215-49d5-8778-8431ab7c5e23

## How to test or reproduce?
Grant users with different ways('losing focus', 'tabbing out', 'entering') of inputting username

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [x] Code follows the style guidelines
- [x] Self-reviewed the code
- [x] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [x] Changes generate no new warnings
- [x] Added tests that prove this fix is effective or that the feature works
- [x] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->