### PR TITLE
KFLUXUI-375 - [Snapshots Details Page] Fix: handle nullable 'labels' field

### DIFF
--- a/src/components/Commits/CommitDetails/visualization/__data__/MockCommitWorkflowData.ts
+++ b/src/components/Commits/CommitDetails/visualization/__data__/MockCommitWorkflowData.ts
@@ -8982,6 +8982,35 @@ export const MockSnapshots: Snapshot[] = [
       ],
     },
   },
+  {
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    kind: 'Snapshot',
+    metadata: {
+      generateName: 'my-test-output-no-labels',
+      annotations: {
+        'test.appstudio.openshift.io/status':
+          '[{"scenario":"app-sample-go-basic-enterprise-contract","status":"Pending","lastUpdateTime":"2023-09-20T16:00:38.969982048Z","details":"Failed to find deploymentTargetClass with right provisioner for copy of existingEnvironment","startTime":"2023-09-20T16:00:17.970660813Z","completionTime":"2023-09-20T16:00:38.969982048Z"}]',
+      },
+      resourceVersion: '92260135',
+      name: 'snapshot with diff err',
+      uid: '406579cb-03dc-4ebd-9d36-aafc9478eb9c',
+      creationTimestamp: '2023-03-27T13:47:16Z',
+      generation: 1,
+      namespace: 'jephilli-tenant',
+      ownerReferences: [],
+    },
+    spec: {
+      application: 'my-test-output',
+      artifacts: {},
+      components: [
+        {
+          containerImage:
+            'quay.io/redhat-appstudio/user-workload@sha256:0afbdd832f28a7de094e6f0771f5b1b7a80bd8f45d282823ae9ef093d29fac52',
+          name: 'devfile-sample-go-basic-kksq',
+        },
+      ],
+    },
+  },
 ];
 
 export const MockReleases = [];

--- a/src/components/SnapshotDetails/SnapshotDetailsView.tsx
+++ b/src/components/SnapshotDetails/SnapshotDetailsView.tsx
@@ -24,7 +24,7 @@ const SnapshotDetailsView: React.FC = () => {
   const [snapshot, loaded, loadErr] = useSnapshot(namespace, snapshotName);
 
   const buildPipelineName = React.useMemo(
-    () => loaded && !loadErr && snapshot?.metadata?.labels[SnapshotLabels.BUILD_PIPELINE_LABEL],
+    () => loaded && !loadErr && snapshot?.metadata?.labels?.[SnapshotLabels.BUILD_PIPELINE_LABEL],
     [snapshot, loaded, loadErr],
   );
 

--- a/src/components/SnapshotDetails/__tests__/SnapshotDetailsView.spec.tsx
+++ b/src/components/SnapshotDetails/__tests__/SnapshotDetailsView.spec.tsx
@@ -58,6 +58,19 @@ const errorSnapshotResources = (params: WatchK8sResource) => {
   return [[], true];
 };
 
+const getSnapshotWithNoLabels = (params: WatchK8sResource) => {
+  if (params?.groupVersionKind === SnapshotGroupVersionKind) {
+    return [
+      mockSnapshots.find((s) => s.metadata.generateName === 'my-test-output-no-labels'),
+      true,
+    ];
+  }
+  if (params?.groupVersionKind === PipelineRunGroupVersionKind) {
+    return [[pipelineWithCommits[0]], true];
+  }
+  return [[], true];
+};
+
 describe('SnapshotDetailsView', () => {
   beforeEach(() => {
     useParamsMock.mockReturnValue({
@@ -117,5 +130,16 @@ describe('SnapshotDetailsView', () => {
     });
     renderWithQueryClientAndRouter(<SnapshotDetails />);
     screen.queryByText('scn 2');
+  });
+
+  it('should render without crashing when snapshot has no labels', () => {
+    watchResourceMock.mockImplementation(getSnapshotWithNoLabels);
+    useParamsMock.mockReturnValue({
+      snapshotName: 'my-test-output-no-labels',
+      applicationName: 'my-test-output',
+    });
+    renderWithQueryClientAndRouter(<SnapshotDetails />);
+    expect(screen.getByTestId('snapshot-header-details')).toBeInTheDocument();
+    expect(screen.getByTestId('snapshot-name').innerHTML).toBe('my-test-output-no-labels');
   });
 });

--- a/src/components/SnapshotDetails/tabs/SnapshotOverview.tsx
+++ b/src/components/SnapshotDetails/tabs/SnapshotOverview.tsx
@@ -30,7 +30,7 @@ const SnapshotOverviewTab: React.FC = () => {
   const [snapshot, loaded, loadErr] = useSnapshot(namespace, snapshotName);
 
   const buildPipelineName = React.useMemo(
-    () => loaded && !loadErr && snapshot?.metadata?.labels[SnapshotLabels.BUILD_PIPELINE_LABEL],
+    () => loaded && !loadErr && snapshot?.metadata?.labels?.[SnapshotLabels.BUILD_PIPELINE_LABEL],
     [snapshot, loaded, loadErr],
   );
 


### PR DESCRIPTION
## Fixes 

This fixes: https://issues.redhat.com/browse/KFLUXUI-375

## Description

In this PR, we're fixing an issue on the "Snapshots Details Page" where a given snapshot might not have any `labels` inside its `metadata`.

By using optional chaining (`snapshot?.metadata?.labels`), we prevent errors when trying to access label keys.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

**Before the changes in this PR (error/bug):**

![snapshot-without-labels-error](https://github.com/user-attachments/assets/d0120186-8327-451f-9bf2-84d16ceb9da0)

**After the changes in this PR (fix):**

![snapshot-without-labels-fix](https://github.com/user-attachments/assets/8851a4f3-8241-4aed-bb89-3ba2524b73ba)


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1. Basically you need to have a snapshot with no "labels". Buut, since I was not able to reproduce such scenario, I used a tool called `HTTP Toolkit` and I edited the response from the endpoint to **not** return any `labels` inside the `metadata` object 🙂 
2. Alternatively, you can follow a much smarter approach (suggested by Cara 🙂) to edit the snapshot.yaml via `oc`/`kubectl` removing the `labels`. I tried it too and it works just fine to reproduce the issue and check the fix ☕ 

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

