### PR TITLE
fix(KFLUXUI-226): check if the pipeline status change automatically on ComponentDetailsTab component

### DIFF
--- a/e2e-tests/tests/basic-happy-path.spec.ts
+++ b/e2e-tests/tests/basic-happy-path.spec.ts
@@ -110,11 +110,7 @@ describe('Basic Happy Path', () => {
       // Pipeline build plan was removed from the Pipeline runs Tab
       // See https://issues.redhat.com/browse/KFLUXBUGS-603
       ComponentsTabPage.openComponent(componentName);
-      // Use clickSendingPullRequest() until the bug is fixed
-      // https://issues.redhat.com/browse/KFLUXUI-226
-      componentPage.clickSendingPullRequest();
-      // componentPage.clickMergePullRequest();
-      componentPage.verifyAndWaitForPRIsSent();
+      componentPage.clickMergePullRequest();
 
       APIHelper.mergePR(
         repoOwner,

--- a/src/components/Components/ComponentDetails/tabs/ComponentDetailsTab.tsx
+++ b/src/components/Components/ComponentDetails/tabs/ComponentDetailsTab.tsx
@@ -18,7 +18,7 @@ const ComponentDetailsTab: React.FC = () => {
   const { componentName } = useParams<RouterParams>();
   const track = useTrackEvent();
   const showModal = useModalLauncher();
-  const [component] = useComponent(namespace, componentName);
+  const [component] = useComponent(namespace, componentName, true);
   const customizePipeline = () => {
     track(TrackEvents.ButtonClicked, {
       link_name: 'manage-build-pipeline',


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
[KFLUXUI-226](https://issues.redhat.com/browse/KFLUXUI-226)

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Watch for changes in `component` resource making the label update automatically in `ComponentDetailTab`. Adjust the the E2E test to look for the `Merge pull request` `ComponentDetailTab` and then click on it.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
1. Run the E2E test
2. In the 'Explore Pipeline runs Tab' suite, check the 'Merge the auto-generated PR, and verify the event status on modal' test if it pass and check for a component named `Custom` after closing the pipeline modal (modal we send the pr to github and merge the first pipeline)

Support test:
1. Create a new component
2. Open `ComponentDetailTab` page
3. Wait for some seconds. you should see the label change from `Send pull request` to `Merge pull request`.


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->