### PR TITLE
KFLUXUI-230: Add support for "re-running" a Release

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -61,6 +61,7 @@ module.exports = {
           'image_controller',
           'application_url',
           'sbom_server',
+          'release_name',
         ],
       },
     ],

--- a/src/components/Releases/ReleasesListRow.tsx
+++ b/src/components/Releases/ReleasesListRow.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { css } from '@patternfly/react-styles';
 import { useReleaseStatus } from '../../hooks/useReleaseStatus';
 import {
   APPLICATION_RELEASE_DETAILS_PATH,
   PIPELINERUN_DETAILS_PATH,
   SNAPSHOT_DETAILS_PATH,
 } from '../../routes/paths';
+import ActionMenu from '../../shared/components/action-menu/ActionMenu';
 import { RowFunctionArgs, TableData } from '../../shared/components/table';
 import { Timestamp } from '../../shared/components/timestamp/Timestamp';
 import { useNamespace } from '../../shared/providers/Namespace';
@@ -19,6 +19,7 @@ import {
   getFinalPipelineRunFromRelease,
 } from '../../utils/release-utils';
 import { StatusIconWithText } from '../StatusIcon/StatusIcon';
+import { useReleaseActions } from './release-actions';
 import { releasesTableColumnClasses } from './ReleasesListHeader';
 
 const ReleasesListRow: React.FC<
@@ -35,6 +36,7 @@ const ReleasesListRow: React.FC<
   const [finalPrNamespace, finalPipelineRun] = getNamespaceAndPRName(
     getFinalPipelineRunFromRelease(obj),
   );
+  const actions = useReleaseActions(obj);
 
   return (
     <>
@@ -122,7 +124,9 @@ const ReleasesListRow: React.FC<
           '-'
         )}
       </TableData>
-      <TableData className={css(releasesTableColumnClasses.kebab, 'm-no-actions')}> </TableData>
+      <TableData className={releasesTableColumnClasses.kebab}>
+        <ActionMenu actions={actions} />
+      </TableData>
     </>
   );
 };

--- a/src/components/Releases/release-actions.ts
+++ b/src/components/Releases/release-actions.ts
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { useAuth } from '../../auth/useAuth';
+import { PipelineRunLabel } from '../../consts/pipelinerun';
+import { Action } from '../../shared/components/action-menu/types';
+import { useNamespace } from '../../shared/providers/Namespace/useNamespaceInfo';
+import { ReleaseKind } from '../../types';
+import { releaseRerun } from '../../utils/release-actions';
+
+export const useReleaseActions = (release: ReleaseKind): Action[] => {
+  const namespace = useNamespace();
+  const applicationName = release.metadata?.labels?.[PipelineRunLabel.APPLICATION] ?? '';
+  const releaseName = release.metadata?.name;
+  const {
+    user: { email },
+  } = useAuth();
+
+  const actions: Action[] = React.useMemo(() => {
+    if (!release) {
+      return [];
+    }
+    const updatedActions: Action[] = [
+      {
+        cta: () => releaseRerun(release, email),
+        id: 're-run-release',
+        label: 'Re-run release',
+        analytics: {
+          link_name: 're-run-release',
+          link_location: 'release-actions',
+          release_name: releaseName,
+          app_name: applicationName,
+          namespace,
+        },
+      },
+    ];
+    return updatedActions;
+  }, [release, releaseName, applicationName, namespace, email]);
+
+  return actions;
+};

--- a/src/consts/release.ts
+++ b/src/consts/release.ts
@@ -1,0 +1,4 @@
+export enum ReleaseLabel {
+  AUTOMATED = 'release.appstudio.openshift.io/automated',
+  AUTHOR = 'release.appstudio.openshift.io/author',
+}

--- a/src/utils/__tests__/release-utils.spec.ts
+++ b/src/utils/__tests__/release-utils.spec.ts
@@ -1,0 +1,23 @@
+import { generateNewReleaseName } from '../release-utils';
+
+const mockedCurrentName = 'local-release-2965kp';
+const mockedCurrentNameWithRerun = 'local-release-2965kp-rerun-x52gs';
+
+describe('release utils', () => {
+  describe('generateNewReleaseName', () => {
+    it("generate new release name successfully - name without 'rerun'", () => {
+      const newName = generateNewReleaseName(mockedCurrentName);
+      expect(newName).toMatch(/^local-release-2965kp-rerun-$/);
+    });
+
+    it("generate new release name successfully - name with 'rerun'", () => {
+      const newName = generateNewReleaseName(mockedCurrentNameWithRerun);
+      expect(newName).toMatch(/^local-release-2965kp-rerun-$/);
+    });
+
+    it('handles empty string gracefully', () => {
+      const newName = generateNewReleaseName('');
+      expect(newName).toMatch(/^release-rerun-$/);
+    });
+  });
+});

--- a/src/utils/release-actions.ts
+++ b/src/utils/release-actions.ts
@@ -1,0 +1,39 @@
+import { ReleaseLabel } from '../consts/release';
+import { K8sQueryCreateResource } from '../k8s';
+import { ReleaseModel } from '../models';
+import { ReleaseKind } from '../types';
+import { generateNewReleaseName } from './release-utils';
+
+export const releaseRerun = (release: ReleaseKind, username: string) => {
+  const newName = generateNewReleaseName(release.metadata?.name ?? '');
+
+  const newRelease: ReleaseKind = {
+    ...release,
+    metadata: {
+      ...release.metadata,
+      creationTimestamp: undefined,
+      finalizers: undefined,
+      generateName: `${newName}`,
+      generation: undefined,
+      ownerReferences: undefined,
+      resourceVersion: undefined,
+      uid: undefined,
+      name: undefined,
+      labels: {
+        ...release.metadata.labels,
+        [ReleaseLabel.AUTOMATED]: 'false',
+        [ReleaseLabel.AUTHOR]: username,
+      },
+    },
+    status: undefined,
+  };
+
+  return K8sQueryCreateResource({
+    model: ReleaseModel,
+    queryOptions: {
+      name: release.metadata.name,
+      ns: release.metadata.namespace,
+    },
+    resource: newRelease,
+  });
+};

--- a/src/utils/release-utils.ts
+++ b/src/utils/release-utils.ts
@@ -19,3 +19,15 @@ export const getTenantPipelineRunFromRelease = (release: ReleaseKind): string =>
 export const getFinalPipelineRunFromRelease = (release: ReleaseKind): string => {
   return release.status?.finalProcessing?.pipelineRun;
 };
+
+export const generateNewReleaseName = (currentName: string): string => {
+  // Use a fallback name if currentName is falsy or empty after trimming
+  const safeName = currentName?.trim() || 'release';
+
+  // remove any existing "-rerun" or "-rerun-xxx" from the name
+  const baseName = safeName.replace(/(-rerun(-[a-z0-9]+)?)$/, '');
+
+  const newName = `${baseName}-rerun-`;
+
+  return newName;
+};


### PR DESCRIPTION
## Fixes 

This fixes the issue https://issues.redhat.com/browse/KFLUXUI-230.


## Description

In this PR we’re introducing logic to allow a `Release` to be “re-run” or “re-triggered”.
Behind the scenes, this doesn’t actually re-run the same resource — instead, it creates a new `Release` based on the existing one.
It kinda simulates a "rerun" by cloning the original release, generating a new name with a random suffix, and updating relevant info (e.g. labels)

The implementation follows the approach described here https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/release-service/faq.md?ref_type=heads#how-do-i-retrigger-a-release, which explains how to "rerun"/"re-trigger" a release via CLI 🙂 


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

The screen recording below shows the "re-run" action in action 😄

https://github.com/user-attachments/assets/0c91223f-901e-44ab-884c-8b6ea4bf64fe


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1. Go to `Releases` page
2. Notice that by the end of the "Release Row", there's an `ActionMenu`
3. Click on it and select the "Re-run release" option
4. Notice that a new release was created and it's in progress now
5. ☕ 

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->