### PR TITLE
chore: replace coverity check

### DIFF
--- a/.tekton/konflux-ui-pull-request.yaml
+++ b/.tekton/konflux-ui-pull-request.yaml
@@ -312,6 +312,23 @@ spec:
           values:
             - "false"
       workspaces: []
+    - name: coverity-availability-check
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: coverity-availability-check
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:0b35292eed661c5e3ca307c0ba7f594d17555db2a1da567903b0b47697fa23ed
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
     - name: deprecated-base-image-check
       params:
       - name: IMAGE_URL
@@ -471,32 +488,6 @@ spec:
         operator: in
         values:
         - success
-    - name: coverity-availability-check
-      params:
-      - name: image-digest
-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      - name: CACHI2_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: coverity-availability-check-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check-oci-ta:0.2@sha256:e4d3de79e1b7224dabaca34363fe74c8a090d974be509ce0cd5de4456d017db5
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
     - name: sast-shell-check
       params:
       - name: image-digest

--- a/.tekton/konflux-ui-push.yaml
+++ b/.tekton/konflux-ui-push.yaml
@@ -309,6 +309,23 @@ spec:
           values:
             - "false"
       workspaces: []
+    - name: coverity-availability-check
+      runAfter:
+        - build-image-index
+      taskRef:
+        params:
+          - name: name
+            value: coverity-availability-check
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:0b35292eed661c5e3ca307c0ba7f594d17555db2a1da567903b0b47697fa23ed
+          - name: kind
+            value: task
+        resolver: bundles
+      when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+            - "false"
     - name: deprecated-base-image-check
       params:
       - name: IMAGE_URL
@@ -468,32 +485,6 @@ spec:
         operator: in
         values:
         - success
-    - name: coverity-availability-check
-      params:
-      - name: image-digest
-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      - name: CACHI2_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: coverity-availability-check-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check-oci-ta:0.2@sha256:e4d3de79e1b7224dabaca34363fe74c8a090d974be509ce0cd5de4456d017db5
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
     - name: sast-shell-check
       params:
       - name: image-digest


### PR DESCRIPTION
Task "coverity-availability-check-oci-ta" is used by pipeline task "coverity-availability-check" is or will be the
coverity-availability-check-oci-ta task is deprecated. Please use coverity-availability-check instead.
