### PR TITLE
fix(KONFLUX-5796): the nudging should be enabled for app has a single component

### DIFF
--- a/src/components/ApplicationDetails/__data__/WorkflowTestUtils.ts
+++ b/src/components/ApplicationDetails/__data__/WorkflowTestUtils.ts
@@ -1,4 +1,4 @@
-import { useComponents, useSortedComponents } from '../../../hooks/useComponents';
+import { useAllComponents, useComponents, useSortedComponents } from '../../../hooks/useComponents';
 import { useIntegrationTestScenarios } from '../../../hooks/useIntegrationTestScenarios';
 import { useLatestBuildPipelines } from '../../../hooks/useLatestBuildPipelines';
 import { useLatestIntegrationTestPipelines } from '../../../hooks/useLatestIntegrationTestPipelines';
@@ -15,6 +15,7 @@ import {
 
 jest.mock('../../../hooks/useComponents', () => ({
   useComponents: jest.fn(),
+  useAllComponents: jest.fn(),
   useSortedComponents: jest.fn(),
 }));
 jest.mock('../../../hooks/useIntegrationTestScenarios', () => ({
@@ -36,6 +37,7 @@ jest.mock('../../../hooks/useLatestIntegrationTestPipelines', () => ({
 export const getMockWorkflows = () => {
   const workflowMocks = {
     useComponentsMock: useComponents as jest.Mock,
+    useAllComponentsMock: useAllComponents as jest.Mock,
     useSortedComponentsMock: useSortedComponents as jest.Mock,
     useIntegrationTestScenariosMock: useIntegrationTestScenarios as jest.Mock,
     useLatestBuildPipelinesMock: useLatestBuildPipelines as jest.Mock,
@@ -46,6 +48,7 @@ export const getMockWorkflows = () => {
 
   const applyWorkflowMocks = (mockFns) => {
     mockFns.useComponentsMock.mockReturnValue([mockComponentsData, true]);
+    mockFns.useAllComponentsMock.mockReturnValue([mockComponentsData, true]);
     mockFns.useSortedComponentsMock.mockReturnValue([[], false]);
     mockFns.useIntegrationTestScenariosMock.mockReturnValue([
       mockIntegrationTestScenariosData,

--- a/src/components/ComponentRelation/__tests__/useComponentRelationAction.spec.ts
+++ b/src/components/ComponentRelation/__tests__/useComponentRelationAction.spec.ts
@@ -1,18 +1,22 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { useComponents } from '../../../hooks/useComponents';
+import { useAllComponents, useComponents } from '../../../hooks/useComponents';
 import { useAccessReviewForModel } from '../../../utils/rbac';
 import { useComponentRelationAction } from '../useComponentRelationAction';
 
 jest.mock('../../../utils/rbac', () => ({ useAccessReviewForModel: jest.fn() }));
-
-jest.mock('../../../hooks/useComponents', () => ({ useComponents: jest.fn() }));
+jest.mock('../../../hooks/useComponents', () => ({
+  useComponents: jest.fn(),
+  useAllComponents: jest.fn(),
+}));
 
 const mockUseComponents = useComponents as jest.Mock;
+const mockUseAllComponents = useAllComponents as jest.Mock;
 const mockUseAccessReviewModel = useAccessReviewForModel as jest.Mock;
 
 describe('useComponentRelationAction', () => {
   beforeEach(() => {
     mockUseComponents.mockReturnValue([[{}, {}], true, undefined]);
+    mockUseAllComponents.mockReturnValue([[{}, {}], true, undefined]);
   });
 
   afterEach(() => {
@@ -35,10 +39,32 @@ describe('useComponentRelationAction', () => {
     );
   });
 
-  it('should disable action when there is one component in the app', () => {
+  it('should disable action when there is one component in the app and namespace', () => {
     jest.clearAllMocks();
     // mock one component for the application
     mockUseComponents.mockReturnValue([[{}], true, undefined]);
+    mockUseAllComponents.mockReturnValue([[{}], true, undefined]);
+    mockUseAccessReviewModel.mockReturnValue([true]);
+    const { result } = renderHook(() => useComponentRelationAction('application'));
+    expect(result.current().isDisabled).toEqual(true);
+  });
+
+  it('should not disable action when there is one component in the app but more ones in namespace', () => {
+    jest.clearAllMocks();
+    // mock one component for the application
+    mockUseComponents.mockReturnValue([[{}], true, undefined]);
+    // mock two components for the namespace
+    mockUseAllComponents.mockReturnValue([[{}, {}], true, undefined]);
+    mockUseAccessReviewModel.mockReturnValue([true]);
+    const { result } = renderHook(() => useComponentRelationAction('application'));
+    expect(result.current().isDisabled).toEqual(false);
+  });
+
+  it('should disable action when there is no component in the app but more ones in namespace', () => {
+    jest.clearAllMocks();
+    // mock one component for the application
+    mockUseComponents.mockReturnValue([[], true, undefined]);
+    mockUseAllComponents.mockReturnValue([[{}, {}], true, undefined]);
     mockUseAccessReviewModel.mockReturnValue([true]);
     const { result } = renderHook(() => useComponentRelationAction('application'));
     expect(result.current().isDisabled).toEqual(true);

--- a/src/components/ComponentRelation/useComponentRelationAction.ts
+++ b/src/components/ComponentRelation/useComponentRelationAction.ts
@@ -1,4 +1,4 @@
-import { useComponents } from '../../hooks/useComponents';
+import { useAllComponents, useComponents } from '../../hooks/useComponents';
 import { ComponentModel } from '../../models';
 import { useNamespace } from '../../shared/providers/Namespace';
 import { useAccessReviewForModel } from '../../utils/rbac';
@@ -10,13 +10,22 @@ export const useComponentRelationAction = (application: string) => {
   const namespace = useNamespace();
   const [components, loaded, error] = useComponents(namespace, application);
   const [canUpdateComponent] = useAccessReviewForModel(ComponentModel, 'patch');
+  const [allComponents, allLoaded, allErrors] = useAllComponents(namespace);
+
   return () => ({
     key: 'component-relation-modal',
     label: 'Define component relationships',
     onClick: () => {
       showModal(createComponentRelationModal({ application }));
     },
-    isDisabled: !canUpdateComponent || (loaded && !error ? components.length < 2 : null),
+    // The nudge feature supports for all components in the namespace.
+    isDisabled:
+      !canUpdateComponent ||
+      (loaded && allLoaded && !error && !allErrors
+        ? // For no component of the app or sigle component of the namespace,
+          // the nudge feature should be disabled.
+          components.length < 1 || allComponents.length < 2
+        : null),
     disabledTooltip: !canUpdateComponent
       ? `You don't have access to define component relationships`
       : null,


### PR DESCRIPTION
## Fixes 
[KONFLUX-5796](https://issues.redhat.com/browse/KONFLUX-5796)


## Description
Without the patch, when the app has a single component, the nudge action is disabled.
With the patch, when the app has a single component and there are one more components in the namespace, the nudging action would be enabled.

Note:
When there is no component, or there is one single component in the namespace, the nudging action would be kept as disabled.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
![Screenshot 2025-04-07 at 18 25 31](https://github.com/user-attachments/assets/d304eff8-4e5b-4d43-a1ab-6d772a7c4062)



## How to test or reproduce?
1. create one app with one component and try to update the component relationship
Result:
When there is no other components in the namespace, we cannot update the relationship
When there is one more components in the namespace, we can update the relationship
2. create one app without component
Result:
we cannot update the relationship

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->