### PR TITLE
fix(KONFLUX-5814): fixed strings overflow to other tab

### DIFF
--- a/src/components/Commits/CommitsListPage/CommitsListRow.tsx
+++ b/src/components/Commits/CommitsListPage/CommitsListRow.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
+import { Truncate } from '@patternfly/react-core';
 import { COMMIT_DETAILS_PATH, COMPONENT_DETAILS_PATH } from '../../../routes/paths';
 import { RowFunctionArgs, TableData, Timestamp } from '../../../shared';
 import ActionMenu from '../../../shared/components/action-menu/ActionMenu';
@@ -67,7 +68,9 @@ const CommitsListRow: React.FC<React.PropsWithChildren<RowFunctionArgs<Commit>>>
             : '-'}
         </div>
       </TableData>
-      <TableData className={commitsTableColumnClasses.byUser}>{obj.user ?? '-'}</TableData>
+      <TableData className={commitsTableColumnClasses.byUser}>
+        <Truncate content={obj.user ?? '-'} />
+      </TableData>
       <TableData className={commitsTableColumnClasses.committedAt}>
         <Timestamp timestamp={obj.creationTime} />
       </TableData>


### PR DESCRIPTION
## Fixes 
<a href="https://issues.redhat.com/browse/KONFLUX-5814">KONFLUX-5814</a>


## Description
Strings present in "By user" column in latest commit tab of Activity was overflowing to other column, fixed using truncate.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<img width="1396" alt="image" src="https://github.com/user-attachments/assets/3f5f3cad-1bd8-4ef4-9793-e040eec26d02" />



## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->