### PR TITLE
KONFLUX-7750: Fix sorting issue on Applications list by name

### DIFF
--- a/src/components/Applications/ApplicationListHeader.ts
+++ b/src/components/Applications/ApplicationListHeader.ts
@@ -1,3 +1,5 @@
+import { createTableHeaders } from '../../shared/components/table/utils';
+
 export const applicationTableColumnClasses = {
   name: 'pf-m-width-35',
   components: 'pf-m-width-30',
@@ -5,25 +7,15 @@ export const applicationTableColumnClasses = {
   kebab: 'pf-v5-c-table__action',
 };
 
-export const ApplicationListHeader = () => {
-  return [
-    {
-      title: 'Name',
-      props: { className: applicationTableColumnClasses.name },
-    },
-    {
-      title: 'Components',
-      props: { className: applicationTableColumnClasses.components },
-    },
-    {
-      title: 'Last deploy',
-      props: { className: applicationTableColumnClasses.lastDeploy },
-    },
-    {
-      title: ' ',
-      props: {
-        className: applicationTableColumnClasses.kebab,
-      },
-    },
-  ];
-};
+export const enum SortableHeaders {
+  name,
+}
+
+const appColumns = [
+  { title: 'Name', className: applicationTableColumnClasses.name, sortable: true },
+  { title: 'Components', className: applicationTableColumnClasses.components },
+  { title: 'Last deploy', className: applicationTableColumnClasses.lastDeploy },
+  { title: ' ', className: applicationTableColumnClasses.kebab },
+];
+
+export default createTableHeaders(appColumns);

--- a/src/components/Releases/ReleasesListHeader.tsx
+++ b/src/components/Releases/ReleasesListHeader.tsx
@@ -1,5 +1,4 @@
-import { SortByDirection, ThProps } from '@patternfly/react-table';
-import { HeaderFunc } from '../../shared/components/table/Table';
+import { createTableHeaders } from '../../shared/components/table/utils';
 
 export const releasesTableColumnClasses = {
   name: 'pf-m-width-20  pf-m-width-10-on-xl wrap-column',
@@ -14,72 +13,22 @@ export const releasesTableColumnClasses = {
   kebab: 'pf-v5-c-table__action',
 };
 
-type CreateHeader = (
-  activeIndex: number,
-  activeDirection: SortByDirection,
-  onSort: ThProps['sort']['onSort'],
-) => HeaderFunc;
-
 export const enum SortableHeaders {
   name,
   created,
 }
 
-const getReleasesListHeader: CreateHeader = (activeIndex, activeDirection, onSort) => () => {
-  const getSortParams = (columnIndex: number) => ({
-    columnIndex,
-    sortBy: { index: activeIndex, direction: activeDirection },
-    onSort,
-  });
+const releaseColumns = [
+  { title: 'Name', className: releasesTableColumnClasses.name, sortable: true },
+  { title: 'Created', className: releasesTableColumnClasses.created, sortable: true },
+  { title: 'Duration', className: releasesTableColumnClasses.duration },
+  { title: 'Status', className: releasesTableColumnClasses.status },
+  { title: 'Release Plan', className: releasesTableColumnClasses.releasePlan },
+  { title: 'Release Snapshot', className: releasesTableColumnClasses.releaseSnapshot },
+  { title: 'Tenant Pipeline', className: releasesTableColumnClasses.tenantPipelineRun },
+  { title: 'Managed Pipeline', className: releasesTableColumnClasses.managedPipelineRun },
+  { title: 'Final Pipeline', className: releasesTableColumnClasses.finalPipelineRun },
+  { title: ' ', className: releasesTableColumnClasses.kebab },
+];
 
-  return [
-    {
-      title: 'Name',
-      props: {
-        className: releasesTableColumnClasses.name,
-        sort: getSortParams(SortableHeaders.name),
-      },
-    },
-    {
-      title: 'Created',
-      props: {
-        className: releasesTableColumnClasses.created,
-        sort: getSortParams(SortableHeaders.created),
-      },
-    },
-    {
-      title: 'Duration',
-      props: { className: releasesTableColumnClasses.duration },
-    },
-    {
-      title: 'Status',
-      props: { className: releasesTableColumnClasses.status },
-    },
-    {
-      title: 'Release Plan',
-      props: { className: releasesTableColumnClasses.releasePlan },
-    },
-    {
-      title: 'Release Snapshot',
-      props: { className: releasesTableColumnClasses.releaseSnapshot },
-    },
-    {
-      title: 'Tenant Pipeline',
-      props: { className: releasesTableColumnClasses.tenantPipelineRun },
-    },
-    {
-      title: 'Managed Pipeline',
-      props: { className: releasesTableColumnClasses.managedPipelineRun },
-    },
-    {
-      title: 'Final Pipeline',
-      props: { className: releasesTableColumnClasses.finalPipelineRun },
-    },
-    {
-      title: ' ',
-      props: { className: releasesTableColumnClasses.kebab },
-    },
-  ];
-};
-
-export default getReleasesListHeader;
+export default createTableHeaders(releaseColumns);

--- a/src/shared/components/table/__tests__/utils.spec.tsx
+++ b/src/shared/components/table/__tests__/utils.spec.tsx
@@ -1,0 +1,58 @@
+import { SortByDirection } from '@patternfly/react-table';
+import { ComponentProps } from '~/shared/components/table/Table';
+import { ColumnConfig, createTableHeaders } from '../utils';
+
+describe('List Utils', () => {
+  describe('createTableHeaders', () => {
+    const onSortMock = jest.fn();
+
+    const tableComponentPropsMock: ComponentProps = {
+      data: [],
+      unfilteredData: [],
+      filters: [],
+      selected: false,
+      match: undefined,
+      kindObj: undefined,
+    };
+
+    const genericColumnsConfig: ColumnConfig[] = [
+      { title: 'Name', className: 'class-name', sortable: true },
+      { title: 'Created', className: 'class-created', sortable: true },
+      { title: 'Status', className: 'class-status' },
+    ];
+
+    it('should return a function that returns properly structured headers', () => {
+      const getHeaders = createTableHeaders(genericColumnsConfig);
+      const headers = getHeaders(0, SortByDirection.asc, onSortMock)(tableComponentPropsMock);
+
+      expect(headers).toHaveLength(3);
+      expect(headers[0].title).toBe('Name');
+      expect(headers[0].props.className).toBe('class-name');
+      expect(headers[0].props.sort).toBeDefined();
+
+      expect(headers[2].title).toBe('Status');
+      expect(headers[2].props.className).toBe('class-status');
+      expect(headers[2].props.sort).toBeUndefined();
+    });
+
+    it('should include correct sort params for sortable columns', () => {
+      const activeIndex = 1;
+      const direction = SortByDirection.desc;
+      const getHeaders = createTableHeaders(genericColumnsConfig);
+      const headers = getHeaders(activeIndex, direction, onSortMock)(tableComponentPropsMock);
+
+      expect(headers[1].props.sort).toEqual({
+        columnIndex: 1,
+        sortBy: { index: activeIndex, direction },
+        onSort: onSortMock,
+      });
+    });
+
+    it('should not include sort params for non-sortable columns', () => {
+      const getHeaders = createTableHeaders(genericColumnsConfig);
+      const headers = getHeaders(0, SortByDirection.asc, onSortMock)(tableComponentPropsMock);
+
+      expect(headers[2].props.sort).toBeUndefined();
+    });
+  });
+});

--- a/src/shared/components/table/utils.ts
+++ b/src/shared/components/table/utils.ts
@@ -1,0 +1,34 @@
+import { SortByDirection, ThProps } from '@patternfly/react-table';
+import { HeaderFunc } from './Table';
+
+export type ColumnConfig = {
+  title: string;
+  className: string;
+  sortable?: boolean;
+  style?: React.CSSProperties;
+};
+
+export const createTableHeaders = (
+  columnConfig: ColumnConfig[],
+): ((
+  activeIndex: number,
+  activeDirection: SortByDirection,
+  onSort: ThProps['sort']['onSort'],
+) => HeaderFunc) => {
+  return (activeIndex, activeDirection, onSort) => () => {
+    const getSortParams = (columnIndex: number) => ({
+      columnIndex,
+      sortBy: { index: activeIndex, direction: activeDirection },
+      onSort,
+    });
+
+    return columnConfig.map((column, index) => ({
+      title: column.title,
+      props: {
+        className: column.className,
+        style: column.style,
+        ...(column.sortable && { sort: getSortParams(index) }),
+      },
+    }));
+  };
+};


### PR DESCRIPTION
## Fixes 

This fixes the issue https://issues.redhat.com/browse/KONFLUX-7750

## Description

This PR implements sorting by name on the "Applications" page. While working on this feature, I noticed a similar behavior on the "Releases" page. So as a result,  I refactored the logic for creating table headers into a more generic utility function called `createTableHeaders`, which is now used on both pages.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

**Applications page:**

![applications-with-sorting](https://github.com/user-attachments/assets/6067b6d0-412a-4012-850c-08920b537a6b)

**Releases page (to show that nothing changes and it still works as expected):**

![releases-refactor-no-changes](https://github.com/user-attachments/assets/e70cb56c-4f67-479e-b5ec-5d13ecea1efc)



## How to test or reproduce?

1. Make sure you have a few applications
2. Go to "Applications" page and now you'll notice that it's possible to sort the name column
3. ☕ 

Additional testing:

1. Since I also updated `ReleasesListHeader` to use the `createTableHeaders` utilities, you can also check the "Releases" page to see that it continues working as expected 


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [x] Code follows the style guidelines
- [x] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [x] Changes generate no new warnings
- [x] Added tests that prove this fix is effective or that the feature works
- [x] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->