### PR TITLE
chore(KFLUXUI-149): User can close "What's next" tiles

### DIFF
--- a/src/components/WhatsNext/WhatsNextSection.tsx
+++ b/src/components/WhatsNext/WhatsNextSection.tsx
@@ -47,12 +47,15 @@ const WhatsNextSection: React.FunctionComponent<React.PropsWithChildren<WhatsNex
     DISMISSED_CARD_STORAGE_KEY,
   );
 
-  const handleCardDismissal = (id: number) => {
-    setWhatsNextData((prev) => prev.filter((item) => item.id !== id));
-    let dismissedCards: number[] = [];
-    if (localStorageItem !== null) dismissedCards = localStorageItem;
-    setLocalStorageItem([id, ...dismissedCards]);
-  };
+  const handleCardDismissal = React.useCallback(
+    (id: number) => {
+      setWhatsNextData((prev) => prev.filter((item) => item.id !== id));
+      let dismissedCards: number[] = [];
+      if (localStorageItem !== null) dismissedCards = localStorageItem;
+      setLocalStorageItem([id, ...dismissedCards]);
+    },
+    [localStorageItem, setLocalStorageItem],
+  );
 
   React.useEffect(() => {
     const list: WhatsNextItem[] = whatsNextItems.filter(
@@ -61,59 +64,57 @@ const WhatsNextSection: React.FunctionComponent<React.PropsWithChildren<WhatsNex
     setWhatsNextData(list);
   }, [whatsNextItems, localStorageItem]);
 
-  return (
-    whatsNextData?.length > 0 && (
-      <PageSection padding={{ default: 'noPadding' }} variant={PageSectionVariants.light} isFilled>
-        <Title size="lg" headingLevel="h3" className="pf-v5-u-mt-lg pf-v5-u-mb-sm">
-          What&apos;s next?
-        </Title>
-        {whatsNextData.map((item) => (
-          <Card className="whats-next-card" key={item.id} isFlat>
-            <SplitItem>
-              <img src={item.icon} alt={item.title} className="whats-next-card__icon" />
-            </SplitItem>
-            <SplitItem className="whats-next-card__content" isFilled>
-              <Title headingLevel="h4">{item.title}</Title>
-              <HelperText>{item.description}</HelperText>
-            </SplitItem>
-            <SplitItem className="whats-next-card__cta" data-test={item.cta.testId}>
-              <ButtonWithAccessTooltip
-                {...(item.cta.onClick
-                  ? { onClick: item.cta.onClick }
-                  : !item.cta.external
-                    ? {
-                        component: (props) => <Link {...props} to={item.cta.href} />,
-                      }
-                    : {
-                        component: 'a',
-                        href: item.cta.href,
-                        target: '_blank',
-                        rel: 'noreferrer',
-                      })}
-                isDisabled={item.cta.disabled}
-                tooltip={item.cta.disabledTooltip}
-                variant="secondary"
-                analytics={item.cta.analytics}
-              >
-                {item.cta.label}
-              </ButtonWithAccessTooltip>
-              {item.helpLink && (
-                <ExternalLink href={item.helpLink} isInline={false}>
-                  Learn more
-                </ExternalLink>
-              )}
-              <CloseButton
-                dataTestID="close-button"
-                onClick={() => {
-                  handleCardDismissal(item.id);
-                }}
-              />
-            </SplitItem>
-          </Card>
-        ))}
-      </PageSection>
-    )
-  );
+  return whatsNextData?.length > 0 ? (
+    <PageSection padding={{ default: 'noPadding' }} variant={PageSectionVariants.light} isFilled>
+      <Title size="lg" headingLevel="h3" className="pf-v5-u-mt-lg pf-v5-u-mb-sm">
+        What&apos;s next?
+      </Title>
+      {whatsNextData.map((item) => (
+        <Card className="whats-next-card" key={item.id} isFlat>
+          <SplitItem>
+            <img src={item.icon} alt={item.title} className="whats-next-card__icon" />
+          </SplitItem>
+          <SplitItem className="whats-next-card__content" isFilled>
+            <Title headingLevel="h4">{item.title}</Title>
+            <HelperText>{item.description}</HelperText>
+          </SplitItem>
+          <SplitItem className="whats-next-card__cta" data-test={item.cta.testId}>
+            <ButtonWithAccessTooltip
+              {...(item.cta.onClick
+                ? { onClick: item.cta.onClick }
+                : !item.cta.external
+                  ? {
+                      component: (props) => <Link {...props} to={item.cta.href} />,
+                    }
+                  : {
+                      component: 'a',
+                      href: item.cta.href,
+                      target: '_blank',
+                      rel: 'noreferrer',
+                    })}
+              isDisabled={item.cta.disabled}
+              tooltip={item.cta.disabledTooltip}
+              variant="secondary"
+              analytics={item.cta.analytics}
+            >
+              {item.cta.label}
+            </ButtonWithAccessTooltip>
+            {item.helpLink && (
+              <ExternalLink href={item.helpLink} isInline={false}>
+                Learn more
+              </ExternalLink>
+            )}
+            <CloseButton
+              dataTestID="close-button"
+              onClick={() => {
+                handleCardDismissal(item.id);
+              }}
+            />
+          </SplitItem>
+        </Card>
+      ))}
+    </PageSection>
+  ) : null;
 };
 
 export default WhatsNextSection;

--- a/src/components/WhatsNext/WhatsNextSection.tsx
+++ b/src/components/WhatsNext/WhatsNextSection.tsx
@@ -8,12 +8,14 @@ import {
   SplitItem,
   Title,
 } from '@patternfly/react-core';
+import { useLocalStorage } from '~/hooks/useLocalStorage';
 import { CloseButton } from '../../shared';
 import ExternalLink from '../../shared/components/links/ExternalLink';
 import { ButtonWithAccessTooltip } from '../ButtonWithAccessTooltip';
 import './WhatsNextSection.scss';
 
 export type WhatsNextItem = {
+  id: number;
   title: string;
   description: string;
   icon: string;
@@ -41,75 +43,76 @@ const WhatsNextSection: React.FunctionComponent<React.PropsWithChildren<WhatsNex
   whatsNextItems,
 }) => {
   const [whatsNextData, setWhatsNextData] = React.useState(whatsNextItems);
+  const [localStorageItem, setLocalStorageItem] = useLocalStorage<number[]>(
+    DISMISSED_CARD_STORAGE_KEY,
+  );
 
-  const handleCardDismissal = (title: string) => {
-    setWhatsNextData((prev) => prev.filter((item) => item.title !== title));
-    let dismissedCards: string[] = [];
-    if (localStorage.getItem(DISMISSED_CARD_STORAGE_KEY) !== null)
-      dismissedCards = JSON.parse(localStorage.getItem(DISMISSED_CARD_STORAGE_KEY));
-    localStorage.setItem(DISMISSED_CARD_STORAGE_KEY, JSON.stringify([title, ...dismissedCards]));
+  const handleCardDismissal = (id: number) => {
+    setWhatsNextData((prev) => prev.filter((item) => item.id !== id));
+    let dismissedCards: number[] = [];
+    if (localStorageItem !== null) dismissedCards = localStorageItem;
+    setLocalStorageItem([id, ...dismissedCards]);
   };
 
   React.useEffect(() => {
-    let dismissedCards: string[] = [];
-    if (localStorage.getItem(DISMISSED_CARD_STORAGE_KEY) !== null)
-      dismissedCards = JSON.parse(localStorage.getItem(DISMISSED_CARD_STORAGE_KEY));
     const list: WhatsNextItem[] = whatsNextItems.filter(
-      (item) => !dismissedCards.includes(item.title),
+      (item) => !localStorageItem?.includes(item?.id),
     );
     setWhatsNextData(list);
-  }, [whatsNextItems]);
+  }, [whatsNextItems, localStorageItem]);
 
   return (
-    <PageSection padding={{ default: 'noPadding' }} variant={PageSectionVariants.light} isFilled>
-      <Title size="lg" headingLevel="h3" className="pf-v5-u-mt-lg pf-v5-u-mb-sm">
-        {whatsNextData?.length > 0 && "What's next?"}
-      </Title>
-      {whatsNextData.map((item) => (
-        <Card className="whats-next-card" key={item.title} isFlat>
-          <SplitItem>
-            <img src={item.icon} alt={item.title} className="whats-next-card__icon" />
-          </SplitItem>
-          <SplitItem className="whats-next-card__content" isFilled>
-            <Title headingLevel="h4">{item.title}</Title>
-            <HelperText>{item.description}</HelperText>
-          </SplitItem>
-          <SplitItem className="whats-next-card__cta" data-test={item.cta.testId}>
-            <ButtonWithAccessTooltip
-              {...(item.cta.onClick
-                ? { onClick: item.cta.onClick }
-                : !item.cta.external
-                  ? {
-                      component: (props) => <Link {...props} to={item.cta.href} />,
-                    }
-                  : {
-                      component: 'a',
-                      href: item.cta.href,
-                      target: '_blank',
-                      rel: 'noreferrer',
-                    })}
-              isDisabled={item.cta.disabled}
-              tooltip={item.cta.disabledTooltip}
-              variant="secondary"
-              analytics={item.cta.analytics}
-            >
-              {item.cta.label}
-            </ButtonWithAccessTooltip>
-            {item.helpLink && (
-              <ExternalLink href={item.helpLink} isInline={false}>
-                Learn more
-              </ExternalLink>
-            )}
-            <CloseButton
-              dataTestID="close-button"
-              onClick={() => {
-                handleCardDismissal(item.title);
-              }}
-            />
-          </SplitItem>
-        </Card>
-      ))}
-    </PageSection>
+    whatsNextData?.length > 0 && (
+      <PageSection padding={{ default: 'noPadding' }} variant={PageSectionVariants.light} isFilled>
+        <Title size="lg" headingLevel="h3" className="pf-v5-u-mt-lg pf-v5-u-mb-sm">
+          What&apos;s next?
+        </Title>
+        {whatsNextData.map((item) => (
+          <Card className="whats-next-card" key={item.id} isFlat>
+            <SplitItem>
+              <img src={item.icon} alt={item.title} className="whats-next-card__icon" />
+            </SplitItem>
+            <SplitItem className="whats-next-card__content" isFilled>
+              <Title headingLevel="h4">{item.title}</Title>
+              <HelperText>{item.description}</HelperText>
+            </SplitItem>
+            <SplitItem className="whats-next-card__cta" data-test={item.cta.testId}>
+              <ButtonWithAccessTooltip
+                {...(item.cta.onClick
+                  ? { onClick: item.cta.onClick }
+                  : !item.cta.external
+                    ? {
+                        component: (props) => <Link {...props} to={item.cta.href} />,
+                      }
+                    : {
+                        component: 'a',
+                        href: item.cta.href,
+                        target: '_blank',
+                        rel: 'noreferrer',
+                      })}
+                isDisabled={item.cta.disabled}
+                tooltip={item.cta.disabledTooltip}
+                variant="secondary"
+                analytics={item.cta.analytics}
+              >
+                {item.cta.label}
+              </ButtonWithAccessTooltip>
+              {item.helpLink && (
+                <ExternalLink href={item.helpLink} isInline={false}>
+                  Learn more
+                </ExternalLink>
+              )}
+              <CloseButton
+                dataTestID="close-button"
+                onClick={() => {
+                  handleCardDismissal(item.id);
+                }}
+              />
+            </SplitItem>
+          </Card>
+        ))}
+      </PageSection>
+    )
   );
 };
 

--- a/src/components/WhatsNext/WhatsNextSection.tsx
+++ b/src/components/WhatsNext/WhatsNextSection.tsx
@@ -42,14 +42,12 @@ const DISMISSED_CARD_STORAGE_KEY = 'dismissedCards';
 const WhatsNextSection: React.FunctionComponent<React.PropsWithChildren<WhatsNextSectionProps>> = ({
   whatsNextItems,
 }) => {
-  const [whatsNextData, setWhatsNextData] = React.useState(whatsNextItems);
   const [localStorageItem, setLocalStorageItem] = useLocalStorage<number[]>(
     DISMISSED_CARD_STORAGE_KEY,
   );
 
   const handleCardDismissal = React.useCallback(
     (id: number) => {
-      setWhatsNextData((prev) => prev.filter((item) => item.id !== id));
       let dismissedCards: number[] = [];
       if (localStorageItem !== null) dismissedCards = localStorageItem as number[];
       setLocalStorageItem([id, ...dismissedCards]);
@@ -57,62 +55,59 @@ const WhatsNextSection: React.FunctionComponent<React.PropsWithChildren<WhatsNex
     [localStorageItem, setLocalStorageItem],
   );
 
-  React.useEffect(() => {
-    const list: WhatsNextItem[] = whatsNextItems.filter(
-      (item) => !(localStorageItem as number[])?.includes(item?.id),
-    );
-    setWhatsNextData(list);
-  }, [whatsNextItems, localStorageItem]);
-
-  return whatsNextData?.length > 0 ? (
+  return !(localStorageItem?.length === 6) ? (
     <PageSection padding={{ default: 'noPadding' }} variant={PageSectionVariants.light} isFilled>
       <Title size="lg" headingLevel="h3" className="pf-v5-u-mt-lg pf-v5-u-mb-sm">
         What&apos;s next?
       </Title>
-      {whatsNextData.map((item) => (
-        <Card className="whats-next-card" key={item.id} isFlat>
-          <SplitItem>
-            <img src={item.icon} alt={item.title} className="whats-next-card__icon" />
-          </SplitItem>
-          <SplitItem className="whats-next-card__content" isFilled>
-            <Title headingLevel="h4">{item.title}</Title>
-            <HelperText>{item.description}</HelperText>
-          </SplitItem>
-          <SplitItem className="whats-next-card__cta" data-test={item.cta.testId}>
-            <ButtonWithAccessTooltip
-              {...(item.cta.onClick
-                ? { onClick: item.cta.onClick }
-                : !item.cta.external
-                  ? {
-                      component: (props) => <Link {...props} to={item.cta.href} />,
-                    }
-                  : {
-                      component: 'a',
-                      href: item.cta.href,
-                      target: '_blank',
-                      rel: 'noreferrer',
-                    })}
-              isDisabled={item.cta.disabled}
-              tooltip={item.cta.disabledTooltip}
-              variant="secondary"
-              analytics={item.cta.analytics}
-            >
-              {item.cta.label}
-            </ButtonWithAccessTooltip>
-            {item.helpLink && (
-              <ExternalLink href={item.helpLink} isInline={false}>
-                Learn more
-              </ExternalLink>
-            )}
-            <CloseButton
-              dataTestID="close-button"
-              onClick={() => {
-                handleCardDismissal(item.id);
-              }}
-            />
-          </SplitItem>
-        </Card>
-      ))}
+      {whatsNextItems.map((item) => {
+        return (
+          !(localStorageItem as number[])?.includes(item?.id) && (
+            <Card className="whats-next-card" key={item.id} isFlat>
+              <SplitItem>
+                <img src={item.icon} alt={item.title} className="whats-next-card__icon" />
+              </SplitItem>
+              <SplitItem className="whats-next-card__content" isFilled>
+                <Title headingLevel="h4">{item.title}</Title>
+                <HelperText>{item.description}</HelperText>
+              </SplitItem>
+              <SplitItem className="whats-next-card__cta" data-test={item.cta.testId}>
+                <ButtonWithAccessTooltip
+                  {...(item.cta.onClick
+                    ? { onClick: item.cta.onClick }
+                    : !item.cta.external
+                      ? {
+                          component: (props) => <Link {...props} to={item.cta.href} />,
+                        }
+                      : {
+                          component: 'a',
+                          href: item.cta.href,
+                          target: '_blank',
+                          rel: 'noreferrer',
+                        })}
+                  isDisabled={item.cta.disabled}
+                  tooltip={item.cta.disabledTooltip}
+                  variant="secondary"
+                  analytics={item.cta.analytics}
+                >
+                  {item.cta.label}
+                </ButtonWithAccessTooltip>
+                {item.helpLink && (
+                  <ExternalLink href={item.helpLink} isInline={false}>
+                    Learn more
+                  </ExternalLink>
+                )}
+                <CloseButton
+                  dataTestID="close-button"
+                  onClick={() => {
+                    handleCardDismissal(item.id);
+                  }}
+                />
+              </SplitItem>
+            </Card>
+          )
+        );
+      })}
     </PageSection>
   ) : null;
 };

--- a/src/components/WhatsNext/WhatsNextSection.tsx
+++ b/src/components/WhatsNext/WhatsNextSection.tsx
@@ -49,13 +49,13 @@ const WhatsNextSection: React.FunctionComponent<React.PropsWithChildren<WhatsNex
   };
 
   React.useEffect(() => {
-    let dimissedCards: string[] = [];
+    let dismissedCards: string[] = [];
     if (localStorage.getItem('dismissedCards') !== null)
-      dimissedCards = JSON.parse(localStorage.getItem('dismissedCards'));
-    if (dimissedCards.length === 0) setWhatsNextData(whatsNextItems);
+      dismissedCards = JSON.parse(localStorage.getItem('dismissedCards'));
+    if (dismissedCards.length === 0) setWhatsNextData(whatsNextItems);
     else {
       const list = whatsNextItems.filter((item) => {
-        return !dimissedCards.find((title) => title === item.title);
+        return !dismissedCards.find((title) => title === item.title);
       });
       setWhatsNextData(list);
     }

--- a/src/components/WhatsNext/WhatsNextSection.tsx
+++ b/src/components/WhatsNext/WhatsNextSection.tsx
@@ -35,6 +35,8 @@ type WhatsNextSectionProps = {
   whatsNextItems: WhatsNextItem[];
 };
 
+const DISMISSED_CARD_STORAGE_KEY = 'dismissedCards';
+
 const WhatsNextSection: React.FunctionComponent<React.PropsWithChildren<WhatsNextSectionProps>> = ({
   whatsNextItems,
 }) => {
@@ -43,22 +45,19 @@ const WhatsNextSection: React.FunctionComponent<React.PropsWithChildren<WhatsNex
   const handleCardDismissal = (title: string) => {
     setWhatsNextData((prev) => prev.filter((item) => item.title !== title));
     let dismissedCards: string[] = [];
-    if (localStorage.getItem('dismissedCards') !== null)
-      dismissedCards = JSON.parse(localStorage.getItem('dismissedCards'));
-    localStorage.setItem('dismissedCards', JSON.stringify([title, ...dismissedCards]));
+    if (localStorage.getItem(DISMISSED_CARD_STORAGE_KEY) !== null)
+      dismissedCards = JSON.parse(localStorage.getItem(DISMISSED_CARD_STORAGE_KEY));
+    localStorage.setItem(DISMISSED_CARD_STORAGE_KEY, JSON.stringify([title, ...dismissedCards]));
   };
 
   React.useEffect(() => {
     let dismissedCards: string[] = [];
-    if (localStorage.getItem('dismissedCards') !== null)
-      dismissedCards = JSON.parse(localStorage.getItem('dismissedCards'));
-    if (dismissedCards.length === 0) setWhatsNextData(whatsNextItems);
-    else {
-      const list = whatsNextItems.filter((item) => {
-        return !dismissedCards.find((title) => title === item.title);
-      });
-      setWhatsNextData(list);
-    }
+    if (localStorage.getItem(DISMISSED_CARD_STORAGE_KEY) !== null)
+      dismissedCards = JSON.parse(localStorage.getItem(DISMISSED_CARD_STORAGE_KEY));
+    const list: WhatsNextItem[] = whatsNextItems.filter(
+      (item) => !dismissedCards.includes(item.title),
+    );
+    setWhatsNextData(list);
   }, [whatsNextItems]);
 
   return (

--- a/src/components/WhatsNext/WhatsNextSection.tsx
+++ b/src/components/WhatsNext/WhatsNextSection.tsx
@@ -55,7 +55,8 @@ const WhatsNextSection: React.FunctionComponent<React.PropsWithChildren<WhatsNex
     [localStorageItem, setLocalStorageItem],
   );
 
-  return !(localStorageItem?.length === whatsNextItems.length) ? (
+  if (localStorageItem?.length === whatsNextItems.length) return null;
+  return (
     <PageSection padding={{ default: 'noPadding' }} variant={PageSectionVariants.light} isFilled>
       <Title size="lg" headingLevel="h3" className="pf-v5-u-mt-lg pf-v5-u-mb-sm">
         What&apos;s next?
@@ -109,7 +110,7 @@ const WhatsNextSection: React.FunctionComponent<React.PropsWithChildren<WhatsNex
         );
       })}
     </PageSection>
-  ) : null;
+  );
 };
 
 export default WhatsNextSection;

--- a/src/components/WhatsNext/WhatsNextSection.tsx
+++ b/src/components/WhatsNext/WhatsNextSection.tsx
@@ -59,7 +59,7 @@ const WhatsNextSection: React.FunctionComponent<React.PropsWithChildren<WhatsNex
 
   React.useEffect(() => {
     const list: WhatsNextItem[] = whatsNextItems.filter(
-      (item) => !localStorageItem?.includes(item?.id),
+      (item) => !(localStorageItem as number[])?.includes(item?.id),
     );
     setWhatsNextData(list);
   }, [whatsNextItems, localStorageItem]);

--- a/src/components/WhatsNext/WhatsNextSection.tsx
+++ b/src/components/WhatsNext/WhatsNextSection.tsx
@@ -51,7 +51,7 @@ const WhatsNextSection: React.FunctionComponent<React.PropsWithChildren<WhatsNex
     (id: number) => {
       setWhatsNextData((prev) => prev.filter((item) => item.id !== id));
       let dismissedCards: number[] = [];
-      if (localStorageItem !== null) dismissedCards = localStorageItem;
+      if (localStorageItem !== null) dismissedCards = localStorageItem as number[];
       setLocalStorageItem([id, ...dismissedCards]);
     },
     [localStorageItem, setLocalStorageItem],

--- a/src/components/WhatsNext/WhatsNextSection.tsx
+++ b/src/components/WhatsNext/WhatsNextSection.tsx
@@ -8,9 +8,9 @@ import {
   SplitItem,
   Title,
 } from '@patternfly/react-core';
+import { CloseButton } from '../../shared';
 import ExternalLink from '../../shared/components/links/ExternalLink';
 import { ButtonWithAccessTooltip } from '../ButtonWithAccessTooltip';
-
 import './WhatsNextSection.scss';
 
 export type WhatsNextItem = {
@@ -38,12 +38,35 @@ type WhatsNextSectionProps = {
 const WhatsNextSection: React.FunctionComponent<React.PropsWithChildren<WhatsNextSectionProps>> = ({
   whatsNextItems,
 }) => {
+  const [whatsNextData, setWhatsNextData] = React.useState(whatsNextItems);
+
+  const handleCardDismissal = (title: string) => {
+    setWhatsNextData((prev) => prev.filter((item) => item.title !== title));
+    let dimissedCards: string[] = [];
+    if (localStorage.getItem('dismissedCards') !== null)
+      dimissedCards = JSON.parse(localStorage.getItem('dismissedCards'));
+    localStorage.setItem('dismissedCards', JSON.stringify([title, ...dimissedCards]));
+  };
+
+  React.useEffect(() => {
+    let dimissedCards: string[] = [];
+    if (localStorage.getItem('dismissedCards') !== null)
+      dimissedCards = JSON.parse(localStorage.getItem('dismissedCards'));
+    if (dimissedCards.length === 0) setWhatsNextData(whatsNextItems);
+    else {
+      const list = whatsNextItems.filter((item) => {
+        return !dimissedCards.find((title) => title === item.title);
+      });
+      setWhatsNextData(list);
+    }
+  }, [whatsNextItems]);
+
   return (
     <PageSection padding={{ default: 'noPadding' }} variant={PageSectionVariants.light} isFilled>
       <Title size="lg" headingLevel="h3" className="pf-v5-u-mt-lg pf-v5-u-mb-sm">
-        What&apos;s next?
+        {whatsNextData?.length > 0 && "What's next?"}
       </Title>
-      {whatsNextItems.map((item) => (
+      {whatsNextData.map((item) => (
         <Card className="whats-next-card" key={item.title} isFlat>
           <SplitItem>
             <img src={item.icon} alt={item.title} className="whats-next-card__icon" />
@@ -78,6 +101,12 @@ const WhatsNextSection: React.FunctionComponent<React.PropsWithChildren<WhatsNex
                 Learn more
               </ExternalLink>
             )}
+            <CloseButton
+              dataTestID="close-button"
+              onClick={() => {
+                handleCardDismissal(item.title);
+              }}
+            />
           </SplitItem>
         </Card>
       ))}

--- a/src/components/WhatsNext/WhatsNextSection.tsx
+++ b/src/components/WhatsNext/WhatsNextSection.tsx
@@ -42,10 +42,10 @@ const WhatsNextSection: React.FunctionComponent<React.PropsWithChildren<WhatsNex
 
   const handleCardDismissal = (title: string) => {
     setWhatsNextData((prev) => prev.filter((item) => item.title !== title));
-    let dimissedCards: string[] = [];
+    let dismissedCards: string[] = [];
     if (localStorage.getItem('dismissedCards') !== null)
-      dimissedCards = JSON.parse(localStorage.getItem('dismissedCards'));
-    localStorage.setItem('dismissedCards', JSON.stringify([title, ...dimissedCards]));
+      dismissedCards = JSON.parse(localStorage.getItem('dismissedCards'));
+    localStorage.setItem('dismissedCards', JSON.stringify([title, ...dismissedCards]));
   };
 
   React.useEffect(() => {

--- a/src/components/WhatsNext/WhatsNextSection.tsx
+++ b/src/components/WhatsNext/WhatsNextSection.tsx
@@ -55,7 +55,7 @@ const WhatsNextSection: React.FunctionComponent<React.PropsWithChildren<WhatsNex
     [localStorageItem, setLocalStorageItem],
   );
 
-  return !(localStorageItem?.length === 6) ? (
+  return !(localStorageItem?.length === whatsNextItems.length) ? (
     <PageSection padding={{ default: 'noPadding' }} variant={PageSectionVariants.light} isFilled>
       <Title size="lg" headingLevel="h3" className="pf-v5-u-mt-lg pf-v5-u-mb-sm">
         What&apos;s next?

--- a/src/components/WhatsNext/__tests__/WhatsNextSection.spec.tsx
+++ b/src/components/WhatsNext/__tests__/WhatsNextSection.spec.tsx
@@ -20,6 +20,7 @@ const mockOnClick = jest.fn();
 
 const mockWhatsNextItems: WhatsNextItem[] = [
   {
+    id: 0,
     title: 'React router action',
     description: 'Sample action to take user to a router link inside the app.',
     icon: componentsIcon,
@@ -30,6 +31,7 @@ const mockWhatsNextItems: WhatsNextItem[] = [
     helpLink: 'mock-help-id',
   },
   {
+    id: 1,
     title: 'External link action',
     description: 'Sample action to take user to an external link.',
     icon: gitAppIcon,
@@ -40,6 +42,7 @@ const mockWhatsNextItems: WhatsNextItem[] = [
     },
   },
   {
+    id: 2,
     title: 'On click action',
     description: 'Sample action to trigger an onClick action.',
     icon: gitAppIcon,

--- a/src/components/WhatsNext/__tests__/WhatsNextSection.spec.tsx
+++ b/src/components/WhatsNext/__tests__/WhatsNextSection.spec.tsx
@@ -83,4 +83,19 @@ describe('Whats Next Section', () => {
     });
     expect(mockOnClick).toHaveBeenCalled();
   });
+
+  it('it should close the card when clicked on close button', () => {
+    render(<WhatsNextSection whatsNextItems={[mockWhatsNextItems[0]]} />);
+    expect(screen.getByText('React router action')).toBeInTheDocument();
+    expect(screen.getByText('Take me to router link')).toBeInTheDocument();
+
+    act(() => {
+      const trigger = screen.getByTestId('close-button');
+      fireEvent.click(trigger);
+    });
+
+    expect(mockOnClick).toHaveBeenCalled();
+    expect(screen.queryByText('React router action')).not.toBeInTheDocument();
+    expect(screen.queryByText('Take me to router link')).not.toBeInTheDocument();
+  });
 });

--- a/src/components/WhatsNext/useWhatsNextItems.ts
+++ b/src/components/WhatsNext/useWhatsNextItems.ts
@@ -32,6 +32,7 @@ export const useWhatsNextItems = (applicationName: string) => {
 
   const whatsNextItems: WhatsNextItem[] = [
     {
+      id: 0,
       title: 'Grow your application',
       description: 'Grow your application by adding components.',
       icon: componentsIcon,
@@ -51,6 +52,7 @@ export const useWhatsNextItems = (applicationName: string) => {
       helpLink: 'https://konflux-ci.dev/docs/building/creating/',
     },
     {
+      id: 1,
       title: 'Add integration tests',
       description:
         'Integration tests run in parallel, validating each new component build with the latest version of all other components.',
@@ -71,6 +73,7 @@ export const useWhatsNextItems = (applicationName: string) => {
       helpLink: 'https://konflux-ci.dev/docs/testing/integration/adding/',
     },
     {
+      id: 2,
       title: 'Create a release plan',
       description:
         'A release object represents deployable snapshot of your application. To release your code, create a release plan with release details.',
@@ -91,6 +94,7 @@ export const useWhatsNextItems = (applicationName: string) => {
       helpLink: 'https://konflux-ci.dev/docs/releasing/',
     },
     {
+      id: 3,
       title: 'Install our GitHub app',
       description: 'Install the GitHub app to monitor your work from a commit to deployment.',
       icon: gitAppIcon,
@@ -108,6 +112,7 @@ export const useWhatsNextItems = (applicationName: string) => {
       helpLink: 'https://konflux-ci.dev/docs/building/creating/',
     },
     {
+      id: 4,
       title: 'Make a code change',
       description: 'Make a change to your source code to automatically trigger a new build.',
       icon: editCodeIcon,
@@ -124,6 +129,7 @@ export const useWhatsNextItems = (applicationName: string) => {
       helpLink: 'https://konflux-ci.dev/docs/building/creating/',
     },
     {
+      id: 5,
       title: 'Manage build pipelines',
       description:
         'Add some automation by upgrading your default build pipelines to custom build pipelines.',


### PR DESCRIPTION


## Chore
<a href="https://issues.redhat.com/browse/KFLUXUI-149">KFLUXUI-149</a>



## Description
Close button added on each card allowing to close the card in the what's Next Section under Application.



## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
<img width="1432" alt="image" src="https://github.com/user-attachments/assets/68798cf9-eb04-4e57-8d4f-6bda6ca129f9" />

<br>
<hr>
 When all the cards are closed, What's next option is not shown
<img width="1434" alt="image" src="https://github.com/user-attachments/assets/a3747b60-8d03-4bb8-8217-33cab0d4a424" />



## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

When any card is closed , it will not be redisplayed.


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [X] Chrome
- [X] Firefox
- [X] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->