### PR TITLE
feat(KFLUXUI-231): [Release Details] add `YAML` tab

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -23,7 +23,7 @@ export default {
   },
   roots: ['<rootDir>/src/'],
   transformIgnorePatterns: [
-    '/node_modules/(?!@patternfly|uuid|lodash-es|@popperjs|i18next|d3|d3-array|delaunator|robust-predicates|internmap|react-dnd|react-dnd-html5-backend|dnd-core|@react-dnd|p-limit|yocto-queue|react-hotkeys-hook)',
+    '/node_modules/(?!@patternfly|uuid|lodash-es|@popperjs|i18next|d3|d3-array|delaunator|robust-predicates|internmap|react-dnd|react-dnd-html5-backend|dnd-core|@react-dnd|p-limit|yocto-queue|react-hotkeys-hook|yaml|monaco-)',
   ],
   collectCoverageFrom: [
     'src/**/*.{js,jsx,ts,tsx}',

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@patternfly/patternfly": "^5.3.1",
     "@patternfly/react-charts": "7.4.5",
+    "@patternfly/react-code-editor": "^5.3.1",
     "@patternfly/react-core": "5.3.4",
     "@patternfly/react-icons": "^5.3.2",
     "@patternfly/react-log-viewer": "5.3.0",
@@ -48,6 +49,8 @@
     "git-url-parse": "^15.0.0",
     "js-base64": "^3.7.7",
     "lodash-es": "4.17.23",
+    "monaco-editor": "^0.51.0",
+    "monaco-yaml": "^5.3.1",
     "p-limit": "^6.2.0",
     "prismjs": "^1.30.0",
     "react": "^18.3.1",
@@ -59,6 +62,7 @@
     "react-router-dom": "6.25.1",
     "sanitize-html": "^2.13.0",
     "showdown": "^2.1.0",
+    "yaml": "^2.7.1",
     "yup": "^0.32.11",
     "zustand": "^5.0.4"
   },
@@ -109,6 +113,8 @@
     "json-schema-to-typescript": "^15.0.4",
     "lint-staged": "^15.2.7",
     "mini-css-extract-plugin": "^2.9.0",
+    "monaco-editor-webpack-plugin": "^7.1.0",
+    "openapi-types": "^12.1.3",
     "prettier": "3.3.2",
     "react-refresh": "^0.14.2",
     "sass": "^1.77.8",

--- a/src/components/Releases/ReleaseDetailsView.tsx
+++ b/src/components/Releases/ReleaseDetailsView.tsx
@@ -117,6 +117,11 @@ const ReleaseDetailsView: React.FC = () => {
           label: 'Release artifacts',
           isFilled: true,
         },
+        {
+          key: 'yaml',
+          label: 'YAML',
+          isFilled: true,
+        },
       ]}
     />
   );

--- a/src/components/Releases/ReleaseYamlTab.scss
+++ b/src/components/Releases/ReleaseYamlTab.scss
@@ -1,0 +1,3 @@
+.release-yaml-tab {
+  padding-block: var(--pf-v5-global--spacer--lg);
+}

--- a/src/components/Releases/ReleaseYamlTab.tsx
+++ b/src/components/Releases/ReleaseYamlTab.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { useParams } from 'react-router-dom';
+import { Bullseye, Flex, Spinner } from '@patternfly/react-core';
+import { useRelease } from '~/hooks/useReleases';
+import { RouterParams } from '~/routes/utils';
+import { YAMLCodeEditor } from '~/shared/components/code-editor/YAMLCodeEditor';
+import { useNamespace } from '~/shared/providers/Namespace';
+import { getErrorState } from '~/shared/utils/error-utils';
+
+export const ReleaseYamlTab: React.FC = () => {
+  const { releaseName } = useParams<RouterParams>();
+  const namespace = useNamespace();
+  const [release, loaded, error] = useRelease(namespace, releaseName);
+
+  if (!loaded) {
+    return (
+      <Bullseye>
+        <Spinner size="lg" />
+      </Bullseye>
+    );
+  }
+
+  if (error) {
+    return getErrorState(error, loaded, 'release');
+  }
+
+  return (
+    <Flex className="pf-v5-u-py-lg">
+      <YAMLCodeEditor code={release} />
+    </Flex>
+  );
+};
+
+export default ReleaseYamlTab;

--- a/src/components/Releases/ReleaseYamlTab.tsx
+++ b/src/components/Releases/ReleaseYamlTab.tsx
@@ -7,10 +7,12 @@ import { YAMLCodeEditor } from '~/shared/components/code-editor/YAMLCodeEditor';
 import { useNamespace } from '~/shared/providers/Namespace';
 import { getErrorState } from '~/shared/utils/error-utils';
 
+import './ReleaseYamlTab.scss';
+
 export const ReleaseYamlTab: React.FC = () => {
   const { releaseName } = useParams<RouterParams>();
   const namespace = useNamespace();
-  const [release, loaded, error] = useRelease(namespace, releaseName);
+  const [release, loaded, error] = useRelease(namespace, releaseName ?? '');
 
   if (!loaded) {
     return (
@@ -25,7 +27,7 @@ export const ReleaseYamlTab: React.FC = () => {
   }
 
   return (
-    <Flex className="pf-v5-u-py-lg">
+    <Flex className="release-yaml-tab">
       <YAMLCodeEditor code={release} />
     </Flex>
   );

--- a/src/components/Releases/__tests__/ReleaseYamlTab.spec.tsx
+++ b/src/components/Releases/__tests__/ReleaseYamlTab.spec.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { stringify as yamlStringify } from 'yaml';
+import { useRelease } from '../../../hooks/useReleases';
+import { mockedSwaggerDefinitions } from '../../../shared/components/code-editor/__data__/mock-data';
+import { useSwaggerDefinitions } from '../../../shared/components/code-editor/hooks/useSwaggerDefinitions';
+import { renderWithQueryClient } from '../../../unit-test-utils';
+import { mockUseNamespaceHook } from '../../../unit-test-utils/mock-namespace';
+import { mockReleases } from '../__data__/mock-release-data';
+import { ReleaseYamlTab } from '../ReleaseYamlTab';
+
+jest.mock('react-router-dom', () => ({
+  Link: (props) => <a href={props.to}>{props.children}</a>,
+  useParams: () => ({ releaseName: 'test-release' }),
+}));
+
+jest.mock('../../../hooks/useReleases', () => ({
+  useRelease: jest.fn(),
+}));
+
+jest.mock('../../../shared/components/code-editor/hooks/useSwaggerDefinitions', () => ({
+  useSwaggerDefinitions: jest.fn(),
+}));
+
+jest.mock('../../../shared/components/code-editor/monaco', () => ({
+  registerYAMLinMonaco: jest.fn(),
+}));
+
+jest.mock('@patternfly/react-code-editor', () => ({
+  CodeEditor: (props) => {
+    React.useEffect(() => {
+      props.onEditorDidMount?.({}, {});
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return <pre data-test="mock-editor">{props.code}</pre>;
+  },
+  Language: { yaml: 'yaml', json: 'json' },
+  EditorDidMount: jest.fn(),
+}));
+
+const mockUseRelease = useRelease as jest.Mock;
+const useNamespaceMock = mockUseNamespaceHook('my-ns');
+
+describe('ReleaseYamlTab', () => {
+  beforeEach(() => {
+    useNamespaceMock.mockReturnValue('my-ns');
+
+    (useSwaggerDefinitions as jest.Mock).mockReturnValue({
+      data: mockedSwaggerDefinitions,
+      isLoading: false,
+    });
+  });
+
+  it('should render loading indicator', () => {
+    mockUseRelease.mockReturnValue([mockReleases[0], false]);
+
+    renderWithQueryClient(<ReleaseYamlTab />);
+
+    expect(screen.getByRole('progressbar')).toBeVisible();
+  });
+
+  it('should render correct YAML content', () => {
+    const release = mockReleases[0];
+    mockUseRelease.mockReturnValue([release, true, undefined]);
+
+    renderWithQueryClient(<ReleaseYamlTab />);
+
+    const expectedYaml = yamlStringify(release);
+    const editorContent = screen.getByTestId('mock-editor').textContent;
+    expect(editorContent?.replace(/\s+/g, '')).toEqual(expectedYaml.replace(/\s+/g, ''));
+  });
+
+  it('should render error state when release fetch fails', () => {
+    const error = new Error('Failed to fetch release');
+    mockUseRelease.mockReturnValue([null, true, error]);
+
+    renderWithQueryClient(<ReleaseYamlTab />);
+
+    expect(screen.getByText(/Unable to load release/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/Releases/__tests__/ReleaseYamlTab.spec.tsx
+++ b/src/components/Releases/__tests__/ReleaseYamlTab.spec.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { stringify as yamlStringify } from 'yaml';
-import { useRelease } from '../../../hooks/useReleases';
-import { mockedSwaggerDefinitions } from '../../../shared/components/code-editor/__data__/mock-data';
-import { useSwaggerDefinitions } from '../../../shared/components/code-editor/hooks/useSwaggerDefinitions';
-import { renderWithQueryClient } from '../../../unit-test-utils';
-import { mockUseNamespaceHook } from '../../../unit-test-utils/mock-namespace';
+import { useRelease } from '~/hooks/useReleases';
+import { mockedSwaggerDefinitions } from '~/shared/components/code-editor/__data__/mock-data';
+import { useSwaggerDefinitions } from '~/shared/components/code-editor/hooks/useSwaggerDefinitions';
+import { renderWithQueryClient } from '~/unit-test-utils';
+import { mockUseNamespaceHook } from '~/unit-test-utils/mock-namespace';
 import { mockReleases } from '../__data__/mock-release-data';
 import { ReleaseYamlTab } from '../ReleaseYamlTab';
 
@@ -14,15 +14,15 @@ jest.mock('react-router-dom', () => ({
   useParams: () => ({ releaseName: 'test-release' }),
 }));
 
-jest.mock('../../../hooks/useReleases', () => ({
+jest.mock('~/hooks/useReleases', () => ({
   useRelease: jest.fn(),
 }));
 
-jest.mock('../../../shared/components/code-editor/hooks/useSwaggerDefinitions', () => ({
+jest.mock('~/shared/components/code-editor/hooks/useSwaggerDefinitions', () => ({
   useSwaggerDefinitions: jest.fn(),
 }));
 
-jest.mock('../../../shared/components/code-editor/monaco', () => ({
+jest.mock('~/shared/components/code-editor/monaco', () => ({
   registerYAMLinMonaco: jest.fn(),
 }));
 

--- a/src/routes/page-routes/__tests__/release.spec.tsx
+++ b/src/routes/page-routes/__tests__/release.spec.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { APPLICATION_RELEASE_DETAILS_PATH } from '../../paths';
+import releaseRoutes from '../release';
+
+jest.mock('../../../components/Releases', () => ({
+  ReleaseDetailsLayout: () => <div>ReleaseDetailsLayout</div>,
+  ReleaseOverviewTab: () => <div>ReleaseOverviewTab</div>,
+  ReleasePipelineRunTab: () => <div>ReleasePipelineRunTab</div>,
+  releaseListViewTabLoader: jest.fn(),
+}));
+
+jest.mock('../../../components/Releases/ReleaseArtifactsTab', () => {
+  return function ReleaseArtifactsTab() {
+    return <div>ReleaseArtifactsTab</div>;
+  };
+});
+
+jest.mock('../../../components/Releases/ReleaseYamlTab', () => ({
+  ReleaseYamlTab: () => <div>ReleaseYamlTab</div>,
+}));
+
+describe('Release Routes Configuration', () => {
+  it('should export an array of routes', () => {
+    expect(Array.isArray(releaseRoutes)).toBe(true);
+    expect(releaseRoutes).toHaveLength(1);
+  });
+
+  describe('main release route', () => {
+    let mainRoute: {
+      path: string;
+      loader: unknown;
+      errorElement: JSX.Element;
+      element: JSX.Element;
+      children: Array<{
+        path?: string;
+        index?: boolean;
+        element?: JSX.Element;
+        lazy?: () => Promise<{ element: JSX.Element }>;
+      }>;
+    };
+
+    beforeEach(() => {
+      [mainRoute] = releaseRoutes;
+    });
+
+    it('should have correct path', () => {
+      expect(mainRoute.path).toBe(APPLICATION_RELEASE_DETAILS_PATH.path);
+    });
+
+    it('should have loader function', () => {
+      expect(typeof mainRoute.loader).toBe('function');
+    });
+
+    it('should have error element', () => {
+      expect(mainRoute.errorElement).toBeDefined();
+      expect(React.isValidElement(mainRoute.errorElement)).toBe(true);
+    });
+
+    it('should have children routes', () => {
+      expect(Array.isArray(mainRoute.children)).toBe(true);
+      expect(mainRoute.children).toHaveLength(4);
+    });
+
+    it('should have overview tab as index route', () => {
+      const overviewRoute = mainRoute.children.find((child) => child.index === true);
+      expect(overviewRoute).toBeDefined();
+      expect(overviewRoute?.element).toBeDefined();
+      expect(React.isValidElement(overviewRoute?.element)).toBe(true);
+    });
+
+    it('should have pipelineruns child route', () => {
+      const pipelinerunsRoute = mainRoute.children.find((child) => child.path === 'pipelineruns');
+      expect(pipelinerunsRoute).toBeDefined();
+      expect(pipelinerunsRoute?.element).toBeDefined();
+      expect(React.isValidElement(pipelinerunsRoute?.element)).toBe(true);
+    });
+
+    it('should have artifacts child route', () => {
+      const artifactsRoute = mainRoute.children.find((child) => child.path === 'artifacts');
+      expect(artifactsRoute).toBeDefined();
+      expect(artifactsRoute?.path).toBe('artifacts');
+      expect(artifactsRoute?.element).toBeDefined();
+      expect(React.isValidElement(artifactsRoute?.element)).toBe(true);
+    });
+
+    it('should have yaml child route with lazy loading', async () => {
+      const yamlRoute = mainRoute.children.find((child) => child.path === 'yaml');
+      expect(yamlRoute).toBeDefined();
+      expect(typeof yamlRoute?.lazy).toBe('function');
+
+      const lazyResult = await yamlRoute?.lazy?.();
+      expect(lazyResult).toBeDefined();
+      expect(lazyResult).toHaveProperty('element');
+      expect(React.isValidElement(lazyResult?.element)).toBe(true);
+    });
+
+    it('should have all route elements defined', () => {
+      // eslint-disable-next-line @typescript-eslint/no-shadow
+      const [mainRoute] = releaseRoutes;
+      expect(mainRoute.element).toBeDefined();
+      expect(React.isValidElement(mainRoute.element)).toBe(true);
+      expect(mainRoute.errorElement).toBeDefined();
+      expect(React.isValidElement(mainRoute.errorElement)).toBe(true);
+    });
+  });
+});

--- a/src/routes/page-routes/release.tsx
+++ b/src/routes/page-routes/release.tsx
@@ -33,6 +33,13 @@ const releaseRoutes = [
         path: 'artifacts',
         element: <ReleaseArtifactsTab />,
       },
+      {
+        path: 'yaml',
+        async lazy() {
+          const { ReleaseYamlTab } = await import('../../components/Releases/ReleaseYamlTab');
+          return { element: <ReleaseYamlTab /> };
+        },
+      },
     ],
   },
 ];

--- a/src/shared/components/code-editor/CodeEditor.tsx
+++ b/src/shared/components/code-editor/CodeEditor.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { loader } from '@monaco-editor/react';
+import {
+  CodeEditor as PatternFlyCodeEditor,
+  Language,
+  EditorDidMount,
+  CodeEditorProps,
+} from '@patternfly/react-code-editor';
+import { Flex, FlexItem, type PopoverProps } from '@patternfly/react-core';
+import * as monacoConfig from 'monaco-editor/esm/vs/editor/editor.api';
+import {
+  KeyboardShortcutHint,
+  type ShortcutEntry,
+} from '~/shared/components/keyboard-shortcut-hint/KeyboardShortcutHint';
+
+loader.config({ monaco: monacoConfig });
+
+const CODE_EDITOR_SHORTCUTS: ShortcutEntry[] = [
+  { keys: 'F1', macKeys: 'Fn+F1', description: 'View all editor shortcuts' },
+  { keys: 'Hover', description: 'View property descriptions' },
+];
+
+const shortcutsPopoverProps: PopoverProps = {
+  'aria-label': 'Shortcuts',
+  bodyContent: <KeyboardShortcutHint shortcuts={CODE_EDITOR_SHORTCUTS} />,
+  maxWidth: '25rem',
+  distance: 18,
+};
+
+export type Props = {
+  code: string;
+  language?: Language;
+  height?: CodeEditorProps['height'];
+  showShortcuts?: boolean;
+  onEditorDidMount: EditorDidMount;
+};
+
+export const CodeEditor: React.FC<Props> = ({
+  code,
+  height = '500px',
+  showShortcuts = true,
+  language = Language.yaml,
+  onEditorDidMount,
+}) => {
+  return (
+    <Flex flex={{ default: 'flex_1' }}>
+      <FlexItem flex={{ default: 'flex_1' }}>
+        <PatternFlyCodeEditor
+          language={language}
+          code={code}
+          options={{
+            readOnly: true,
+          }}
+          onEditorDidMount={onEditorDidMount}
+          isDarkTheme
+          height={height}
+          shortcutsPopoverProps={showShortcuts ? shortcutsPopoverProps : undefined}
+        />
+      </FlexItem>
+    </Flex>
+  );
+};

--- a/src/shared/components/code-editor/YAMLCodeEditor.tsx
+++ b/src/shared/components/code-editor/YAMLCodeEditor.tsx
@@ -43,7 +43,6 @@ export const YAMLCodeEditor: React.FC<Props> = ({ code, ...props }) => {
   return (
     <CodeEditor
       {...props}
-      data-test="monaco-editor"
       language={Language.yaml}
       code={yamlStringify(code ?? {})}
       onEditorDidMount={(_, monaco) => handleEditorDidMount(monaco)}

--- a/src/shared/components/code-editor/YAMLCodeEditor.tsx
+++ b/src/shared/components/code-editor/YAMLCodeEditor.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import type { Monaco } from '@monaco-editor/react';
 import { Language } from '@patternfly/react-code-editor';
-import { Bullseye, Spinner } from '@patternfly/react-core';
 import { stringify as yamlStringify } from 'yaml';
-import { getErrorState } from '~/shared/utils/error-utils';
 import { CodeEditor, type Props as CodeEditorProps } from './CodeEditor';
 import { useSwaggerDefinitions } from './hooks/useSwaggerDefinitions';
 import { registerYAMLinMonaco } from './monaco';
@@ -13,7 +11,7 @@ type Props = Omit<CodeEditorProps, 'code' | 'onEditorDidMount'> & {
 };
 
 export const YAMLCodeEditor: React.FC<Props> = ({ code, ...props }) => {
-  const { data: swaggerDefinitions, isLoading, error } = useSwaggerDefinitions();
+  const { data: swaggerDefinitions } = useSwaggerDefinitions();
 
   const [monacoInstance, setMonacoInstance] = React.useState<Monaco | null>(null);
 
@@ -27,18 +25,6 @@ export const YAMLCodeEditor: React.FC<Props> = ({ code, ...props }) => {
       registerYAMLinMonaco(monacoInstance, swaggerDefinitions);
     }
   }, [monacoInstance, swaggerDefinitions]);
-
-  if (isLoading) {
-    return (
-      <Bullseye>
-        <Spinner size="lg" />
-      </Bullseye>
-    );
-  }
-
-  if (error) {
-    return getErrorState(error, !isLoading, 'yaml code editor');
-  }
 
   return (
     <CodeEditor

--- a/src/shared/components/code-editor/YAMLCodeEditor.tsx
+++ b/src/shared/components/code-editor/YAMLCodeEditor.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import type { Monaco } from '@monaco-editor/react';
+import { Language } from '@patternfly/react-code-editor';
+import { Bullseye, Spinner } from '@patternfly/react-core';
+import { stringify as yamlStringify } from 'yaml';
+import { getErrorState } from '~/shared/utils/error-utils';
+import { CodeEditor, type Props as CodeEditorProps } from './CodeEditor';
+import { useSwaggerDefinitions } from './hooks/useSwaggerDefinitions';
+import { registerYAMLinMonaco } from './monaco';
+
+type Props = Omit<CodeEditorProps, 'code' | 'onEditorDidMount'> & {
+  code: Record<string, unknown> | undefined;
+};
+
+export const YAMLCodeEditor: React.FC<Props> = ({ code, ...props }) => {
+  const { data: swaggerDefinitions, isLoading, error } = useSwaggerDefinitions();
+
+  const [monacoInstance, setMonacoInstance] = React.useState<Monaco | null>(null);
+
+  const handleEditorDidMount = (monaco: Monaco) => {
+    if (!monaco) return;
+    setMonacoInstance(monaco);
+  };
+
+  React.useEffect(() => {
+    if (monacoInstance && swaggerDefinitions) {
+      registerYAMLinMonaco(monacoInstance, swaggerDefinitions);
+    }
+  }, [monacoInstance, swaggerDefinitions]);
+
+  if (isLoading) {
+    return (
+      <Bullseye>
+        <Spinner size="lg" />
+      </Bullseye>
+    );
+  }
+
+  if (error) {
+    return getErrorState(error, !isLoading, 'yaml code editor');
+  }
+
+  return (
+    <CodeEditor
+      {...props}
+      data-test="monaco-editor"
+      language={Language.yaml}
+      code={yamlStringify(code ?? {})}
+      onEditorDidMount={(_, monaco) => handleEditorDidMount(monaco)}
+    />
+  );
+};

--- a/src/shared/components/code-editor/__data__/mock-data.ts
+++ b/src/shared/components/code-editor/__data__/mock-data.ts
@@ -1,0 +1,188 @@
+import { OpenAPISchemaDefinitions } from '../types';
+
+export const mockedSwaggerDefinitions: OpenAPISchemaDefinitions = {
+  'com.coreos.dex.v1.AuthCode': {
+    type: 'object',
+    'x-kubernetes-group-version-kind': [
+      {
+        group: 'dex.coreos.com',
+        kind: 'AuthCode',
+        version: 'v1',
+      },
+    ],
+  },
+  'com.coreos.dex.v1.AuthCodeList': {
+    description: 'AuthCodeList is a list of AuthCode',
+    type: 'object',
+    required: ['items'],
+    properties: {
+      apiVersion: {
+        description: 'APIVersion defines the versioned schema of this representation of an object.',
+        type: 'string',
+        example: 'dex.coreos.com/v1',
+      },
+      items: {
+        description: 'List of authcodes.',
+        type: 'array',
+        items: {
+          $ref: '#/definitions/com.coreos.dex.v1.AuthCode',
+        },
+        example: [
+          {
+            apiVersion: 'dex.coreos.com/v1',
+            kind: 'AuthCode',
+            metadata: {
+              name: 'mock-authcode',
+            },
+          },
+        ],
+      },
+      kind: {
+        description: 'Kind is a string value representing the REST resource.',
+        type: 'string',
+        example: 'AuthCodeList',
+      },
+      metadata: {
+        description: 'Standard list metadata.',
+        $ref: '#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta',
+        example: {
+          resourceVersion: '123',
+          selfLink: '/apis/dex.coreos.com/v1/authcodes',
+        },
+      },
+    },
+    'x-kubernetes-group-version-kind': [
+      {
+        group: 'dex.coreos.com',
+        kind: 'AuthCodeList',
+        version: 'v1',
+      },
+    ],
+  },
+  'com.coreos.dex.v1.AuthRequest': {
+    type: 'object',
+    'x-kubernetes-group-version-kind': [
+      {
+        group: 'dex.coreos.com',
+        kind: 'AuthRequest',
+        version: 'v1',
+      },
+    ],
+  },
+  'com.coreos.dex.v1.AuthRequestList': {
+    description: 'AuthRequestList is a list of AuthRequest',
+    type: 'object',
+    required: ['items'],
+    properties: {
+      apiVersion: {
+        description: 'APIVersion defines the versioned schema.',
+        type: 'string',
+        example: 'dex.coreos.com/v1',
+      },
+      items: {
+        description: 'List of authrequests.',
+        type: 'array',
+        items: {
+          $ref: '#/definitions/com.coreos.dex.v1.AuthRequest',
+        },
+        example: [
+          {
+            apiVersion: 'dex.coreos.com/v1',
+            kind: 'AuthRequest',
+            metadata: {
+              name: 'mock-authrequest',
+            },
+          },
+        ],
+      },
+      kind: {
+        description: 'Kind is a string value.',
+        type: 'string',
+        example: 'AuthRequestList',
+      },
+      metadata: {
+        description: 'Standard list metadata.',
+        $ref: '#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta',
+        example: {
+          resourceVersion: '456',
+          selfLink: '/apis/dex.coreos.com/v1/authrequests',
+        },
+      },
+    },
+    'x-kubernetes-group-version-kind': [
+      {
+        group: 'dex.coreos.com',
+        kind: 'AuthRequestList',
+        version: 'v1',
+      },
+    ],
+  },
+  'com.coreos.dex.v1.Connector': {
+    type: 'object',
+    'x-kubernetes-group-version-kind': [
+      {
+        group: 'dex.coreos.com',
+        kind: 'Connector',
+        version: 'v1',
+      },
+    ],
+  },
+  'com.coreos.dex.v1.ConnectorList': {
+    description: 'ConnectorList is a list of Connector',
+    type: 'object',
+    required: ['items'],
+    properties: {
+      apiVersion: {
+        description: 'APIVersion defines the versioned schema.',
+        type: 'string',
+        example: 'dex.coreos.com/v1',
+      },
+      items: {
+        description: 'List of connectors.',
+        type: 'array',
+        items: {
+          $ref: '#/definitions/com.coreos.dex.v1.Connector',
+        },
+        example: [
+          {
+            apiVersion: 'dex.coreos.com/v1',
+            kind: 'Connector',
+            metadata: {
+              name: 'mock-connector',
+            },
+          },
+        ],
+      },
+      kind: {
+        description: 'Kind is a string value.',
+        type: 'string',
+        example: 'ConnectorList',
+      },
+      metadata: {
+        description: 'Standard list metadata.',
+        $ref: '#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta',
+        example: {
+          resourceVersion: '789',
+          selfLink: '/apis/dex.coreos.com/v1/connectors',
+        },
+      },
+    },
+    'x-kubernetes-group-version-kind': [
+      {
+        group: 'dex.coreos.com',
+        kind: 'ConnectorList',
+        version: 'v1',
+      },
+    ],
+  },
+  'com.coreos.dex.v1.DeviceRequest': {
+    type: 'object',
+    'x-kubernetes-group-version-kind': [
+      {
+        group: 'dex.coreos.com',
+        kind: 'DeviceRequest',
+        version: 'v1',
+      },
+    ],
+  },
+};

--- a/src/shared/components/code-editor/__tests__/CodeEditor.spec.tsx
+++ b/src/shared/components/code-editor/__tests__/CodeEditor.spec.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { Language } from '@patternfly/react-code-editor';
+import { render, screen } from '@testing-library/react';
+import { CodeEditor } from '../CodeEditor';
+
+jest.mock('monaco-editor/esm/vs/editor/editor.api', () => ({
+  // Providing a minimal mock object to satisfy the shape expected by loader.config
+  editor: {},
+  languages: {},
+}));
+
+jest.mock('@monaco-editor/react', () => {
+  const original = jest.requireActual('@monaco-editor/react');
+  return {
+    ...original,
+    loader: {
+      config: jest.fn(),
+    },
+  };
+});
+
+let capturedProps: Record<string, unknown> = {};
+
+// The mock needs to be defined BEFORE the import of CodeEditor
+jest.mock('@patternfly/react-code-editor', () => {
+  const original = jest.requireActual('@patternfly/react-code-editor');
+
+  const MockPatternFlyCodeEditor = (props) => {
+    // Capture props to assert against them later
+    capturedProps = props;
+
+    // Immediately run onEditorDidMount to satisfy test requirements
+    React.useEffect(() => {
+      props.onEditorDidMount?.({}, {});
+    }, [props, props.onEditorDidMount]);
+
+    // Render a simple element for testing content
+    return <pre data-test="mock-editor">{props.code}</pre>;
+  };
+  MockPatternFlyCodeEditor.displayName = 'PatternFlyCodeEditor';
+
+  return {
+    ...original, // Keep Language and other exports
+    CodeEditor: MockPatternFlyCodeEditor,
+    EditorDidMount: original.EditorDidMount,
+  };
+});
+
+describe('CodeEditor', () => {
+  const mockOnEditorDidMount = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedProps = {};
+  });
+
+  it('should render the editor with the correct code', () => {
+    const code = 'application: test-app';
+    render(<CodeEditor code={code} onEditorDidMount={mockOnEditorDidMount} />);
+
+    const editorContent = screen.getByTestId('mock-editor');
+    expect(editorContent).toHaveTextContent(code);
+  });
+
+  it('should trigger onEditorDidMount when the editor is mounted', () => {
+    render(<CodeEditor code="application: test-app" onEditorDidMount={mockOnEditorDidMount} />);
+
+    expect(mockOnEditorDidMount).toHaveBeenCalled();
+  });
+
+  it('should use default prop values when not provided', () => {
+    render(<CodeEditor code="test" onEditorDidMount={mockOnEditorDidMount} />);
+
+    expect(capturedProps.language).toBe(Language.yaml);
+    expect(capturedProps.height).toBe('500px');
+    expect(capturedProps.shortcutsPopoverProps).toEqual(
+      expect.objectContaining({ 'aria-label': 'Shortcuts' }),
+    );
+    expect(capturedProps.isDarkTheme).toBe(true);
+    expect(capturedProps.options).toEqual({ readOnly: true });
+  });
+
+  it('should pass custom height prop to PatternFlyCodeEditor', () => {
+    render(<CodeEditor code="test" onEditorDidMount={mockOnEditorDidMount} height="300px" />);
+
+    expect(capturedProps.height).toBe('300px');
+  });
+
+  it('should pass custom language prop to PatternFlyCodeEditor', () => {
+    render(
+      <CodeEditor code="test" onEditorDidMount={mockOnEditorDidMount} language={Language.json} />,
+    );
+
+    expect(capturedProps.language).toBe(Language.json);
+  });
+
+  it('should pass shortcutsPopoverProps when showShortcuts is true (default)', () => {
+    render(<CodeEditor code="test" onEditorDidMount={mockOnEditorDidMount} />);
+
+    expect(capturedProps.shortcutsPopoverProps).toEqual(
+      expect.objectContaining({ 'aria-label': 'Shortcuts' }),
+    );
+  });
+
+  it('should not pass shortcutsPopoverProps when showShortcuts is false', () => {
+    render(
+      <CodeEditor code="test" onEditorDidMount={mockOnEditorDidMount} showShortcuts={false} />,
+    );
+
+    expect(capturedProps.shortcutsPopoverProps).toBeUndefined();
+  });
+
+  it('should pass all required props to PatternFlyCodeEditor', () => {
+    const code = 'application: test-app';
+    render(<CodeEditor code={code} onEditorDidMount={mockOnEditorDidMount} />);
+
+    expect(capturedProps.code).toBe(code);
+    expect(capturedProps.language).toBe(Language.yaml);
+    expect(capturedProps.height).toBe('500px');
+    expect(capturedProps.onEditorDidMount).toBe(mockOnEditorDidMount);
+    expect(capturedProps.isDarkTheme).toBe(true);
+    expect(capturedProps.options).toEqual({ readOnly: true });
+  });
+
+  it('should render Flex and FlexItem structure', () => {
+    const { container } = render(
+      <CodeEditor code="test" onEditorDidMount={mockOnEditorDidMount} />,
+    );
+
+    expect(container.querySelector('.pf-v5-l-flex')).toBeInTheDocument();
+    const flexElement = container.querySelector('.pf-v5-l-flex');
+    expect(flexElement).toBeInTheDocument();
+    expect(flexElement?.children.length).toBeGreaterThan(0);
+  });
+
+  it('should handle all props together', () => {
+    const code = 'test: value';
+    render(
+      <CodeEditor
+        code={code}
+        onEditorDidMount={mockOnEditorDidMount}
+        height="400px"
+        language={Language.json}
+        showShortcuts={true}
+      />,
+    );
+
+    expect(capturedProps.code).toBe(code);
+    expect(capturedProps.height).toBe('400px');
+    expect(capturedProps.language).toBe(Language.json);
+    expect(capturedProps.shortcutsPopoverProps).toEqual(
+      expect.objectContaining({ 'aria-label': 'Shortcuts' }),
+    );
+    expect(capturedProps.isDarkTheme).toBe(true);
+  });
+
+  it('should render with showShortcuts explicitly set to true', () => {
+    render(<CodeEditor code="test" onEditorDidMount={mockOnEditorDidMount} showShortcuts={true} />);
+
+    expect(capturedProps.shortcutsPopoverProps).toEqual(
+      expect.objectContaining({ 'aria-label': 'Shortcuts' }),
+    );
+  });
+});

--- a/src/shared/components/code-editor/__tests__/YAMLCodeEditor.spec.tsx
+++ b/src/shared/components/code-editor/__tests__/YAMLCodeEditor.spec.tsx
@@ -1,0 +1,217 @@
+import React from 'react';
+import type { Monaco } from '@monaco-editor/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { mockedSwaggerDefinitions } from '../__data__/mock-data';
+import { useSwaggerDefinitions } from '../hooks/useSwaggerDefinitions';
+import { registerYAMLinMonaco } from '../monaco';
+import { YAMLCodeEditor } from '../YAMLCodeEditor';
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: jest.fn(() => jest.fn()),
+  };
+});
+
+const mockMonaco: Monaco = {
+  languages: {
+    getLanguages: () => [{ id: 'yaml' }],
+  },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any;
+
+jest.mock('@monaco-editor/react', () => ({
+  loader: {
+    config: jest.fn(),
+    init: jest.fn().mockResolvedValue({}),
+  },
+  default: (props) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    React.useEffect(() => {
+      props.onMount?.({}, mockMonaco);
+    }, [props]);
+    return <div data-test="monaco-editor">{props.value}</div>;
+  },
+}));
+
+jest.mock('../hooks/useSwaggerDefinitions', () => ({
+  useSwaggerDefinitions: jest.fn(),
+}));
+
+jest.mock('../monaco', () => ({
+  registerYAMLinMonaco: jest.fn(),
+}));
+
+jest.mock('@patternfly/react-code-editor', () => ({
+  CodeEditor: (props) => {
+    React.useEffect(() => {
+      props.onEditorDidMount?.({}, mockMonaco);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return <pre data-test="mock-editor">{props.code}</pre>;
+  },
+  Language: { yaml: 'yaml', json: 'json' },
+  EditorDidMount: jest.fn(),
+}));
+
+const queryClient = new QueryClient();
+
+describe('YAMLCodeEditor', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useSwaggerDefinitions as jest.Mock).mockReturnValue({
+      data: mockedSwaggerDefinitions,
+      isLoading: false,
+    });
+  });
+
+  it('should render the YAMLCodeEditor and parse code into YAML string', () => {
+    const code = { application: 'test-app' };
+    render(
+      <QueryClientProvider client={queryClient}>
+        <YAMLCodeEditor code={code} />
+      </QueryClientProvider>,
+    );
+
+    const editor = screen.getByTestId('mock-editor');
+    expect(editor).toHaveTextContent('application: test-app');
+  });
+
+  it('should show loading spinner when definitions are loading', () => {
+    (useSwaggerDefinitions as jest.Mock).mockReturnValue({
+      data: null,
+      isLoading: true,
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <YAMLCodeEditor code={undefined} />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByRole('progressbar')).toBeVisible();
+  });
+
+  it('should register YAML schema with Monaco', async () => {
+    const code = { application: 'test-app' };
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <YAMLCodeEditor code={code} />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(registerYAMLinMonaco).toHaveBeenCalled();
+    });
+  });
+
+  it('should handle empty code gracefully', () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <YAMLCodeEditor code={undefined} />
+      </QueryClientProvider>,
+    );
+
+    const editor = screen.getByTestId('mock-editor');
+    expect(editor).toHaveTextContent('{}');
+  });
+
+  it('should handle swagger definitions fetch error gracefully', () => {
+    (useSwaggerDefinitions as jest.Mock).mockReturnValue({
+      data: null,
+      isLoading: false,
+      isError: true,
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <YAMLCodeEditor code={{ application: 'test-app' }} />
+      </QueryClientProvider>,
+    );
+
+    const editor = screen.getByTestId('mock-editor');
+    expect(editor).toBeInTheDocument();
+    expect(registerYAMLinMonaco).not.toHaveBeenCalled();
+  });
+
+  describe('error state handling', () => {
+    it('should display error state when useSwaggerDefinitions returns an error', () => {
+      const errorObject = new Error('Something went wrong');
+      (useSwaggerDefinitions as jest.Mock).mockReturnValue({
+        data: null,
+        isLoading: false,
+        error: errorObject,
+      });
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <YAMLCodeEditor code={{ application: 'test-app' }} />
+        </QueryClientProvider>,
+      );
+
+      expect(screen.getByText('Unable to load yaml code editor')).toBeInTheDocument();
+      expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+      expect(screen.queryByTestId('mock-editor')).not.toBeInTheDocument();
+      expect(registerYAMLinMonaco).not.toHaveBeenCalled();
+    });
+
+    it('should display error state with 404 error code', () => {
+      const error404 = { code: 404 };
+      (useSwaggerDefinitions as jest.Mock).mockReturnValue({
+        data: null,
+        isLoading: false,
+        error: error404,
+      });
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <YAMLCodeEditor code={{ application: 'test-app' }} />
+        </QueryClientProvider>,
+      );
+
+      // 404 errors show NotFoundEmptyState instead
+      expect(screen.getByText('404: Page not found')).toBeInTheDocument();
+      expect(screen.queryByTestId('mock-editor')).not.toBeInTheDocument();
+      expect(registerYAMLinMonaco).not.toHaveBeenCalled();
+    });
+
+    it('should not display error state when loading', () => {
+      const errorWithCode = { code: 500, message: 'Internal Server Error' };
+      (useSwaggerDefinitions as jest.Mock).mockReturnValue({
+        data: null,
+        isLoading: true,
+        error: errorWithCode,
+      });
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <YAMLCodeEditor code={{ application: 'test-app' }} />
+        </QueryClientProvider>,
+      );
+
+      // Should show loading spinner, not error state
+      expect(screen.getByRole('progressbar')).toBeVisible();
+      expect(screen.queryByText('Unable to load yaml code editor')).not.toBeInTheDocument();
+    });
+
+    it('should not display error state when there is no error', () => {
+      (useSwaggerDefinitions as jest.Mock).mockReturnValue({
+        data: mockedSwaggerDefinitions,
+        isLoading: false,
+        error: null,
+      });
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <YAMLCodeEditor code={{ application: 'test-app' }} />
+        </QueryClientProvider>,
+      );
+
+      expect(screen.queryByText('Unable to load yaml code editor')).not.toBeInTheDocument();
+      expect(screen.getByTestId('mock-editor')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/shared/components/code-editor/__tests__/YAMLCodeEditor.spec.tsx
+++ b/src/shared/components/code-editor/__tests__/YAMLCodeEditor.spec.tsx
@@ -79,21 +79,6 @@ describe('YAMLCodeEditor', () => {
     expect(editor).toHaveTextContent('application: test-app');
   });
 
-  it('should show loading spinner when definitions are loading', () => {
-    (useSwaggerDefinitions as jest.Mock).mockReturnValue({
-      data: null,
-      isLoading: true,
-    });
-
-    render(
-      <QueryClientProvider client={queryClient}>
-        <YAMLCodeEditor code={undefined} />
-      </QueryClientProvider>,
-    );
-
-    expect(screen.getByRole('progressbar')).toBeVisible();
-  });
-
   it('should register YAML schema with Monaco', async () => {
     const code = { application: 'test-app' };
 
@@ -119,11 +104,11 @@ describe('YAMLCodeEditor', () => {
     expect(editor).toHaveTextContent('{}');
   });
 
-  it('should handle swagger definitions fetch error gracefully', () => {
+  it('should render editor without schema when definitions fail to load', () => {
     (useSwaggerDefinitions as jest.Mock).mockReturnValue({
       data: null,
       isLoading: false,
-      isError: true,
+      error: new Error('fetch failed'),
     });
 
     render(
@@ -132,86 +117,23 @@ describe('YAMLCodeEditor', () => {
       </QueryClientProvider>,
     );
 
-    const editor = screen.getByTestId('mock-editor');
-    expect(editor).toBeInTheDocument();
+    expect(screen.getByTestId('mock-editor')).toBeInTheDocument();
     expect(registerYAMLinMonaco).not.toHaveBeenCalled();
   });
 
-  describe('error state handling', () => {
-    it('should display error state when useSwaggerDefinitions returns an error', () => {
-      const errorObject = new Error('Something went wrong');
-      (useSwaggerDefinitions as jest.Mock).mockReturnValue({
-        data: null,
-        isLoading: false,
-        error: errorObject,
-      });
-
-      render(
-        <QueryClientProvider client={queryClient}>
-          <YAMLCodeEditor code={{ application: 'test-app' }} />
-        </QueryClientProvider>,
-      );
-
-      expect(screen.getByText('Unable to load yaml code editor')).toBeInTheDocument();
-      expect(screen.getByText('Something went wrong')).toBeInTheDocument();
-      expect(screen.queryByTestId('mock-editor')).not.toBeInTheDocument();
-      expect(registerYAMLinMonaco).not.toHaveBeenCalled();
+  it('should render editor while definitions are still loading', () => {
+    (useSwaggerDefinitions as jest.Mock).mockReturnValue({
+      data: null,
+      isLoading: true,
     });
 
-    it('should display error state with 404 error code', () => {
-      const error404 = { code: 404 };
-      (useSwaggerDefinitions as jest.Mock).mockReturnValue({
-        data: null,
-        isLoading: false,
-        error: error404,
-      });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <YAMLCodeEditor code={{ application: 'test-app' }} />
+      </QueryClientProvider>,
+    );
 
-      render(
-        <QueryClientProvider client={queryClient}>
-          <YAMLCodeEditor code={{ application: 'test-app' }} />
-        </QueryClientProvider>,
-      );
-
-      // 404 errors show NotFoundEmptyState instead
-      expect(screen.getByText('404: Page not found')).toBeInTheDocument();
-      expect(screen.queryByTestId('mock-editor')).not.toBeInTheDocument();
-      expect(registerYAMLinMonaco).not.toHaveBeenCalled();
-    });
-
-    it('should not display error state when loading', () => {
-      const errorWithCode = { code: 500, message: 'Internal Server Error' };
-      (useSwaggerDefinitions as jest.Mock).mockReturnValue({
-        data: null,
-        isLoading: true,
-        error: errorWithCode,
-      });
-
-      render(
-        <QueryClientProvider client={queryClient}>
-          <YAMLCodeEditor code={{ application: 'test-app' }} />
-        </QueryClientProvider>,
-      );
-
-      // Should show loading spinner, not error state
-      expect(screen.getByRole('progressbar')).toBeVisible();
-      expect(screen.queryByText('Unable to load yaml code editor')).not.toBeInTheDocument();
-    });
-
-    it('should not display error state when there is no error', () => {
-      (useSwaggerDefinitions as jest.Mock).mockReturnValue({
-        data: mockedSwaggerDefinitions,
-        isLoading: false,
-        error: null,
-      });
-
-      render(
-        <QueryClientProvider client={queryClient}>
-          <YAMLCodeEditor code={{ application: 'test-app' }} />
-        </QueryClientProvider>,
-      );
-
-      expect(screen.queryByText('Unable to load yaml code editor')).not.toBeInTheDocument();
-      expect(screen.getByTestId('mock-editor')).toBeInTheDocument();
-    });
+    expect(screen.getByTestId('mock-editor')).toBeInTheDocument();
+    expect(registerYAMLinMonaco).not.toHaveBeenCalled();
   });
 });

--- a/src/shared/components/code-editor/__tests__/monaco.spec.ts
+++ b/src/shared/components/code-editor/__tests__/monaco.spec.ts
@@ -1,0 +1,165 @@
+/* eslint-disable no-console */
+import { registerYAMLinMonaco } from '../monaco';
+import { openAPItoJSONSchema } from '../openapi-to-json-schema';
+import { OpenAPISchemaDefinitions } from '../types';
+
+const mockConfigureMonacoYaml = jest.fn();
+
+jest.mock('monaco-yaml', () => ({
+  configureMonacoYaml: (...args: unknown[]) => mockConfigureMonacoYaml(...args),
+}));
+
+jest.mock('../openapi-to-json-schema', () => ({
+  openAPItoJSONSchema: jest.fn(),
+}));
+
+const mockOpenAPItoJSONSchema = openAPItoJSONSchema as jest.MockedFunction<
+  typeof openAPItoJSONSchema
+>;
+
+describe('registerYAMLinMonaco', () => {
+  const mockSwaggerDefinitions: OpenAPISchemaDefinitions = {
+    'io.k8s.api.core.v1.Pod': {
+      type: 'object',
+      properties: {
+        metadata: { type: 'object' },
+      },
+    },
+  };
+
+  const mockJSONSchema = {
+    definitions: {
+      Pod: {
+        type: 'object',
+        properties: {
+          metadata: { type: 'object' },
+        },
+      },
+    },
+    oneOf: [{ $ref: '#/definitions/Pod' }],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    console.warn = jest.fn();
+    mockOpenAPItoJSONSchema.mockReturnValue(mockJSONSchema);
+  });
+
+  it('should warn and return early when monacoInstance is undefined', () => {
+    registerYAMLinMonaco(undefined, mockSwaggerDefinitions);
+
+    expect(console.warn).toHaveBeenCalledWith('registerYAMLinMonaco: monacoInstance is undefined');
+    expect(mockConfigureMonacoYaml).not.toHaveBeenCalled();
+  });
+
+  it('should warn and return early when monacoInstance is null', () => {
+    registerYAMLinMonaco(null, mockSwaggerDefinitions);
+
+    expect(console.warn).toHaveBeenCalledWith('registerYAMLinMonaco: monacoInstance is undefined');
+    expect(mockConfigureMonacoYaml).not.toHaveBeenCalled();
+  });
+
+  it('should not register YAML when already registered (more than 1 YAML language)', () => {
+    const mockMonaco = {
+      languages: {
+        getLanguages: jest.fn().mockReturnValue([
+          { id: 'yaml' },
+          { id: 'yaml' }, // duplicate YAML language
+          { id: 'json' },
+        ]),
+      },
+    } as unknown as typeof import('monaco-editor/esm/vs/editor/editor.api');
+
+    registerYAMLinMonaco(mockMonaco, mockSwaggerDefinitions);
+
+    expect(mockConfigureMonacoYaml).not.toHaveBeenCalled();
+  });
+
+  it('should register YAML when not already registered (exactly 1 YAML language)', () => {
+    const mockMonaco = {
+      languages: {
+        getLanguages: jest.fn().mockReturnValue([
+          { id: 'yaml' }, // only default YAML
+          { id: 'json' },
+        ]),
+      },
+    } as unknown as typeof import('monaco-editor/esm/vs/editor/editor.api');
+
+    registerYAMLinMonaco(mockMonaco, mockSwaggerDefinitions);
+
+    expect(mockOpenAPItoJSONSchema).toHaveBeenCalledWith(mockSwaggerDefinitions);
+    expect(mockConfigureMonacoYaml).toHaveBeenCalledWith(mockMonaco, {
+      isKubernetes: true,
+      validate: true,
+      schemas: [
+        {
+          uri: 'inmemory:yaml',
+          fileMatch: ['*'],
+          schema: mockJSONSchema,
+        },
+      ],
+      hover: true,
+      completion: true,
+    });
+  });
+
+  it('should register YAML when no YAML language exists', () => {
+    const mockMonaco = {
+      languages: {
+        getLanguages: jest.fn().mockReturnValue([{ id: 'json' }]),
+      },
+    } as unknown as typeof import('monaco-editor/esm/vs/editor/editor.api');
+
+    registerYAMLinMonaco(mockMonaco, mockSwaggerDefinitions);
+
+    expect(mockConfigureMonacoYaml).toHaveBeenCalled();
+  });
+
+  it('should handle empty languages array', () => {
+    const mockMonaco = {
+      languages: {
+        getLanguages: jest.fn().mockReturnValue([]),
+      },
+    } as unknown as typeof import('monaco-editor/esm/vs/editor/editor.api');
+
+    registerYAMLinMonaco(mockMonaco, mockSwaggerDefinitions);
+
+    expect(mockConfigureMonacoYaml).toHaveBeenCalled();
+  });
+
+  it('should handle when languages.getLanguages returns undefined', () => {
+    const mockMonaco = {
+      languages: {
+        getLanguages: jest.fn().mockReturnValue(undefined),
+      },
+    } as unknown as typeof import('monaco-editor/esm/vs/editor/editor.api');
+
+    // should treat undefined as empty array and register YAML
+    expect(() => {
+      registerYAMLinMonaco(mockMonaco, mockSwaggerDefinitions);
+    }).not.toThrow();
+    expect(mockConfigureMonacoYaml).toHaveBeenCalled();
+  });
+
+  it('should convert swagger definitions to JSON schema before registering', () => {
+    const mockMonaco = {
+      languages: {
+        getLanguages: jest.fn().mockReturnValue([{ id: 'json' }]),
+      },
+    } as unknown as typeof import('monaco-editor/esm/vs/editor/editor.api');
+
+    registerYAMLinMonaco(mockMonaco, mockSwaggerDefinitions);
+
+    expect(mockOpenAPItoJSONSchema).toHaveBeenCalledWith(mockSwaggerDefinitions);
+    expect(mockConfigureMonacoYaml).toHaveBeenCalledWith(
+      mockMonaco,
+      expect.objectContaining({
+        schemas: [
+          expect.objectContaining({
+            schema: mockJSONSchema,
+          }),
+        ],
+      }),
+    );
+  });
+});

--- a/src/shared/components/code-editor/__tests__/monaco.spec.ts
+++ b/src/shared/components/code-editor/__tests__/monaco.spec.ts
@@ -1,6 +1,3 @@
-/* eslint-disable no-console */
-import { registerYAMLinMonaco } from '../monaco';
-import { openAPItoJSONSchema } from '../openapi-to-json-schema';
 import { OpenAPISchemaDefinitions } from '../types';
 
 const mockConfigureMonacoYaml = jest.fn();
@@ -13,81 +10,91 @@ jest.mock('../openapi-to-json-schema', () => ({
   openAPItoJSONSchema: jest.fn(),
 }));
 
-const mockOpenAPItoJSONSchema = openAPItoJSONSchema as jest.MockedFunction<
-  typeof openAPItoJSONSchema
->;
+jest.mock('~/monitoring/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn() },
+}));
 
-describe('registerYAMLinMonaco', () => {
-  const mockSwaggerDefinitions: OpenAPISchemaDefinitions = {
-    'io.k8s.api.core.v1.Pod': {
+const mockSwaggerDefinitions: OpenAPISchemaDefinitions = {
+  'io.k8s.api.core.v1.Pod': {
+    type: 'object',
+    properties: {
+      metadata: { type: 'object' },
+    },
+  },
+};
+
+const mockJSONSchema = {
+  definitions: {
+    Pod: {
       type: 'object',
       properties: {
         metadata: { type: 'object' },
       },
     },
-  };
+  },
+  oneOf: [{ $ref: '#/definitions/Pod' }],
+};
 
-  const mockJSONSchema = {
-    definitions: {
-      Pod: {
-        type: 'object',
-        properties: {
-          metadata: { type: 'object' },
-        },
-      },
+const createMockMonaco = () =>
+  ({
+    languages: {
+      getLanguages: jest.fn().mockReturnValue([{ id: 'yaml' }]),
     },
-    oneOf: [{ $ref: '#/definitions/Pod' }],
-  };
+  }) as unknown as typeof import('monaco-editor/esm/vs/editor/editor.api');
 
+describe('registerYAMLinMonaco', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    console.warn = jest.fn();
-    mockOpenAPItoJSONSchema.mockReturnValue(mockJSONSchema);
   });
 
+  const loadFreshModule = () => {
+    const result = {} as {
+      registerYAMLinMonaco: typeof import('../monaco').registerYAMLinMonaco;
+      openAPItoJSONSchema: jest.Mock;
+      logger: { warn: jest.Mock };
+    };
+
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+      const monacoModule = require('../monaco');
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+      const schemaModule = require('../openapi-to-json-schema');
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+      const loggerModule = require('~/monitoring/logger');
+      result.registerYAMLinMonaco = monacoModule.registerYAMLinMonaco;
+      result.openAPItoJSONSchema = schemaModule.openAPItoJSONSchema;
+      result.logger = loggerModule.logger;
+    });
+
+    return result;
+  };
+
   it('should warn and return early when monacoInstance is undefined', () => {
+    const { registerYAMLinMonaco, logger } = loadFreshModule();
+
     registerYAMLinMonaco(undefined, mockSwaggerDefinitions);
 
-    expect(console.warn).toHaveBeenCalledWith('registerYAMLinMonaco: monacoInstance is undefined');
+    expect(logger.warn).toHaveBeenCalledWith('registerYAMLinMonaco: monacoInstance is undefined');
     expect(mockConfigureMonacoYaml).not.toHaveBeenCalled();
   });
 
   it('should warn and return early when monacoInstance is null', () => {
+    const { registerYAMLinMonaco, logger } = loadFreshModule();
+
     registerYAMLinMonaco(null, mockSwaggerDefinitions);
 
-    expect(console.warn).toHaveBeenCalledWith('registerYAMLinMonaco: monacoInstance is undefined');
+    expect(logger.warn).toHaveBeenCalledWith('registerYAMLinMonaco: monacoInstance is undefined');
     expect(mockConfigureMonacoYaml).not.toHaveBeenCalled();
   });
 
-  it('should not register YAML when already registered (more than 1 YAML language)', () => {
-    const mockMonaco = {
-      languages: {
-        getLanguages: jest.fn().mockReturnValue([
-          { id: 'yaml' },
-          { id: 'yaml' }, // duplicate YAML language
-          { id: 'json' },
-        ]),
-      },
-    } as unknown as typeof import('monaco-editor/esm/vs/editor/editor.api');
+  it('should register YAML schema on first call', () => {
+    const { registerYAMLinMonaco, openAPItoJSONSchema } = loadFreshModule();
+    openAPItoJSONSchema.mockReturnValue(mockJSONSchema);
+    const mockMonaco = createMockMonaco();
 
     registerYAMLinMonaco(mockMonaco, mockSwaggerDefinitions);
 
-    expect(mockConfigureMonacoYaml).not.toHaveBeenCalled();
-  });
-
-  it('should register YAML when not already registered (exactly 1 YAML language)', () => {
-    const mockMonaco = {
-      languages: {
-        getLanguages: jest.fn().mockReturnValue([
-          { id: 'yaml' }, // only default YAML
-          { id: 'json' },
-        ]),
-      },
-    } as unknown as typeof import('monaco-editor/esm/vs/editor/editor.api');
-
-    registerYAMLinMonaco(mockMonaco, mockSwaggerDefinitions);
-
-    expect(mockOpenAPItoJSONSchema).toHaveBeenCalledWith(mockSwaggerDefinitions);
+    expect(openAPItoJSONSchema).toHaveBeenCalledWith(mockSwaggerDefinitions);
     expect(mockConfigureMonacoYaml).toHaveBeenCalledWith(mockMonaco, {
       isKubernetes: true,
       validate: true,
@@ -103,63 +110,16 @@ describe('registerYAMLinMonaco', () => {
     });
   });
 
-  it('should register YAML when no YAML language exists', () => {
-    const mockMonaco = {
-      languages: {
-        getLanguages: jest.fn().mockReturnValue([{ id: 'json' }]),
-      },
-    } as unknown as typeof import('monaco-editor/esm/vs/editor/editor.api');
+  it('should not register YAML schema on subsequent calls', () => {
+    const { registerYAMLinMonaco, openAPItoJSONSchema } = loadFreshModule();
+    openAPItoJSONSchema.mockReturnValue(mockJSONSchema);
+    const mockMonaco = createMockMonaco();
 
     registerYAMLinMonaco(mockMonaco, mockSwaggerDefinitions);
+    expect(mockConfigureMonacoYaml).toHaveBeenCalledTimes(1);
 
-    expect(mockConfigureMonacoYaml).toHaveBeenCalled();
-  });
-
-  it('should handle empty languages array', () => {
-    const mockMonaco = {
-      languages: {
-        getLanguages: jest.fn().mockReturnValue([]),
-      },
-    } as unknown as typeof import('monaco-editor/esm/vs/editor/editor.api');
-
+    mockConfigureMonacoYaml.mockClear();
     registerYAMLinMonaco(mockMonaco, mockSwaggerDefinitions);
-
-    expect(mockConfigureMonacoYaml).toHaveBeenCalled();
-  });
-
-  it('should handle when languages.getLanguages returns undefined', () => {
-    const mockMonaco = {
-      languages: {
-        getLanguages: jest.fn().mockReturnValue(undefined),
-      },
-    } as unknown as typeof import('monaco-editor/esm/vs/editor/editor.api');
-
-    // should treat undefined as empty array and register YAML
-    expect(() => {
-      registerYAMLinMonaco(mockMonaco, mockSwaggerDefinitions);
-    }).not.toThrow();
-    expect(mockConfigureMonacoYaml).toHaveBeenCalled();
-  });
-
-  it('should convert swagger definitions to JSON schema before registering', () => {
-    const mockMonaco = {
-      languages: {
-        getLanguages: jest.fn().mockReturnValue([{ id: 'json' }]),
-      },
-    } as unknown as typeof import('monaco-editor/esm/vs/editor/editor.api');
-
-    registerYAMLinMonaco(mockMonaco, mockSwaggerDefinitions);
-
-    expect(mockOpenAPItoJSONSchema).toHaveBeenCalledWith(mockSwaggerDefinitions);
-    expect(mockConfigureMonacoYaml).toHaveBeenCalledWith(
-      mockMonaco,
-      expect.objectContaining({
-        schemas: [
-          expect.objectContaining({
-            schema: mockJSONSchema,
-          }),
-        ],
-      }),
-    );
+    expect(mockConfigureMonacoYaml).not.toHaveBeenCalled();
   });
 });

--- a/src/shared/components/code-editor/__tests__/monaco.spec.ts
+++ b/src/shared/components/code-editor/__tests__/monaco.spec.ts
@@ -55,11 +55,11 @@ describe('registerYAMLinMonaco', () => {
     };
 
     jest.isolateModules(() => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
       const monacoModule = require('../monaco');
-      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
       const schemaModule = require('../openapi-to-json-schema');
-      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
       const loggerModule = require('~/monitoring/logger');
       result.registerYAMLinMonaco = monacoModule.registerYAMLinMonaco;
       result.openAPItoJSONSchema = schemaModule.openAPItoJSONSchema;

--- a/src/shared/components/code-editor/__tests__/openapi-to-json-schema.spec.ts
+++ b/src/shared/components/code-editor/__tests__/openapi-to-json-schema.spec.ts
@@ -1,0 +1,444 @@
+import { openAPItoJSONSchema } from '../openapi-to-json-schema';
+
+describe('openAPItoJSONSchema', () => {
+  it('should return null when openAPI is null', () => {
+    expect(openAPItoJSONSchema(null)).toBeNull();
+  });
+
+  it('should return null when openAPI is undefined', () => {
+    expect(openAPItoJSONSchema(undefined)).toBeNull();
+  });
+
+  it('should convert simple OpenAPI definitions to JSON Schema', () => {
+    const openAPI = {
+      'io.k8s.api.core.v1.Pod': {
+        type: 'object',
+        properties: {
+          metadata: { type: 'object' },
+        },
+      },
+    };
+
+    const result = openAPItoJSONSchema(openAPI);
+
+    expect(result).toEqual({
+      definitions: {
+        'io.k8s.api.core.v1.Pod': {
+          type: 'object',
+          properties: {
+            metadata: { type: 'object' },
+          },
+        },
+      },
+      oneOf: [
+        {
+          $ref: '#/definitions/io.k8s.api.core.v1.Pod',
+        },
+      ],
+    });
+  });
+
+  it('should convert multiple OpenAPI definitions to JSON Schema', () => {
+    const openAPI = {
+      'io.k8s.api.core.v1.Pod': {
+        type: 'object',
+        properties: {
+          metadata: { type: 'object' },
+        },
+      },
+      'io.k8s.api.core.v1.Service': {
+        type: 'object',
+        properties: {
+          spec: { type: 'object' },
+        },
+      },
+    };
+
+    const result = openAPItoJSONSchema(openAPI);
+
+    expect(result?.definitions['io.k8s.api.core.v1.Pod']).toBeDefined();
+    expect(result?.definitions['io.k8s.api.core.v1.Service']).toBeDefined();
+    expect(result?.oneOf).toHaveLength(2);
+    expect(result?.oneOf).toContainEqual({ $ref: '#/definitions/io.k8s.api.core.v1.Pod' });
+    expect(result?.oneOf).toContainEqual({ $ref: '#/definitions/io.k8s.api.core.v1.Service' });
+  });
+
+  it('should convert GroupVersionKind annotations to JSON Schema enums', () => {
+    const openAPI = {
+      'io.k8s.api.core.v1.Pod': {
+        type: 'object',
+        properties: {
+          metadata: { type: 'object' },
+        },
+        'x-kubernetes-group-version-kind': [
+          {
+            group: '',
+            version: 'v1',
+            kind: 'Pod',
+          },
+        ],
+      },
+    };
+
+    const result = openAPItoJSONSchema(openAPI);
+
+    expect(result?.definitions['io.k8s.api.core.v1.Pod'].properties.apiVersion).toEqual({
+      enum: ['v1'],
+    });
+    expect(result?.definitions['io.k8s.api.core.v1.Pod'].properties.kind).toEqual({
+      enum: ['Pod'],
+    });
+  });
+
+  it('should handle GroupVersionKind with group and version', () => {
+    const openAPI = {
+      'io.k8s.api.apps.v1.Deployment': {
+        type: 'object',
+        properties: {
+          metadata: { type: 'object' },
+        },
+        'x-kubernetes-group-version-kind': [
+          {
+            group: 'apps',
+            version: 'v1',
+            kind: 'Deployment',
+          },
+        ],
+      },
+    };
+
+    const result = openAPItoJSONSchema(openAPI);
+
+    expect(result?.definitions['io.k8s.api.apps.v1.Deployment'].properties.apiVersion).toEqual({
+      enum: ['apps/v1'],
+    });
+    expect(result?.definitions['io.k8s.api.apps.v1.Deployment'].properties.kind).toEqual({
+      enum: ['Deployment'],
+    });
+  });
+
+  it('should append to existing apiVersion enum', () => {
+    const openAPI = {
+      'io.k8s.api.core.v1.Pod': {
+        type: 'object',
+        properties: {
+          apiVersion: {
+            enum: ['v1'],
+          },
+          metadata: { type: 'object' },
+        },
+        'x-kubernetes-group-version-kind': [
+          {
+            group: 'apps',
+            version: 'v1',
+            kind: 'Pod',
+          },
+        ],
+      },
+    };
+
+    const result = openAPItoJSONSchema(openAPI);
+
+    expect(result?.definitions['io.k8s.api.core.v1.Pod'].properties.apiVersion.enum).toContain(
+      'v1',
+    );
+    expect(result?.definitions['io.k8s.api.core.v1.Pod'].properties.apiVersion.enum).toContain(
+      'apps/v1',
+    );
+  });
+
+  it('should append to existing kind enum', () => {
+    const openAPI = {
+      'io.k8s.api.core.v1.Pod': {
+        type: 'object',
+        properties: {
+          kind: {
+            enum: ['Pod'],
+          },
+          metadata: { type: 'object' },
+        },
+        'x-kubernetes-group-version-kind': [
+          {
+            group: '',
+            version: 'v1',
+            kind: 'Service',
+          },
+        ],
+      },
+    };
+
+    const result = openAPItoJSONSchema(openAPI);
+
+    expect(result?.definitions['io.k8s.api.core.v1.Pod'].properties.kind.enum).toContain('Pod');
+    expect(result?.definitions['io.k8s.api.core.v1.Pod'].properties.kind.enum).toContain('Service');
+  });
+
+  it('should handle GroupVersionKind with only version (no group)', () => {
+    const openAPI = {
+      'io.k8s.api.core.v1.Pod': {
+        type: 'object',
+        properties: {
+          metadata: { type: 'object' },
+        },
+        'x-kubernetes-group-version-kind': [
+          {
+            group: '',
+            version: 'v1',
+            kind: 'Pod',
+          },
+        ],
+      },
+    };
+
+    const result = openAPItoJSONSchema(openAPI);
+
+    expect(result?.definitions['io.k8s.api.core.v1.Pod'].properties.apiVersion.enum).toEqual([
+      'v1',
+    ]);
+  });
+
+  it('should handle multiple GroupVersionKind entries', () => {
+    const openAPI = {
+      'io.k8s.api.core.v1.Pod': {
+        type: 'object',
+        properties: {
+          metadata: { type: 'object' },
+        },
+        'x-kubernetes-group-version-kind': [
+          {
+            group: '',
+            version: 'v1',
+            kind: 'Pod',
+          },
+          {
+            group: 'apps',
+            version: 'v1',
+            kind: 'Deployment',
+          },
+        ],
+      },
+    };
+
+    const result = openAPItoJSONSchema(openAPI);
+
+    expect(result?.definitions['io.k8s.api.core.v1.Pod'].properties.apiVersion.enum).toContain(
+      'v1',
+    );
+    expect(result?.definitions['io.k8s.api.core.v1.Pod'].properties.apiVersion.enum).toContain(
+      'apps/v1',
+    );
+    expect(result?.definitions['io.k8s.api.core.v1.Pod'].properties.kind.enum).toContain('Pod');
+    expect(result?.definitions['io.k8s.api.core.v1.Pod'].properties.kind.enum).toContain(
+      'Deployment',
+    );
+  });
+
+  it('should skip definitions without properties when converting GVK', () => {
+    const openAPI = {
+      'io.k8s.api.core.v1.Pod': {
+        type: 'object',
+        'x-kubernetes-group-version-kind': [
+          {
+            group: '',
+            version: 'v1',
+            kind: 'Pod',
+          },
+        ],
+      },
+    };
+
+    const result = openAPItoJSONSchema(openAPI);
+
+    // Should not add apiVersion/kind if properties don't exist
+    expect(result?.definitions['io.k8s.api.core.v1.Pod'].properties).toBeUndefined();
+  });
+
+  it('should skip definitions without x-kubernetes-group-version-kind', () => {
+    const openAPI = {
+      'io.k8s.api.core.v1.Pod': {
+        type: 'object',
+        properties: {
+          metadata: { type: 'object' },
+        },
+      },
+    };
+
+    const result = openAPItoJSONSchema(openAPI);
+
+    expect(result?.definitions['io.k8s.api.core.v1.Pod']).toEqual({
+      type: 'object',
+      properties: {
+        metadata: { type: 'object' },
+      },
+    });
+  });
+
+  it('should handle empty OpenAPI object', () => {
+    const openAPI = {};
+
+    const result = openAPItoJSONSchema(openAPI);
+
+    expect(result).toEqual({
+      definitions: {},
+      oneOf: [],
+    });
+  });
+
+  it('should handle GroupVersionKind with only version (no group, no kind)', () => {
+    const openAPI = {
+      'io.k8s.api.core.v1.Pod': {
+        type: 'object',
+        properties: {
+          metadata: { type: 'object' },
+        },
+        'x-kubernetes-group-version-kind': [
+          {
+            group: '',
+            version: 'v1',
+            kind: '',
+          },
+        ],
+      },
+    };
+
+    const result = openAPItoJSONSchema(openAPI);
+
+    expect(result?.definitions['io.k8s.api.core.v1.Pod'].properties.apiVersion.enum).toEqual([
+      'v1',
+    ]);
+    expect(result?.definitions['io.k8s.api.core.v1.Pod'].properties.kind).toEqual({
+      enum: [],
+    });
+  });
+
+  it('should handle apiVersion without existing enum property', () => {
+    const openAPI = {
+      'io.k8s.api.core.v1.Pod': {
+        type: 'object',
+        properties: {
+          apiVersion: {
+            type: 'string',
+          },
+          metadata: { type: 'object' },
+        },
+        'x-kubernetes-group-version-kind': [
+          {
+            group: '',
+            version: 'v1',
+            kind: 'Pod',
+          },
+        ],
+      },
+    };
+
+    const result = openAPItoJSONSchema(openAPI);
+
+    expect(result?.definitions['io.k8s.api.core.v1.Pod'].properties.apiVersion.enum).toEqual([
+      'v1',
+    ]);
+  });
+
+  it('should handle kind without existing enum property', () => {
+    const openAPI = {
+      'io.k8s.api.core.v1.Pod': {
+        type: 'object',
+        properties: {
+          kind: {
+            type: 'string',
+          },
+          metadata: { type: 'object' },
+        },
+        'x-kubernetes-group-version-kind': [
+          {
+            group: '',
+            version: 'v1',
+            kind: 'Pod',
+          },
+        ],
+      },
+    };
+
+    const result = openAPItoJSONSchema(openAPI);
+
+    expect(result?.definitions['io.k8s.api.core.v1.Pod'].properties.kind.enum).toEqual(['Pod']);
+  });
+
+  it('should handle GroupVersionKind with group but no version', () => {
+    const openAPI = {
+      'io.k8s.api.core.v1.Pod': {
+        type: 'object',
+        properties: {
+          metadata: { type: 'object' },
+        },
+        'x-kubernetes-group-version-kind': [
+          {
+            group: 'apps',
+            version: '',
+            kind: 'Pod',
+          },
+        ],
+      },
+    };
+
+    const result = openAPItoJSONSchema(openAPI);
+
+    expect(result?.definitions['io.k8s.api.core.v1.Pod'].properties.apiVersion).toEqual({
+      enum: [],
+    });
+    expect(result?.definitions['io.k8s.api.core.v1.Pod'].properties.kind.enum).toEqual(['Pod']);
+  });
+
+  it('should execute createOrAppendAPIVersion when apiVersion exists', () => {
+    const openAPI = {
+      'io.k8s.api.core.v1.Pod': {
+        type: 'object',
+        properties: {
+          apiVersion: {
+            type: 'string',
+          },
+          metadata: { type: 'object' },
+        },
+        'x-kubernetes-group-version-kind': [
+          {
+            group: '',
+            version: 'v1',
+            kind: 'Pod',
+          },
+        ],
+      },
+    };
+
+    const result = openAPItoJSONSchema(openAPI);
+
+    expect(result?.definitions['io.k8s.api.core.v1.Pod'].properties.apiVersion).toBeDefined();
+    expect(result?.definitions['io.k8s.api.core.v1.Pod'].properties.apiVersion.enum).toEqual([
+      'v1',
+    ]);
+  });
+
+  it('should execute createOrAppendKind when kind exists', () => {
+    const openAPI = {
+      'io.k8s.api.core.v1.Pod': {
+        type: 'object',
+        properties: {
+          kind: {
+            type: 'string',
+          },
+          metadata: { type: 'object' },
+        },
+        'x-kubernetes-group-version-kind': [
+          {
+            group: '',
+            version: 'v1',
+            kind: 'Pod',
+          },
+        ],
+      },
+    };
+
+    const result = openAPItoJSONSchema(openAPI);
+
+    expect(result?.definitions['io.k8s.api.core.v1.Pod'].properties.kind).toBeDefined();
+    expect(result?.definitions['io.k8s.api.core.v1.Pod'].properties.kind.enum).toEqual(['Pod']);
+  });
+});

--- a/src/shared/components/code-editor/hooks/__tests__/useSwaggerDefinitions.spec.ts
+++ b/src/shared/components/code-editor/hooks/__tests__/useSwaggerDefinitions.spec.ts
@@ -1,0 +1,118 @@
+/* eslint-disable no-console */
+import * as React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createTestQueryClient } from '~/unit-test-utils/mock-react-query';
+import { OpenAPISchemaDefinitions } from '../../types';
+import { useSwaggerDefinitions } from '../useSwaggerDefinitions';
+
+const mockCommonFetch = jest.fn();
+
+jest.mock('../../../../../k8s', () => ({
+  commonFetch: (...args: unknown[]) => mockCommonFetch(...args),
+}));
+
+describe('useSwaggerDefinitions', () => {
+  let queryClient: QueryClient;
+
+  const renderHookWithQueryClient = () => {
+    return renderHook(() => useSwaggerDefinitions(), {
+      wrapper: ({ children }) =>
+        React.createElement(QueryClientProvider, { client: queryClient }, children),
+    });
+  };
+
+  beforeEach(() => {
+    queryClient = createTestQueryClient();
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('should return loading state initially', () => {
+    mockCommonFetch.mockImplementation(() => new Promise(() => {}));
+
+    const { result } = renderHookWithQueryClient();
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('should return definitions when fetch succeeds with valid data', async () => {
+    const mockDefinitions: OpenAPISchemaDefinitions = {
+      'io.k8s.api.core.v1.Pod': {
+        type: 'object',
+        properties: {
+          metadata: { type: 'object' },
+        },
+      },
+    };
+
+    const mockResponse = {
+      json: jest.fn().mockResolvedValue({ definitions: mockDefinitions }),
+    };
+
+    mockCommonFetch.mockResolvedValue(mockResponse as unknown as Response);
+
+    const { result } = renderHookWithQueryClient();
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockCommonFetch).toHaveBeenCalledWith('/openapi/v2');
+    expect(result.current.data).toEqual(mockDefinitions);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('should return null when definitions are missing in response', async () => {
+    const mockResponse = {
+      json: jest.fn().mockResolvedValue({}),
+    };
+
+    mockCommonFetch.mockResolvedValue(mockResponse as unknown as Response);
+
+    const { result } = renderHookWithQueryClient();
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toBeNull();
+    expect(console.error).toHaveBeenCalledWith(
+      '[ERROR] Definitions missing in OpenAPI response.',
+      undefined,
+      '',
+    );
+  });
+
+  it('should return null and log error when fetch fails', async () => {
+    const error = new Error('Network error');
+    mockCommonFetch.mockRejectedValue(error);
+
+    const { result } = renderHookWithQueryClient();
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toBeNull();
+    expect(console.error).toHaveBeenCalledWith(
+      '[ERROR] Could not get OpenAPI definitions',
+      error,
+      '',
+    );
+  });
+
+  it('should use correct query key and staleTime', () => {
+    mockCommonFetch.mockImplementation(() => new Promise(() => {}));
+
+    renderHookWithQueryClient();
+
+    const queryCache = queryClient.getQueryCache();
+    const queries = queryCache.getAll();
+    expect(queries).toHaveLength(1);
+    expect(queries[0].queryKey).toEqual(['swagger']);
+
+    expect((queries[0].options as { staleTime?: number }).staleTime).toBe(Infinity);
+  });
+});

--- a/src/shared/components/code-editor/hooks/__tests__/useSwaggerDefinitions.spec.ts
+++ b/src/shared/components/code-editor/hooks/__tests__/useSwaggerDefinitions.spec.ts
@@ -8,7 +8,7 @@ import { useSwaggerDefinitions } from '../useSwaggerDefinitions';
 
 const mockCommonFetch = jest.fn();
 
-jest.mock('../../../../../k8s', () => ({
+jest.mock('~/k8s', () => ({
   commonFetch: (...args: unknown[]) => mockCommonFetch(...args),
 }));
 

--- a/src/shared/components/code-editor/hooks/useSwaggerDefinitions.ts
+++ b/src/shared/components/code-editor/hooks/useSwaggerDefinitions.ts
@@ -1,0 +1,30 @@
+import { queryOptions, useQuery } from '@tanstack/react-query';
+import { commonFetch } from '~/k8s';
+import { logger } from '~/monitoring/logger';
+import { OpenAPISchemaDefinitions } from '../types';
+
+const SWAGGER_QUERY_KEY = 'swagger';
+
+const fetchSwaggerDefinitions = async (): Promise<OpenAPISchemaDefinitions | null> => {
+  try {
+    const response = await commonFetch('/openapi/v2');
+    const data = await response.json();
+    if (!data?.definitions) {
+      logger.error('Definitions missing in OpenAPI response.');
+      return null;
+    }
+    return data.definitions as OpenAPISchemaDefinitions;
+  } catch (e) {
+    logger.error('Could not get OpenAPI definitions', e instanceof Error ? e : undefined);
+    return null;
+  }
+};
+
+export const useSwaggerDefinitions = () =>
+  useQuery<OpenAPISchemaDefinitions | null>(
+    queryOptions({
+      queryKey: [SWAGGER_QUERY_KEY],
+      queryFn: fetchSwaggerDefinitions,
+      staleTime: Infinity,
+    }),
+  );

--- a/src/shared/components/code-editor/monaco.ts
+++ b/src/shared/components/code-editor/monaco.ts
@@ -1,0 +1,47 @@
+import type { Monaco } from '@monaco-editor/react';
+import { configureMonacoYaml } from 'monaco-yaml';
+import { openAPItoJSONSchema } from './openapi-to-json-schema';
+import { OpenAPISchemaDefinitions } from './types';
+
+export const registerYAMLinMonaco = (
+  monacoInstance: Monaco,
+  swaggerDefinitions: OpenAPISchemaDefinitions,
+) => {
+  if (!monacoInstance) {
+    // eslint-disable-next-line no-console
+    console.warn('registerYAMLinMonaco: monacoInstance is undefined');
+    return;
+  }
+
+  /**
+   * This exists because we enabled globalAPI in the webpack config. This means that the
+   * the monaco instance may have already been setup with the YAML language features.
+   * Otherwise, we might register all the features again, getting duplicate results.
+   *
+   * Monaco does not provide any APIs for unregistering or checking if the features have already
+   * been registered for a language.
+   *
+   * We check that > 1 YAML language exists because one is the default and
+   * the other is the language server that we register.
+   */
+  if ((monacoInstance.languages?.getLanguages() ?? []).filter((x) => x.id === 'yaml').length <= 1) {
+    // Convert the openAPI schema to something the language server understands
+    const kubernetesJSONSchema = openAPItoJSONSchema(swaggerDefinitions);
+
+    const schemas = [
+      {
+        uri: 'inmemory:yaml',
+        fileMatch: ['*'],
+        schema: kubernetesJSONSchema,
+      },
+    ];
+
+    configureMonacoYaml(monacoInstance, {
+      isKubernetes: true,
+      validate: true,
+      schemas,
+      hover: true,
+      completion: true,
+    });
+  }
+};

--- a/src/shared/components/code-editor/monaco.ts
+++ b/src/shared/components/code-editor/monaco.ts
@@ -1,47 +1,38 @@
 import type { Monaco } from '@monaco-editor/react';
 import { configureMonacoYaml } from 'monaco-yaml';
+import { logger } from '~/monitoring/logger';
 import { openAPItoJSONSchema } from './openapi-to-json-schema';
 import { OpenAPISchemaDefinitions } from './types';
+
+let yamlRegistered = false;
 
 export const registerYAMLinMonaco = (
   monacoInstance: Monaco,
   swaggerDefinitions: OpenAPISchemaDefinitions,
 ) => {
   if (!monacoInstance) {
-    // eslint-disable-next-line no-console
-    console.warn('registerYAMLinMonaco: monacoInstance is undefined');
+    logger.warn('registerYAMLinMonaco: monacoInstance is undefined');
     return;
   }
 
-  /**
-   * This exists because we enabled globalAPI in the webpack config. This means that the
-   * the monaco instance may have already been setup with the YAML language features.
-   * Otherwise, we might register all the features again, getting duplicate results.
-   *
-   * Monaco does not provide any APIs for unregistering or checking if the features have already
-   * been registered for a language.
-   *
-   * We check that > 1 YAML language exists because one is the default and
-   * the other is the language server that we register.
-   */
-  if ((monacoInstance.languages?.getLanguages() ?? []).filter((x) => x.id === 'yaml').length <= 1) {
-    // Convert the openAPI schema to something the language server understands
-    const kubernetesJSONSchema = openAPItoJSONSchema(swaggerDefinitions);
+  if (yamlRegistered) return;
+  yamlRegistered = true;
 
-    const schemas = [
-      {
-        uri: 'inmemory:yaml',
-        fileMatch: ['*'],
-        schema: kubernetesJSONSchema,
-      },
-    ];
+  const kubernetesJSONSchema = openAPItoJSONSchema(swaggerDefinitions);
 
-    configureMonacoYaml(monacoInstance, {
-      isKubernetes: true,
-      validate: true,
-      schemas,
-      hover: true,
-      completion: true,
-    });
-  }
+  const schemas = [
+    {
+      uri: 'inmemory:yaml',
+      fileMatch: ['*'],
+      schema: kubernetesJSONSchema,
+    },
+  ];
+
+  configureMonacoYaml(monacoInstance, {
+    isKubernetes: true,
+    validate: true,
+    schemas,
+    hover: true,
+    completion: true,
+  });
 };

--- a/src/shared/components/code-editor/openapi-to-json-schema.ts
+++ b/src/shared/components/code-editor/openapi-to-json-schema.ts
@@ -1,0 +1,124 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable no-prototype-builtins */
+
+// this file was copied from openshift/console repository - it has some util functions to convert from
+// OpenAPI data to a JSON Schema
+//
+// ref: https://github.com/openshift/console/blob/main/frontend/public/module/k8s/openapi-to-json-schema.ts
+
+// contains all the relevant information for transforming openapi specifications (such as kuberneres openapi)
+// to json schemas
+
+interface GroupVersionKind {
+  kind: string;
+  version: string;
+  group: string;
+}
+
+/**
+ * Given an array of GroupVersionKind objects, return their JSON Schema representation as enums
+ */
+function groupVersionKindToEnums(gvkObjArray: [GroupVersionKind]) {
+  const versionEnum = [];
+  const kindEnum = [];
+  for (const gvkObj of gvkObjArray) {
+    if (gvkObj.group && gvkObj.version) {
+      versionEnum.push(`${gvkObj.group}/${gvkObj.version}`);
+    } else if (gvkObj.version) {
+      versionEnum.push(gvkObj.version);
+    }
+    if (gvkObj.kind) {
+      kindEnum.push(gvkObj.kind);
+    }
+  }
+  return {
+    versionEnum,
+    kindEnum,
+  };
+}
+
+/**
+ * Append enums to APIVersion or create the object if it doesn't exist
+ */
+function createOrAppendAPIVersion(openAPI, apiVersionEnum: string[]) {
+  if (openAPI.apiVersion) {
+    if (openAPI.apiVersion.enum) {
+      openAPI.apiVersion.enum.push(...apiVersionEnum);
+    } else {
+      openAPI.apiVersion.enum = apiVersionEnum;
+    }
+  } else {
+    openAPI.apiVersion = {
+      enum: apiVersionEnum,
+    };
+  }
+}
+
+/**
+ * Append enums to kind or create the object if it doesn't exist
+ */
+function createOrAppendKind(openAPI, kindEnum: string[]) {
+  if (openAPI.kind) {
+    if (openAPI.kind.enum) {
+      openAPI.kind.enum.push(...kindEnum);
+    } else {
+      openAPI.kind.enum = kindEnum;
+    }
+  } else {
+    openAPI.kind = {
+      enum: kindEnum,
+    };
+  }
+}
+
+/**
+ * Converts the openAPI kubernetes specification for group, version, kind to JSON Schema
+ *
+ * Context: The openAPI specification gives the group, version, and kind objects as 'x-kubernetes-group-version-kind'
+ * instead of adding the values to the enum's
+ */
+function convertGroupVersionKindToJSONSchema(openAPI) {
+  for (const definition in openAPI) {
+    if (openAPI.hasOwnProperty(definition)) {
+      const openAPIDefinition = openAPI[definition];
+      const groupVersionKind = openAPIDefinition['x-kubernetes-group-version-kind'];
+
+      // If this object has x-kubernetes-group-version-kind then add their values into correct places in JSON Schema
+      if (groupVersionKind && openAPIDefinition.properties) {
+        const gvkEnums = groupVersionKindToEnums(groupVersionKind);
+        createOrAppendAPIVersion(openAPIDefinition.properties, gvkEnums.versionEnum);
+        createOrAppendKind(openAPIDefinition.properties, gvkEnums.kindEnum);
+      }
+    }
+  }
+  return openAPI;
+}
+
+/**
+ * Takes in the stored kubernetes openAPI object and outputs a JSON Schema of the object
+ */
+export function openAPItoJSONSchema(openAPI) {
+  if (!openAPI) {
+    return null;
+  }
+
+  const convertedOpenAPI = convertGroupVersionKindToJSONSchema(openAPI);
+
+  const oneOfSchemas = [];
+  const openAPIDefinitions = {};
+  for (const schemaProperty in convertedOpenAPI) {
+    if (convertedOpenAPI.hasOwnProperty(schemaProperty)) {
+      openAPIDefinitions[schemaProperty] = convertedOpenAPI[schemaProperty];
+      oneOfSchemas.push({
+        $ref: `#/definitions/${schemaProperty}`,
+      });
+    }
+  }
+
+  return {
+    definitions: {
+      ...openAPIDefinitions,
+    },
+    oneOf: oneOfSchemas,
+  };
+}

--- a/src/shared/components/code-editor/types.ts
+++ b/src/shared/components/code-editor/types.ts
@@ -1,0 +1,4 @@
+import { OpenAPIV2 } from 'openapi-types';
+
+export type OpenAPISchemaObject = OpenAPIV2.Document;
+export type OpenAPISchemaDefinitions = OpenAPISchemaObject['definitions'];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ import { fileURLToPath } from 'url';
 import path from 'path';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import { getWebpackAliases } from './aliases.config.js';
+import MonacoWebpackPlugin from 'monaco-editor-webpack-plugin';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -58,6 +59,21 @@ export default {
   },
   plugins: [
     new HtmlWebpackPlugin({ template: './public/index.html', favicon: './public/favicon.ico' }),
+    new MonacoWebpackPlugin({
+      languages: ['yaml'], // add only 'yaml' language, since that's the only one we're going to support for now
+      features: ['find', 'quickCommand', 'hover'], // only basic features we might need for now
+      globalAPI: true,
+      customLanguages: [
+        {
+          label: 'yaml',
+          entry: 'monaco-yaml',
+          worker: {
+            id: 'monaco-yaml/yamlWorker',
+            entry: 'monaco-yaml/yaml.worker',
+          },
+        },
+      ],
+    }),
   ],
   optimization: {
     moduleIds: 'deterministic',
@@ -94,6 +110,14 @@ export default {
           name: 'vendor',
           chunks: 'all',
           priority: 10,
+        },
+        // isolate 'monaco' dependencies in a separate chunk, it'll decrease the 'vendor' size
+        monaco: {
+          test: /[\\/]node_modules[\\/](monaco-editor|monaco-yaml)/,
+          name: 'monaco',
+          chunks: 'async',
+          priority: 20,
+          enforce: true,
         },
       },
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,7 +62,6 @@ export default {
     new MonacoWebpackPlugin({
       languages: ['yaml'], // add only 'yaml' language, since that's the only one we're going to support for now
       features: ['find', 'quickCommand', 'hover'], // only basic features we might need for now
-      globalAPI: true,
       customLanguages: [
         {
           label: 'yaml',

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'url';
+import path from 'path';
 import { merge } from 'webpack-merge';
 import commonConfig from './webpack.config.js';
 import ReactRefreshWebpackPlugin from '@pmmmwh/react-refresh-webpack-plugin';
@@ -6,6 +8,9 @@ import { config } from '@dotenvx/dotenvx';
 
 config();
 const DEV_SERVER_PORT = 8080;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 export default merge(commonConfig, {
   mode: 'development',
@@ -71,7 +76,13 @@ export default merge(commonConfig, {
   module: {
     rules: [
       {
+        test: /\.css$/i,
+        include: path.resolve(__dirname, 'node_modules/monaco-editor'),
+        use: ['style-loader', 'css-loader'],
+      },
+      {
         test: /\.s?[ac]ss$/i,
+        exclude: path.resolve(__dirname, 'node_modules/monaco-editor'), // Exclude Monaco's CSS
         use: [
           'style-loader',
           'css-loader',

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -1,7 +1,12 @@
+import { fileURLToPath } from 'url';
+import path from 'path';
 import { merge } from 'webpack-merge';
 import commonConfig from './webpack.config.js';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import CssMinimizerPlugin from 'css-minimizer-webpack-plugin';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 export default merge(commonConfig, {
   mode: 'production',
@@ -9,7 +14,13 @@ export default merge(commonConfig, {
   module: {
     rules: [
       {
+        test: /\.css$/i,
+        include: path.resolve(__dirname, 'node_modules/monaco-editor'),
+        use: [MiniCssExtractPlugin.loader, 'css-loader'],
+      },
+      {
         test: /\.s?[ac]ss$/i,
+        exclude: path.resolve(__dirname, 'node_modules/monaco-editor'), // Exclude Monaco's CSS
         use: [
           MiniCssExtractPlugin.loader,
           'css-loader',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2486,6 +2486,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@monaco-editor/loader@npm:^1.5.0":
+  version: 1.7.0
+  resolution: "@monaco-editor/loader@npm:1.7.0"
+  dependencies:
+    state-local: "npm:^1.0.6"
+  checksum: 10/7ee7406f0a7036e2638430d151c65593dcce88e3f344e2e19556c284c23c1b51d5edb08b8c15a6454aaa62f5af459a296db76b9543686e2ea5037c54723d2f2d
+  languageName: node
+  linkType: hard
+
+"@monaco-editor/react@npm:^4.6.0":
+  version: 4.7.0
+  resolution: "@monaco-editor/react@npm:4.7.0"
+  dependencies:
+    "@monaco-editor/loader": "npm:^1.5.0"
+  peerDependencies:
+    monaco-editor: ">= 0.25.0 < 1"
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/d72392c4ed6faf8d830ba43421461e1b767b5978edba0739457d7781aa9533c66982be7f59bb156a77a2b578eddfb4711f50e0d84f0f0d25d28b5ab11140f5cc
+  languageName: node
+  linkType: hard
+
 "@napi-rs/wasm-runtime@npm:^0.2.11":
   version: 0.2.12
   resolution: "@napi-rs/wasm-runtime@npm:0.2.12"
@@ -2767,6 +2789,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@patternfly/react-code-editor@npm:^5.3.1":
+  version: 5.4.18
+  resolution: "@patternfly/react-code-editor@npm:5.4.18"
+  dependencies:
+    "@monaco-editor/react": "npm:^4.6.0"
+    "@patternfly/react-core": "npm:^5.4.14"
+    "@patternfly/react-icons": "npm:^5.4.2"
+    "@patternfly/react-styles": "npm:^5.4.1"
+    react-dropzone: "npm:14.2.3"
+    tslib: "npm:^2.7.0"
+  peerDependencies:
+    react: ^17 || ^18
+    react-dom: ^17 || ^18
+  checksum: 10/166b49ec501e6b529bb79ff9c1dabc9e086cd09d8c5e45a80055e03d6894e1b76e028b3d35c4f880678051e1a00c163e44f4fde4c5ded55af08ee0cf9601bb58
+  languageName: node
+  linkType: hard
+
 "@patternfly/react-core@npm:5.3.4":
   version: 5.3.4
   resolution: "@patternfly/react-core@npm:5.3.4"
@@ -2784,7 +2823,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-core@npm:^5.0.0, @patternfly/react-core@npm:^5.1.1, @patternfly/react-core@npm:^5.3.4":
+"@patternfly/react-core@npm:^5.0.0, @patternfly/react-core@npm:^5.1.1, @patternfly/react-core@npm:^5.3.4, @patternfly/react-core@npm:^5.4.14":
   version: 5.4.14
   resolution: "@patternfly/react-core@npm:5.4.14"
   dependencies:
@@ -5458,7 +5497,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"attr-accept@npm:^2.2.4":
+"attr-accept@npm:^2.2.2, attr-accept@npm:^2.2.4":
   version: 2.2.5
   resolution: "attr-accept@npm:2.2.5"
   checksum: 10/474b1c53e62c5b881c745d1f098196f190c8b493245e95d4b0fea9298d3acb56f551868fc12806885277e55e9d8ad3c5963e92d93456f4e4081dfc5190977bfd
@@ -8376,6 +8415,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"file-selector@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "file-selector@npm:0.6.0"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10/6add4098ae07fd1e9050b1e8d3fd9f128680c1d6648c0676af54ace4586e6e5bfcb8fdfa45b69e9131ffd8175bf630d54a445a5facf9be244f85b99ce309183e
+  languageName: node
+  linkType: hard
+
 "file-selector@npm:^2.1.0":
   version: 2.1.2
   resolution: "file-selector@npm:2.1.2"
@@ -10785,7 +10833,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonc-parser@npm:^3.2.0":
+"jsonc-parser@npm:^3.0.0, jsonc-parser@npm:^3.2.0":
   version: 3.3.1
   resolution: "jsonc-parser@npm:3.3.1"
   checksum: 10/9b0dc391f20b47378f843ef1e877e73ec652a5bdc3c5fa1f36af0f119a55091d147a86c1ee86a232296f55c929bba174538c2bf0312610e0817a22de131cc3f4
@@ -10877,6 +10925,7 @@ __metadata:
     "@dotenvx/dotenvx": "npm:^1.7.0"
     "@patternfly/patternfly": "npm:^5.3.1"
     "@patternfly/react-charts": "npm:7.4.5"
+    "@patternfly/react-code-editor": "npm:^5.3.1"
     "@patternfly/react-core": "npm:5.3.4"
     "@patternfly/react-icons": "npm:^5.3.2"
     "@patternfly/react-log-viewer": "npm:5.3.0"
@@ -10937,6 +10986,10 @@ __metadata:
     lint-staged: "npm:^15.2.7"
     lodash-es: "npm:4.17.23"
     mini-css-extract-plugin: "npm:^2.9.0"
+    monaco-editor: "npm:^0.51.0"
+    monaco-editor-webpack-plugin: "npm:^7.1.0"
+    monaco-yaml: "npm:^5.3.1"
+    openapi-types: "npm:^12.1.3"
     p-limit: "npm:^6.2.0"
     prettier: "npm:3.3.2"
     prismjs: "npm:^1.30.0"
@@ -10969,6 +11022,7 @@ __metadata:
     webpack-dev-server: "npm:^5.0.4"
     webpack-merge: "npm:^6.0.1"
     whatwg-fetch: "npm:^3.6.20"
+    yaml: "npm:^2.7.1"
     yup: "npm:^0.32.11"
     zustand: "npm:^5.0.4"
   languageName: unknown
@@ -11063,7 +11117,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loader-utils@npm:^2.0.4":
+"loader-utils@npm:^2.0.2, loader-utils@npm:^2.0.4":
   version: 2.0.4
   resolution: "loader-utils@npm:2.0.4"
   dependencies:
@@ -11692,6 +11746,82 @@ __metadata:
   languageName: node
   linkType: hard
 
+"monaco-editor-webpack-plugin@npm:^7.1.0":
+  version: 7.1.1
+  resolution: "monaco-editor-webpack-plugin@npm:7.1.1"
+  dependencies:
+    loader-utils: "npm:^2.0.2"
+  peerDependencies:
+    monaco-editor: ">= 0.31.0"
+    webpack: ^4.5.0 || 5.x
+  checksum: 10/633ce250ac28008eb8fa0ce617655793fa014547f5b26f18210b5385365d96a967e799c3c16cf90ea01325fd8fd26d68d0b7995e6b1e5062984e72ee1bd3abd2
+  languageName: node
+  linkType: hard
+
+"monaco-editor@npm:^0.51.0":
+  version: 0.51.0
+  resolution: "monaco-editor@npm:0.51.0"
+  checksum: 10/2d4f076e35edb32add51b9b7a0ff5a7a81bf946cdeda9983ab6b24c2e5b84f537d5a5c781925d7ee8c898e890212b379d3c96139a965ad1004e6dd3d890163fa
+  languageName: node
+  linkType: hard
+
+"monaco-languageserver-types@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "monaco-languageserver-types@npm:0.4.0"
+  dependencies:
+    monaco-types: "npm:^0.1.0"
+    vscode-languageserver-protocol: "npm:^3.0.0"
+    vscode-uri: "npm:^3.0.0"
+  checksum: 10/758740ac3b2ad9ada481cf5d23b1e5a2d229b416307a2de59a73bf76b27ddac211aceba6d11e40cb7d65e4f9b52666201aca42d6bccc1c88c50642c96385a8a2
+  languageName: node
+  linkType: hard
+
+"monaco-marker-data-provider@npm:^1.0.0":
+  version: 1.2.5
+  resolution: "monaco-marker-data-provider@npm:1.2.5"
+  dependencies:
+    monaco-types: "npm:^0.1.0"
+  checksum: 10/44b8964a77059bb95c02e2a516eda9e6a10eb27acdbcfca053912e8f6fec22599f3195eb83a1acf9e5b93647da991e4b4c7acae743d93454a770c484abfc37bf
+  languageName: node
+  linkType: hard
+
+"monaco-types@npm:^0.1.0":
+  version: 0.1.1
+  resolution: "monaco-types@npm:0.1.1"
+  checksum: 10/e2ac69373b51b39bf2c7c40cc5d9416cce6cb4ccab39712f31adae0a564f938252e76f9aae233e46ef15d21ef56770ad7e0930d9ae8fb28e635d64412cdea3f6
+  languageName: node
+  linkType: hard
+
+"monaco-worker-manager@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "monaco-worker-manager@npm:2.0.1"
+  peerDependencies:
+    monaco-editor: ">=0.30.0"
+  checksum: 10/3b12a0bb83354a9b2bf576b6cba7b2e4bfc2233b988fdc1de7f9fb3f6ec2709a1d9178d458aa43e31c424e55d4b555c0223d434fb98dabf2443417cc1cfb7d66
+  languageName: node
+  linkType: hard
+
+"monaco-yaml@npm:^5.3.1":
+  version: 5.4.0
+  resolution: "monaco-yaml@npm:5.4.0"
+  dependencies:
+    jsonc-parser: "npm:^3.0.0"
+    monaco-languageserver-types: "npm:^0.4.0"
+    monaco-marker-data-provider: "npm:^1.0.0"
+    monaco-types: "npm:^0.1.0"
+    monaco-worker-manager: "npm:^2.0.0"
+    path-browserify: "npm:^1.0.0"
+    prettier: "npm:^3.0.0"
+    vscode-languageserver-textdocument: "npm:^1.0.0"
+    vscode-languageserver-types: "npm:^3.0.0"
+    vscode-uri: "npm:^3.0.0"
+    yaml: "npm:^2.0.0"
+  peerDependencies:
+    monaco-editor: ">=0.36"
+  checksum: 10/84c88539c4193bcfcc3d6794d256f55183713b5d2f73f4d0579fe25650eafad09220dc4d7fdbfcbe0e7c4a56f2f89dd333f5bcdccf3f0b59f339663689e78116
+  languageName: node
+  linkType: hard
+
 "mrmime@npm:^2.0.0":
   version: 2.0.1
   resolution: "mrmime@npm:2.0.1"
@@ -12097,6 +12227,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"openapi-types@npm:^12.1.3":
+  version: 12.1.3
+  resolution: "openapi-types@npm:12.1.3"
+  checksum: 10/9d1d7ed848622b63d0a4c3f881689161b99427133054e46b8e3241e137f1c78bb0031c5d80b420ee79ac2e91d2e727ffd6fc13c553d1b0488ddc8ad389dcbef8
+  languageName: node
+  linkType: hard
+
 "opener@npm:^1.5.2":
   version: 1.5.2
   resolution: "opener@npm:1.5.2"
@@ -12298,6 +12435,13 @@ __metadata:
     no-case: "npm:^3.0.4"
     tslib: "npm:^2.0.3"
   checksum: 10/ba98bfd595fc91ef3d30f4243b1aee2f6ec41c53b4546bfa3039487c367abaa182471dcfc830a1f9e1a0df00c14a370514fa2b3a1aacc68b15a460c31116873e
+  languageName: node
+  linkType: hard
+
+"path-browserify@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "path-browserify@npm:1.0.1"
+  checksum: 10/7e7368a5207e7c6b9051ef045711d0dc3c2b6203e96057e408e6e74d09f383061010d2be95cb8593fe6258a767c3e9fc6b2bfc7ce8d48ae8c3d9f6994cca9ad8
   languageName: node
   linkType: hard
 
@@ -12893,6 +13037,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prettier@npm:^3.0.0":
+  version: 3.8.3
+  resolution: "prettier@npm:3.8.3"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 10/4b3b12cbb29e4c96bed936e5d070167552500c18d37676fb3e0caae6199c42860662608e4dc116230698f6e2bb0267ef2548158224c92d40f188d309d72fdd6f
+  languageName: node
+  linkType: hard
+
 "prettier@npm:^3.2.5":
   version: 3.8.1
   resolution: "prettier@npm:3.8.1"
@@ -13152,6 +13305,19 @@ __metadata:
   peerDependencies:
     react: ^18.3.1
   checksum: 10/3f4b73a3aa083091173b29812b10394dd06f4ac06aff410b74702cfb3aa29d7b0ced208aab92d5272919b612e5cda21aeb1d54191848cf6e46e9e354f3541f81
+  languageName: node
+  linkType: hard
+
+"react-dropzone@npm:14.2.3":
+  version: 14.2.3
+  resolution: "react-dropzone@npm:14.2.3"
+  dependencies:
+    attr-accept: "npm:^2.2.2"
+    file-selector: "npm:^0.6.0"
+    prop-types: "npm:^15.8.1"
+  peerDependencies:
+    react: ">= 16.8 || 18.0.0"
+  checksum: 10/34cf1758a896795b579adab5f9cdc144330577ab1826a0b66ff9daa8c60a80ed6b31b8f989647664f2548cfe00b336e9c31a2f3dd8de43111c8318fcc89b279c
   languageName: node
   linkType: hard
 
@@ -14343,6 +14509,13 @@ __metadata:
   version: 1.3.4
   resolution: "stackframe@npm:1.3.4"
   checksum: 10/29ca71c1fd17974c1c178df0236b1407bc65f6ea389cc43dec000def6e42ff548d4453de9a85b76469e2ae2b2abdd802c6b6f3db947c05794efbd740d1cf4121
+  languageName: node
+  linkType: hard
+
+"state-local@npm:^1.0.6":
+  version: 1.0.7
+  resolution: "state-local@npm:1.0.7"
+  checksum: 10/1d956043e270861d40a639ff3457938cf61dbc7e25209d21b55060d8dfaf74742b8a1e525ed6fcb0c2d89b7d3e305bb8589bf27392012889456b3ad82a4b7d0a
   languageName: node
   linkType: hard
 
@@ -15761,6 +15934,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vscode-jsonrpc@npm:8.2.0":
+  version: 8.2.0
+  resolution: "vscode-jsonrpc@npm:8.2.0"
+  checksum: 10/6d57c3aed591d0bc89d1c226061d265b04de528582bef183f5998cac5de78a736887e5238fe48b9f6a14ec32f05d8fda71599f92862ac5dacc7f26bf7399b532
+  languageName: node
+  linkType: hard
+
+"vscode-languageserver-protocol@npm:^3.0.0":
+  version: 3.17.5
+  resolution: "vscode-languageserver-protocol@npm:3.17.5"
+  dependencies:
+    vscode-jsonrpc: "npm:8.2.0"
+    vscode-languageserver-types: "npm:3.17.5"
+  checksum: 10/aeb9c190184c365fa6b835e5aa7574c86cb3ecb2789386bcff76a09b22bc8b8e0d5da47c28193a9c73cfb32c10a12a91191779280324a38efb401e3ef7bad294
+  languageName: node
+  linkType: hard
+
+"vscode-languageserver-textdocument@npm:^1.0.0":
+  version: 1.0.12
+  resolution: "vscode-languageserver-textdocument@npm:1.0.12"
+  checksum: 10/2bc0fde952d40f35a31179623d1491b0fafdee156aaf58557f40f5d394a25fc84826763cdde55fa6ce2ed9cd35a931355ad6dd7fe5db82e7f21e5d865f0af8c6
+  languageName: node
+  linkType: hard
+
+"vscode-languageserver-types@npm:3.17.5, vscode-languageserver-types@npm:^3.0.0":
+  version: 3.17.5
+  resolution: "vscode-languageserver-types@npm:3.17.5"
+  checksum: 10/900d0b81df5bef8d90933e75be089142f6989cc70fdb2d5a3a5f11fa20feb396aaea23ccffc8fbcc83a2f0e1b13c6ee48ff8151f236cbd6e61a4f856efac1a58
+  languageName: node
+  linkType: hard
+
+"vscode-uri@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "vscode-uri@npm:3.1.0"
+  checksum: 10/80c2a2421f44b64008ef1f91dfa52a2d68105cbb4dcea197dbf5b00c65ccaccf218b615e93ec587f26fc3ba04796898f3631a9406e3b04cda970c3ca8eadf646
+  languageName: node
+  linkType: hard
+
 "w3c-xmlserializer@npm:^4.0.0":
   version: 4.0.0
   resolution: "w3c-xmlserializer@npm:4.0.0"
@@ -16326,7 +16537,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.7.0":
+"yaml@npm:^2.0.0, yaml@npm:^2.7.0, yaml@npm:^2.7.1":
   version: 2.8.2
   resolution: "yaml@npm:2.8.2"
   bin:


### PR DESCRIPTION
## Fixes 

Fixes https://issues.redhat.com/browse/KFLUXUI-231


## Description

This PR adds a "YAML" tab to the Release Details page. The tab allows the users to view the full release YAML in a read-only editor.

The implementation uses [PatternFly's @patternfly/react-code-editor](https://www.npmjs.com/package/@patternfly/react-code-editor)(which uses Monaco Editor behind the scenes). This setup provides syntax highlighting, validation, and a read-only experience for YAML content.

Additional libraries used:

* `yaml` – for parsing and formatting the YAML data
* `monaco-editor` – core editor
* `monaco-yaml` – YAML language support and schema validation
* `monaco-editor-webpack-plugin` – proper bundling and worker configuration
* `openapi-types` – typing support for OpenAPI schema parsing


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

https://github.com/user-attachments/assets/dbdd1122-02d5-4ebd-8731-a451bbd5ae76

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1. Go to "Releases" page
2. Select a release from the list
3. Click on `YAML` tab
4. You should see a read-only Monaco Editor showing the YAML content of the selected release
5. ☕ 

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [x] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a YAML tab to Release Details with a read-only, schema-aware YAML editor (syntax highlighting, validation, autocompletion), loading/error states, and keyboard-shortcuts UI.
  * Added a reusable code/YAML editor component for viewing resource YAML.

* **Tests**
  * Added extensive unit tests covering the YAML tab, editor, schema integration, swagger fetching, and shortcut UI.

* **Chores**
  * Integrated editor packages and build config to support the Monaco-based YAML editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->