### PR TITLE
KFLUXUI-232: [Commit Details - PipelineRun Tab] Update to also show "component-less" PipelineRuns

### DIFF
--- a/src/components/Commits/CommitDetails/tabs/CommitsPipelineRunTab.tsx
+++ b/src/components/Commits/CommitDetails/tabs/CommitsPipelineRunTab.tsx
@@ -30,7 +30,7 @@ const CommitsPipelineRunTab: React.FC = () => {
   const { applicationName, commitName } = useParams<RouterParams>();
   const namespace = useNamespace();
   const [pipelineRuns, loaded, error, getNextPage, { isFetchingNextPage, hasNextPage }] =
-    usePipelineRunsForCommit(namespace, applicationName, commitName);
+    usePipelineRunsForCommit(namespace, applicationName, commitName, undefined, false);
   const { filters: unparsedFilters, setFilters, onClearFilters } = React.useContext(FilterContext);
   const filters: PipelineRunsFilterState = useDeepCompareMemoize({
     name: unparsedFilters.name ? (unparsedFilters.name as string) : '',

--- a/src/hooks/__tests__/usePipelineRuns.spec.ts
+++ b/src/hooks/__tests__/usePipelineRuns.spec.ts
@@ -100,6 +100,20 @@ const resultMock3 = [
   },
 ];
 
+const resultMock4 = [
+  {
+    kind: PipelineRunGroupVersionKind.kind,
+    metadata: {
+      name: 'fifth',
+      creationTimestamp: '2022-04-11T19:36:25Z',
+      labels: {
+        'pac.test.appstudio.openshift.io/sha': 'sample-sha',
+        'appstudio.openshift.io/component': 'test-component-2',
+      },
+    },
+  },
+];
+
 const resultMockPush = [
   {
     kind: PipelineRunGroupVersionKind.kind,
@@ -485,6 +499,46 @@ describe('usePipelineRuns', () => {
         usePipelineRunsForCommit('test-ns', 'test-app', 'sample-sha'),
       );
       expect(result.current).toEqual([[...resultMock, ...resultMock2], true, undefined, undefined]);
+    });
+
+    it('should return pipeline runs without filtering by components', () => {
+      useComponentsMock.mockReturnValue([[{ metadata: { name: 'test-component' } }], true]);
+      useK8sWatchResourceMock.mockReturnValueOnce([
+        [...resultMock, ...resultMock2, ...resultMock3, ...resultMock4],
+        true,
+      ]);
+      useTRPipelineRunsMock.mockReturnValue([[], true]);
+      const { result } = renderHook(() =>
+        usePipelineRunsForCommit('test-ns', 'test-app', 'sample-sha', undefined, false),
+      );
+
+      expect(result.current).toEqual([
+        [...resultMock, ...resultMock4, ...resultMock2],
+        true,
+        undefined,
+        undefined,
+        undefined,
+      ]);
+    });
+
+    it('should return pipeline runs filtering by components', () => {
+      useComponentsMock.mockReturnValue([[{ metadata: { name: 'test-component' } }], true]);
+      useK8sWatchResourceMock.mockReturnValueOnce([
+        [...resultMock, ...resultMock2, ...resultMock3, ...resultMock4],
+        true,
+      ]);
+      useTRPipelineRunsMock.mockReturnValue([[], true]);
+      const { result } = renderHook(() =>
+        usePipelineRunsForCommit('test-ns', 'test-app', 'sample-sha', undefined, true),
+      );
+
+      expect(result.current).toEqual([
+        [...resultMock, ...resultMock2],
+        true,
+        undefined,
+        undefined,
+        undefined,
+      ]);
     });
   });
 

--- a/src/hooks/usePipelineRuns.ts
+++ b/src/hooks/usePipelineRuns.ts
@@ -247,6 +247,7 @@ export const usePipelineRunsForCommit = (
   applicationName: string,
   commit: string,
   limit?: number,
+  filterByComponents = true,
 ): [PipelineRunKind[], boolean, unknown, GetNextPage, NextPageProps] => {
   const [components, componentsLoaded] = useComponents(namespace, applicationName);
   const [application, applicationLoaded] = useApplication(namespace, applicationName);
@@ -286,7 +287,9 @@ export const usePipelineRunsForCommit = (
     return [
       pipelineRuns
         .filter((plr) =>
-          componentNames.includes(plr.metadata?.labels?.[PipelineRunLabel.COMPONENT]),
+          filterByComponents
+            ? componentNames.includes(plr.metadata?.labels?.[PipelineRunLabel.COMPONENT])
+            : true,
         )
         .filter((plr) => plr.kind === PipelineRunGroupVersionKind.kind)
         .slice(0, limit ? limit : undefined),
@@ -295,7 +298,16 @@ export const usePipelineRunsForCommit = (
       getNextPage,
       nextPageProps,
     ];
-  }, [componentNames, getNextPage, limit, loaded, nextPageProps, pipelineRuns, plrError]);
+  }, [
+    componentNames,
+    filterByComponents,
+    getNextPage,
+    limit,
+    loaded,
+    nextPageProps,
+    pipelineRuns,
+    plrError,
+  ]);
 };
 
 export const usePipelineRun = (

--- a/src/utils/commits-utils.ts
+++ b/src/utils/commits-utils.ts
@@ -14,7 +14,8 @@ export const statuses = [
 export const getCommitSha = (pipelineRun: PipelineRunKind) =>
   pipelineRun?.metadata.labels?.[PipelineRunLabel.COMMIT_LABEL] ||
   pipelineRun?.metadata.labels?.[PipelineRunLabel.TEST_SERVICE_COMMIT] ||
-  pipelineRun?.metadata.annotations?.[PipelineRunLabel.COMMIT_ANNOTATION];
+  pipelineRun?.metadata.annotations?.[PipelineRunLabel.COMMIT_ANNOTATION] ||
+  pipelineRun?.metadata?.annotations?.[PipelineRunLabel.TEST_SERVICE_COMMIT];
 
 export const createCommitObjectFromPLR = (plr: PipelineRunKind): Commit => {
   if (!plr || !getCommitSha(plr)) {


### PR DESCRIPTION
## Fixes 

This fixes the issue https://issues.redhat.com/browse/KFLUXUI-232

## Description

This PR is adding the changes to allow displaying in the "Commit Details - PipelineRun Tab", the `PipelineRun`s that doesn't have a component directly related to it.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before the fix (notice that the PipelineRun `tenant-bdvhf` is not displayed):

![commit-pipelinerun-without-component-issue](https://github.com/user-attachments/assets/1279357a-38c1-4d8f-ac53-1109f5d73513)

With the fix:

![commit-pipelinerun-without-component-fix](https://github.com/user-attachments/assets/07c46687-ac40-43d2-bd2f-05a19a5acb22)


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1. Find some `PipelineRun` that doesn't have a component
2. Open the Commit Details - PipelineRuns Tab
3. The "component-less" `PipelineRun` should be listed there
4. ☕ 

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->