### PR TITLE
test: add podman timeout for 1 hour

### DIFF
--- a/e2e-tests/BaseContainerfile
+++ b/e2e-tests/BaseContainerfile
@@ -1,6 +1,6 @@
-ARG DEFAULT_CHROME_VERSION='131.0.6778.139-1'
+ARG CHROME_VERSION='135.0.7049.52-1'
 
-FROM cypress/factory:5.1.1
+FROM cypress/factory:5.8.0
 
 RUN apt update && \
     apt install curl jq python3 python3-venv python3-pip xauth skopeo -y

--- a/e2e-tests/Containerfile
+++ b/e2e-tests/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/konflux_ui_qe/konflux-ui-tests-base:latest
+FROM quay.io/konflux_ui_qe/konflux-ui-tests-base:5.8.0
 
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
     install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl

--- a/e2e-tests/tests/basic-happy-path.spec.ts
+++ b/e2e-tests/tests/basic-happy-path.spec.ts
@@ -25,7 +25,7 @@ describe('Basic Happy Path', () => {
   const publicRepo = `https://github.com/${repoOwner}/${repoName}`;
   const componentName: string = Common.generateAppName('java-quarkus');
   const piplinerunlogsTasks = ['init', 'clone-repository', 'build-container', 'show-sbom'];
-  const pipeline = 'docker-build';
+  const pipeline = 'docker-build-oci-ta';
 
   before(function () {
     APIHelper.createRepositoryFromTemplate(sourceOwner, sourceRepo, repoOwner, repoName);
@@ -126,14 +126,17 @@ describe('Basic Happy Path', () => {
 
       componentPage.verifyAndWaitForPRMerge();
       componentPage.closeModal();
-      // Go back to Components tab
       Applications.clickBreadcrumbLink(applicationName);
-      Applications.goToComponentsTab();
     });
 
-    it('Verify the Pipeline run details and Node Graph view', () => {
+    it('Verify the Pipeline run details and Node Graph view', function () {
       Applications.goToPipelinerunsTab();
-      UIhelper.getTableRow('Pipeline run List', `${componentName}-on-pull-request`)
+      UIhelper.getTableRow('Pipeline run List', `${componentName}-on-pull-request`).should(
+        'contain.text',
+        'Cancelling',
+      );
+
+      UIhelper.getTableRow('Pipeline run List', `${componentName}-on-push`)
         .contains(componentName)
         .invoke('text')
         .then((pipelinerunName) => {
@@ -159,23 +162,12 @@ describe('Basic Happy Path', () => {
         });
     });
 
-    it('Wait for on-push build to finish', () => {
+    it('Verify that on-pull pipeline was cancelled', () => {
       Applications.clickBreadcrumbLink('Pipeline runs');
-      UIhelper.getTableRow('Pipeline run List', `${componentName}-on-push`)
-        .contains(componentName)
-        .invoke('text')
-        .then((pipelinerunName) => {
-          UIhelper.clickRowCellInTable('Pipeline run List', pipelinerunName, pipelinerunName);
-          DetailsTab.waitForPLRAndDownloadAllLogs();
-
-          //Verify the Pipeline run details Graph
-          piplinerunlogsTasks.forEach((item) => {
-            UIhelper.verifyGraphNodes(item);
-          });
-        });
-
-      Applications.clickBreadcrumbLink('Pipeline runs');
-      UIhelper.checkTableHasRows('Pipeline run List', 'test', 2);
+      UIhelper.getTableRow('Pipeline run List', `${componentName}-on-pull-request`).should(
+        'contain.text',
+        'Cancelled',
+      );
     });
 
     it('Verify Enterprise contract Test pipeline run Details', () => {


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/KFLUXUI-338

## Description
Quit podman if the test lasts longer than 1 hour.
Update Chrome and Cypress version to lower occurrence of `Socket connection lost` issue.
Switch to default `dockert-build-oci-ta` pipeline.
Fix test for Cancelled pipeline (issue happened due to PaC update in Konflux backend).