### PR TITLE
fix: use `konflux-<role>-<username>-user-actions` naming convertion for role binding names

### DIFF
--- a/src/components/UserAccess/UserAccessForm/EditAccessPage.tsx
+++ b/src/components/UserAccess/UserAccessForm/EditAccessPage.tsx
@@ -11,13 +11,12 @@ import ErrorEmptyState from '../../../shared/components/empty-state/ErrorEmptySt
 import { useNamespace } from '../../../shared/providers/Namespace';
 import { AccessReviewResources } from '../../../types';
 import PageAccessCheck from '../../PageAccess/PageAccessCheck';
-import { sanitizeUsername } from './form-utils';
 import { UserAccessFormPage } from './UserAccessFormPage';
 
 const EditAccessPage: React.FC<React.PropsWithChildren<unknown>> = () => {
   const { bindingName } = useParams<RouterParams>();
   const namespace = useNamespace();
-  const [binding, loaded, error] = useRoleBinding(namespace, sanitizeUsername(bindingName));
+  const [binding, loaded, error] = useRoleBinding(namespace, bindingName);
 
   useDocumentTitle(`Edit access to namespace, ${namespace} | ${FULL_APPLICATION_TITLE}`);
 

--- a/src/components/UserAccess/UserAccessForm/form-utils.ts
+++ b/src/components/UserAccess/UserAccessForm/form-utils.ts
@@ -56,7 +56,7 @@ export const createRBs = async (
     metadata: {
       // To sanitize the username and ensure every user just has one role
       // in the namespace.
-      name: `${sanitizeUsername(username)}`,
+      name: `konflux-${role.toLowerCase()}-${sanitizeUsername(username)}-user-actions`,
       namespace,
     },
     roleRef: {
@@ -97,14 +97,7 @@ export const deleteRB = async (roleBinding: RoleBinding, dryRun?: boolean): Prom
     },
   };
 
-  // K8sQueryDeleteResource enjoys the k8sDeleteResource to delete resources.
-  // However, based on the design of k8sDeleteResource, 'dryRun' just affect the
-  // query parameter but would not affect commonFetchJSON.delete.
-  // That is to say, with 'true' dryRun, the resource would be also deleted.
-  // If so, we have to skip the redeletion when dryRun is false.
-  // To do: let us improve the function when the K8sQueryDeleteResource
-  // works well with dryRun.
-  dryRun ? await K8sQueryDeleteResource(queryOptions) : void 0;
+  await K8sQueryDeleteResource(queryOptions);
 };
 
 /**
@@ -124,14 +117,7 @@ export const editRB = async (
   const usernames = roleBinding.subjects.map((subject) => subject.name);
   const { role, roleMap } = values;
 
-  // We need to delete the role binding before we create the new one.
-  const existingRBs = await getRBs(roleBinding.metadata.namespace);
-
-  const roleBindingExists = existingRBs.some(
-    (binding) => binding.metadata.name === roleBinding.metadata.name,
-  );
-
-  if (roleBindingExists) {
+  if (!dryRun) {
     await deleteRB(roleBinding, dryRun);
   }
 

--- a/src/components/UserAccess/__tests__/user-access-actions.spec.ts
+++ b/src/components/UserAccess/__tests__/user-access-actions.spec.ts
@@ -22,16 +22,16 @@ describe('useRBActions', () => {
 
   const editPermissionItem = {
     label: 'Edit access',
-    id: 'edit-access-user1',
+    id: 'edit-access-metadata-name',
     disabled: false,
     disabledTooltip: "You don't have permission to edit access",
     cta: {
-      href: `/ns/${mockNamespace}/access/edit/user1`,
+      href: `/ns/${mockNamespace}/access/edit/metadata-name`,
     },
   };
   const deletePermissionItem = {
     label: 'Revoke access',
-    id: 'revoke-access-user1',
+    id: 'revoke-access-metadata-name',
     disabled: false,
     disabledTooltip: "You don't have permission to revoke access",
     cta: expect.any(Function),
@@ -69,16 +69,16 @@ describe('useRBActions', () => {
       {
         ...editPermissionItem,
         disabled: true,
-        id: 'edit-access-undefined',
+        id: 'edit-access-metadata-name',
         cta: {
           ...editPermissionItem.cta,
-          href: `/ns/${mockNamespace}/access/edit/undefined`,
+          href: `/ns/${mockNamespace}/access/edit/metadata-name`,
         },
       },
       {
         ...deletePermissionItem,
         disabled: true,
-        id: 'revoke-access-undefined',
+        id: 'revoke-access-metadata-name',
       },
     ];
     expect(actions).toEqual(permissionItems);

--- a/src/components/UserAccess/user-access-actions.ts
+++ b/src/components/UserAccess/user-access-actions.ts
@@ -29,19 +29,19 @@ export const useRBActions = (binding: RoleBinding): Action[] => {
   return [
     {
       label: 'Edit access',
-      id: `edit-access-${userSubject?.name}`,
+      id: `edit-access-${binding.metadata?.name}`,
       disabled: !canUpdate,
       disabledTooltip: "You don't have permission to edit access",
       cta: {
         href: USER_ACCESS_EDIT_PAGE.createPath({
           workspaceName: namespace,
-          bindingName: userSubject?.name,
+          bindingName: binding.metadata.name,
         }),
       },
     },
     {
       cta: () => showModal(revokeAccessModalLauncher(userSubject?.name, binding)),
-      id: `revoke-access-${userSubject?.name}`,
+      id: `revoke-access-${binding.metadata?.name}`,
       label: 'Revoke access',
       disabled: !canDelete,
       disabledTooltip: "You don't have permission to revoke access",

--- a/src/k8s/query/fetch.ts
+++ b/src/k8s/query/fetch.ts
@@ -70,12 +70,20 @@ export const K8sQueryDeleteResource = <TResource extends K8sResourceCommon>(
   requestInit: K8sResourceDeleteOptions,
 ) => {
   return k8sDeleteResource<TResource>(requestInit).finally(() => {
-    !requestInit.queryOptions?.queryParams?.dryRun &&
+    if (!requestInit.queryOptions?.queryParams?.dryRun) {
+      void queryClient.removeQueries({
+        queryKey: createQueryKeys({
+          model: requestInit.model,
+          queryOptions: { ns: requestInit.queryOptions.ns, name: requestInit.queryOptions.name },
+        }),
+        exact: true,
+      });
       void queryClient.invalidateQueries({
         queryKey: createQueryKeys({
           model: requestInit.model,
           queryOptions: { ns: requestInit.queryOptions.ns },
         }),
       });
+    }
   });
 };


### PR DESCRIPTION


## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR uses the naming convention for role binding names

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
no visual changes

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

Test User access:
  - creation flow
  - edit flow
  - list view
  - revoke flow


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->