### PR TITLE
  feat(KFLUXUI-417): add the 'Components' column for secret list page

### DIFF
--- a/src/components/Secrets/SecretsForm/AddSecretForm.tsx
+++ b/src/components/Secrets/SecretsForm/AddSecretForm.tsx
@@ -18,7 +18,7 @@ import { SecretTypeSubForm } from './SecretTypeSubForm';
 const AddSecretForm: React.FC = () => {
   const namespace = useNamespace();
   const navigate = useNavigate();
-  const isNew = useIsOnFeatureFlag('buildServiceAccount');
+  const isBuildServiceAccountFeatureOn = useIsOnFeatureFlag('buildServiceAccount');
   const initialValues: AddSecretFormValues = {
     type: SecretTypeDropdownLabel.opaque,
     name: '',
@@ -50,7 +50,10 @@ const AddSecretForm: React.FC = () => {
         navigate(-1);
       }}
       onSubmit={(values, actions) => {
-        (!isNew ? addSecret(values, namespace) : addSecretWithLinkingComponents(values, namespace))
+        (!isBuildServiceAccountFeatureOn
+          ? addSecret(values, namespace)
+          : addSecretWithLinkingComponents(values, namespace)
+        )
           .then(() => {
             navigate(SECRET_LIST_PATH.createPath({ workspaceName: namespace }));
           })

--- a/src/components/Secrets/SecretsListView/SecretsList.tsx
+++ b/src/components/Secrets/SecretsListView/SecretsList.tsx
@@ -1,21 +1,30 @@
 import * as React from 'react';
+import { useIsOnFeatureFlag } from '~/feature-flags/hooks';
 import { Table } from '../../../shared';
 import { SecretKind } from '../../../types';
 import SecretsListHeader from './SecretsListHeader';
+import SecretsListHeaderWithComponents from './SecretsListHeaderWithComponents';
 import SecretsListRow from './SecretsListRow';
+import SecretsListRowWithComponents from './SecretsListRowWithComponents';
 
 type SecretsListProps = {
   secrets: SecretKind[];
 };
 
 const SecretsList: React.FC<React.PropsWithChildren<SecretsListProps>> = ({ secrets }) => {
+  const isBuildServiceAccountFeatureOn = useIsOnFeatureFlag('buildServiceAccount');
+  const Header = isBuildServiceAccountFeatureOn
+    ? SecretsListHeaderWithComponents
+    : SecretsListHeader;
+  const Row = isBuildServiceAccountFeatureOn ? SecretsListRowWithComponents : SecretsListRow;
+
   return (
     <>
       <Table
         data={secrets}
         aria-label="Secret List"
-        Header={SecretsListHeader}
-        Row={SecretsListRow}
+        Header={Header}
+        Row={Row}
         loaded
         getRowProps={(obj: SecretKind) => ({
           id: obj.metadata.name,

--- a/src/components/Secrets/SecretsListView/SecretsListHeaderWithComponents.tsx
+++ b/src/components/Secrets/SecretsListView/SecretsListHeaderWithComponents.tsx
@@ -1,0 +1,36 @@
+// The 'components' is just one number while the 'keytab'
+// is just two or three words, so let them be shorter.
+export const secretsTableColumnClasses = {
+  secretType: 'pf-m-width-25',
+  name: 'pf-m-width-25 wrap-column',
+  components: 'pf-m-width-15',
+  labels: 'pf-m-width-25 wrap-column',
+  kebab: 'pf-c-table__action', // pf-m-width-15
+};
+
+const SecretsListHeaderWithComponents = () => {
+  return [
+    {
+      title: 'Secret type',
+      props: { className: secretsTableColumnClasses.secretType },
+    },
+    {
+      title: 'Name',
+      props: { className: secretsTableColumnClasses.name },
+    },
+    {
+      title: 'Components',
+      props: { className: secretsTableColumnClasses.components },
+    },
+    {
+      title: 'Labels',
+      props: { className: secretsTableColumnClasses.labels },
+    },
+    {
+      title: ' ',
+      props: { className: secretsTableColumnClasses.kebab },
+    },
+  ];
+};
+
+export default SecretsListHeaderWithComponents;

--- a/src/components/Secrets/SecretsListView/SecretsListRowWithComponents.tsx
+++ b/src/components/Secrets/SecretsListView/SecretsListRowWithComponents.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import { Label, Popover, Spinner } from '@patternfly/react-core';
+import { useLinkedServiceAccounts } from '~/hooks/useLinkedServiceAccounts';
+import { useNamespace } from '~/shared/providers/Namespace';
+import { RowFunctionArgs, TableData } from '../../../shared';
+import ActionMenu from '../../../shared/components/action-menu/ActionMenu';
+import { SecretKind } from '../../../types/secret';
+import { useSecretActions } from '../secret-actions';
+import { getSecretRowLabels, getSecretTypetoLabel } from '../utils/secret-utils';
+import { isLinkableSecret } from '../utils/service-account-utils';
+import { secretsTableColumnClasses } from './SecretsListHeaderWithComponents';
+
+type SecretsListRowProps = RowFunctionArgs<SecretKind>;
+
+const SecretsListRowWithComponents: React.FC<React.PropsWithChildren<SecretsListRowProps>> = ({
+  obj,
+}) => {
+  const actions = useSecretActions(obj);
+  const namespace = useNamespace();
+
+  const { secretLabels } = getSecretRowLabels(obj);
+  const labels =
+    secretLabels !== '-'
+      ? secretLabels.split(', ').map((s) => <Label key={s}>{s}</Label>)
+      : secretLabels;
+
+  const { linkedServiceAccounts, isLoading, error } = useLinkedServiceAccounts(
+    obj.metadata?.namespace || namespace,
+    obj.metadata.name,
+    true,
+  );
+
+  return (
+    <>
+      <TableData className={secretsTableColumnClasses.secretType}>
+        {getSecretTypetoLabel(obj) ?? '-'}
+      </TableData>
+      <TableData className={secretsTableColumnClasses.name}>{obj.metadata?.name}</TableData>
+      <TableData className={secretsTableColumnClasses.components} data-test="components-content">
+        {isLoading ? (
+          <Spinner size="lg" />
+        ) : error ? (
+          <Popover
+            triggerAction="hover"
+            aria-label="Hoverable popover"
+            bodyContent={error?.message || 'Unknown Error'}
+          >
+            <span>Error</span>
+          </Popover>
+        ) : !isLinkableSecret(obj) ? (
+          '-'
+        ) : (
+          // The linkedServiceAccounts returns [] or [sa1, sa2...].
+          <span>{linkedServiceAccounts.length}</span>
+        )}
+      </TableData>
+      <TableData className={secretsTableColumnClasses.labels}>{labels}</TableData>
+      <TableData className={secretsTableColumnClasses.kebab}>
+        <ActionMenu actions={actions} />
+      </TableData>
+    </>
+  );
+};
+
+export default SecretsListRowWithComponents;

--- a/src/components/Secrets/__data__/mock-secrets.ts
+++ b/src/components/Secrets/__data__/mock-secrets.ts
@@ -1,5 +1,5 @@
 import { omit } from 'lodash-es';
-import { ApplicationModel, ComponentModel } from '../../../models';
+import { ApplicationModel, ComponentModel, ServiceAccountModel } from '../../../models';
 import {
   AddSecretFormValues,
   BuildTimeSecret,
@@ -7,6 +7,7 @@ import {
   ComponentSpecs,
   SecretFor,
   SecretFormValues,
+  SecretKind,
   SecretType,
   SecretTypeDropdownLabel,
   SourceSecretType,
@@ -22,6 +23,30 @@ export const mockApplicationRequestData = {
   spec: {
     displayName: 'test-application',
   },
+};
+
+export const mockServiceAccounts = [
+  {
+    apiVersion: `${ServiceAccountModel.apiGroup}/${ServiceAccountModel.apiVersion}`,
+    kind: ServiceAccountModel.kind,
+    metadata: { name: 'sa-1' },
+  },
+  {
+    apiVersion: `${ServiceAccountModel.apiGroup}/${ServiceAccountModel.apiVersion}`,
+    kind: ServiceAccountModel.kind,
+    metadata: { name: 'sa-2' },
+  },
+];
+
+export const mockSecret: SecretKind = {
+  apiVersion: 'v1',
+  kind: 'Secret',
+  metadata: {
+    name: 'my-secret',
+    namespace: 'my-namespace',
+  },
+  data: {},
+  type: 'Opaque',
 };
 
 export const mockComponent: ComponentSpecs = {

--- a/src/components/Secrets/__tests___/SecretsListView.spec.tsx
+++ b/src/components/Secrets/__tests___/SecretsListView.spec.tsx
@@ -2,9 +2,13 @@ import { MemoryRouter } from 'react-router-dom';
 import { Table as PfTable, TableHeader } from '@patternfly/react-table/deprecated';
 import { screen, render, fireEvent, act } from '@testing-library/react';
 import { FilterContextProvider } from '~/components/Filter/generic/FilterContext';
+import { useIsOnFeatureFlag } from '~/feature-flags/hooks';
+import { useLinkedServiceAccounts } from '~/hooks/useLinkedServiceAccounts';
 import { useSecrets } from '../../../hooks/useSecrets';
 import { RemoteSecretStatusReason } from '../../../types';
+import { mockServiceAccounts } from '../__data__/mock-secrets';
 import SecretsListRow from '../SecretsListView/SecretsListRow';
+import SecretsListRowWithComponents from '../SecretsListView/SecretsListRowWithComponents';
 import SecretsListView from '../SecretsListView/SecretsListView';
 import { sampleRemoteSecrets } from './secret-data';
 
@@ -28,21 +32,42 @@ jest.mock('../../../hooks/useSecrets', () => ({
   useSecrets: jest.fn(),
 }));
 
+jest.mock('~/hooks/useLinkedServiceAccounts', () => ({
+  useLinkedServiceAccounts: jest.fn(),
+}));
+
+jest.mock('~/feature-flags/hooks', () => ({
+  useIsOnFeatureFlag: jest.fn(),
+}));
+
 jest.mock('../../../shared/components/table', () => {
   const actual = jest.requireActual('../../../shared/components/table');
+  // eslint-disable-next-line @typescript-eslint/no-shadow, @typescript-eslint/no-var-requires
+  const { useIsOnFeatureFlag } = require('../../../feature-flags/hooks');
+
   return {
     ...actual,
     Table: (props) => {
       const { data, filters, selected, match, kindObj } = props;
       const cProps = { data, filters, selected, match, kindObj };
       const columns = props.Header(cProps);
+      const isBuildServiceAccountFeatureOn = useIsOnFeatureFlag('buildServiceAccount');
+
       return (
         <PfTable role="table" aria-label="table" cells={columns} variant="compact" borders={false}>
           <TableHeader role="rowgroup" />
           <tbody>
-            {props.data.map((d, i) => (
+            {data.map((d, i) => (
               <tr key={i}>
-                <SecretsListRow columns={null} obj={d} customData={props.customData} />
+                {isBuildServiceAccountFeatureOn ? (
+                  <SecretsListRowWithComponents
+                    columns={columns}
+                    obj={d}
+                    customData={props.customData}
+                  />
+                ) : (
+                  <SecretsListRow columns={columns} obj={d} customData={props.customData} />
+                )}
               </tr>
             ))}
           </tbody>
@@ -53,6 +78,8 @@ jest.mock('../../../shared/components/table', () => {
 });
 
 const useSecretsMock = useSecrets as jest.Mock;
+const mockUseLinkedServiceAccounts = useLinkedServiceAccounts as jest.Mock;
+const mockUseIsOnFeatureFlag = useIsOnFeatureFlag as jest.Mock;
 
 const SecretsList = (
   <MemoryRouter>
@@ -93,6 +120,107 @@ describe('Secrets List', () => {
 
     screen.getByText('test-secret-one');
     screen.getByText('Image pull');
+  });
+
+  it('should filter the remote secrets in the workspace', () => {
+    useSecretsMock.mockReturnValue([
+      [
+        {
+          metadata: { name: 'test-secret-three' },
+          ...sampleRemoteSecrets[RemoteSecretStatusReason.AwaitingData],
+          type: 'kubernetes.io/dockerconfigjson',
+        },
+        {
+          metadata: { name: 'test-secret-two' },
+          ...sampleRemoteSecrets[RemoteSecretStatusReason.Injected],
+          type: 'Opaque',
+          data: { keys: ['test'] },
+        },
+      ],
+      true,
+    ]);
+    render(SecretsList);
+
+    const filter = screen.getByPlaceholderText<HTMLInputElement>('Filter by name...');
+    act(() => {
+      fireEvent.change(filter, {
+        target: { value: 'test-secret-two' },
+      });
+      jest.advanceTimersByTime(700);
+    });
+
+    expect(filter.value).toBe('test-secret-two');
+    expect(screen.queryByText('test-secret-one')).not.toBeInTheDocument();
+
+    screen.getByText('test-secret-two');
+    screen.getByText('Key/value (1)');
+  });
+});
+
+describe('Secrets List With Components', () => {
+  beforeEach(() => {
+    mockUseIsOnFeatureFlag.mockReturnValue(true);
+    useSecretsMock.mockReturnValue([
+      [
+        {
+          ...sampleRemoteSecrets[RemoteSecretStatusReason.AwaitingData],
+          type: 'kubernetes.io/dockerconfigjson',
+        },
+      ],
+      true,
+    ]);
+    mockUseLinkedServiceAccounts.mockReturnValue({
+      linkedServiceAccounts: mockServiceAccounts,
+      isLoading: false,
+      error: null,
+    });
+  });
+  it('should render the loader if the secrets are not loaded', () => {
+    useSecretsMock.mockReturnValue([[], false]);
+    render(SecretsList);
+
+    screen.getByRole('progressbar');
+  });
+
+  it('should render the empty state if there are not remote secrets in the workspace', () => {
+    useSecretsMock.mockReturnValue([[], true]);
+    render(SecretsList);
+
+    expect(screen.queryByTestId('secrets-empty-state')).toBeInTheDocument();
+  });
+
+  it('should render all the remote secrets in the namespace', () => {
+    render(SecretsList);
+
+    expect(screen.queryByTestId('secrets-empty-state')).not.toBeInTheDocument();
+    screen.getByText('test-secret-one');
+    screen.getByText('Image pull');
+    screen.getByText('Components');
+    expect(screen.getByTestId('components-content')).toHaveTextContent('2');
+  });
+
+  it('should render all the remote secrets with loading components in the namespace', () => {
+    mockUseLinkedServiceAccounts.mockReturnValue({
+      linkedServiceAccounts: mockServiceAccounts,
+      isLoading: true,
+      error: null,
+    });
+    render(SecretsList);
+    screen.getByText('Components');
+    screen.getByRole('progressbar');
+  });
+
+  it('should render all the remote secrets with  error components in the namespace', () => {
+    mockUseLinkedServiceAccounts.mockReturnValue({
+      linkedServiceAccounts: mockServiceAccounts,
+      isLoading: false,
+      error: {
+        message: 'Forbidden',
+      },
+    });
+    render(SecretsList);
+    screen.getByText('Components');
+    expect(screen.getByTestId('components-content')).toHaveTextContent('Error');
   });
 
   it('should filter the remote secrets in the workspace', () => {

--- a/src/components/Secrets/secret-actions.ts
+++ b/src/components/Secrets/secret-actions.ts
@@ -4,18 +4,15 @@ import { Action } from '../../shared/components/action-menu/types';
 import { SecretKind } from '../../types';
 import { useAccessReviewForModel } from '../../utils/rbac';
 import { useModalLauncher } from '../modal/ModalProvider';
-import { secretDeleteModal, secretDeleteModalForBuildServiceAccount } from './secret-modal';
+import { secretDeleteModal } from './secret-modal';
 
 export const useSecretActions = (secret: SecretKind): Action[] => {
   const showModal = useModalLauncher();
   const [canDelete] = useAccessReviewForModel(SecretModel, 'delete');
-  const isNew = useIsOnFeatureFlag('buildServiceAccount');
+  const isBuildServiceAccountFeatureOn = useIsOnFeatureFlag('buildServiceAccount');
   return [
     {
-      cta: () =>
-        showModal(
-          !isNew ? secretDeleteModal(secret) : secretDeleteModalForBuildServiceAccount(secret),
-        ),
+      cta: () => showModal(secretDeleteModal(secret, isBuildServiceAccountFeatureOn)),
       id: `delete-${secret.metadata.name.toLowerCase()}`,
       label: 'Delete',
       disabled: !canDelete,

--- a/src/components/Secrets/secret-modal.tsx
+++ b/src/components/Secrets/secret-modal.tsx
@@ -1,5 +1,5 @@
-import { SecretModel } from '../../models';
-import { SecretKind, SecretTypeDisplayLabel } from '../../types';
+import { SecretModel } from '~/models';
+import { SecretKind, SecretTypeDisplayLabel } from '~/types';
 import { createDeleteModalLauncher } from '../modal/DeleteResourceModal';
 import { typeToLabel } from './utils/secret-utils';
 import {
@@ -7,28 +7,17 @@ import {
   unlinkSecretFromServiceAccounts,
 } from './utils/service-account-utils';
 
-export const secretDeleteModalForBuildServiceAccount = (secret: SecretKind) =>
-  createDeleteModalLauncher(secret.kind)({
-    obj: secret,
-    model: SecretModel,
-    submitCallback: unlinkSecretFromServiceAccounts,
-    displayName: secret.metadata.name,
-    description: (
-      <>
-        The secret <strong>{secret.metadata.name}</strong> and its value will be deleted from all
-        the environments it is attached to.
-      </>
-    ),
-  });
+export const secretDeleteModal = (secret: SecretKind, isFeatureFlagEnabled: boolean) => {
+  const submitCallback = isFeatureFlagEnabled
+    ? unlinkSecretFromServiceAccounts
+    : typeToLabel(secret.type) === SecretTypeDisplayLabel.imagePull
+      ? unLinkSecretFromServiceAccount
+      : null;
 
-export const secretDeleteModal = (secret: SecretKind) =>
-  createDeleteModalLauncher(secret.kind)({
+  return createDeleteModalLauncher(secret.kind)({
     obj: secret,
     model: SecretModel,
-    submitCallback:
-      typeToLabel(secret.type) === SecretTypeDisplayLabel.imagePull
-        ? unLinkSecretFromServiceAccount
-        : null,
+    submitCallback,
     displayName: secret.metadata.name,
     description: (
       <>
@@ -37,3 +26,4 @@ export const secretDeleteModal = (secret: SecretKind) =>
       </>
     ),
   });
+};

--- a/src/components/Secrets/utils/__tests__/service-account-utils.spec.ts
+++ b/src/components/Secrets/utils/__tests__/service-account-utils.spec.ts
@@ -9,6 +9,7 @@ import {
   linkSecretToBuildServiceAccount,
   unLinkSecretFromBuildServiceAccount,
   unLinkSecretFromServiceAccount,
+  isLinkableSecret,
 } from '../service-account-utils';
 
 const imagePullSecret = {
@@ -53,6 +54,35 @@ const testSecrets = [
 const k8sPatchResourceMock = createK8sUtilMock('K8sQueryPatchResource');
 const k8sGetResourceMock = createK8sUtilMock('K8sGetResource');
 const K8sListResourceItemsMock = createK8sUtilMock('K8sListResourceItems');
+
+describe('isLinkableSecret', () => {
+  it('should return true for dockerjson/dockercfg/basicAuth', () => {
+    for (const validType of [
+      SecretType.dockercfg,
+      SecretType.dockerconfigjson,
+      SecretType.basicAuth,
+    ]) {
+      const validSecret = { ...imagePullSecret, type: validType };
+      expect(isLinkableSecret(validSecret)).toBe(true);
+    }
+  });
+
+  it('should return false for invalid secret types', () => {
+    for (const invalidType of [
+      SecretType.opaque,
+      SecretType.sshAuth,
+      SecretType.tls,
+      SecretType.serviceAccountToken,
+    ]) {
+      const invalidSecret = { ...imagePullSecret, type: invalidType };
+      expect(isLinkableSecret(invalidSecret)).toBe(false);
+    }
+  });
+
+  it('should return false when secret is undefined', () => {
+    expect(isLinkableSecret(undefined)).toBe(false);
+  });
+});
 
 describe('linkSecretToServiceAccount', () => {
   beforeEach(() => {

--- a/src/hooks/__tests__/useLinkedServiceAccounts.spec.tsx
+++ b/src/hooks/__tests__/useLinkedServiceAccounts.spec.tsx
@@ -1,0 +1,72 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { mockServiceAccounts } from '~/components/Secrets/__data__/mock-secrets';
+import * as serviceAccountUtils from '~/components/Secrets/utils/service-account-utils';
+import { createK8sWatchResourceMock } from '~/utils/test-utils';
+import { useLinkedServiceAccounts } from '../useLinkedServiceAccounts';
+
+jest.mock('~/components/Secrets/utils/service-account-utils', () => ({
+  ...jest.requireActual('~/components/Secrets/utils/service-account-utils'),
+  filterLinkedServiceAccounts: jest.fn(),
+}));
+
+const useK8sWatchResourceMock = createK8sWatchResourceMock();
+
+describe('useLinkedServiceAccounts', () => {
+  const namespace = 'test-namespace';
+  const secretName = 'test-secret';
+  const watch = true;
+
+  const mockFilterLinkedServiceAccounts =
+    serviceAccountUtils.filterLinkedServiceAccounts as jest.Mock;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns empty array and loading true initially', () => {
+    useK8sWatchResourceMock.mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useLinkedServiceAccounts(namespace, secretName, watch));
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.linkedServiceAccounts).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns filtered linked service accounts when data is loaded', () => {
+    useK8sWatchResourceMock.mockReturnValue({
+      data: mockServiceAccounts,
+      isLoading: false,
+      error: null,
+    });
+
+    const filteredAccounts = [mockServiceAccounts[1]];
+    mockFilterLinkedServiceAccounts.mockReturnValue(filteredAccounts);
+
+    const { result } = renderHook(() => useLinkedServiceAccounts(namespace, secretName, watch));
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.linkedServiceAccounts).toEqual(filteredAccounts);
+    expect(mockFilterLinkedServiceAccounts).toHaveBeenCalledWith(secretName, mockServiceAccounts);
+  });
+
+  it('returns error when useK8sWatchResource returns error', () => {
+    const mockError = new Error('Failed to load');
+    useK8sWatchResourceMock.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: mockError,
+    });
+
+    const { result } = renderHook(() => useLinkedServiceAccounts(namespace, secretName, watch));
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe(mockError);
+    expect(result.current.linkedServiceAccounts).toEqual([]);
+  });
+});

--- a/src/hooks/useLinkedServiceAccounts.ts
+++ b/src/hooks/useLinkedServiceAccounts.ts
@@ -1,0 +1,32 @@
+import { useMemo } from 'react';
+import { filterLinkedServiceAccounts } from '~/components/Secrets/utils/service-account-utils';
+import { useK8sWatchResource } from '~/k8s';
+import { ServiceAccountGroupVersionKind, ServiceAccountModel } from '~/models';
+import { ServiceAccountKind } from '~/types';
+
+export const useLinkedServiceAccounts = (namespace: string, secretName: string, watch: boolean) => {
+  const {
+    data: serviceAccounts,
+    isLoading,
+    error,
+  } = useK8sWatchResource<ServiceAccountKind[]>(
+    {
+      groupVersionKind: ServiceAccountGroupVersionKind,
+      namespace,
+      isList: true,
+      watch,
+    },
+    ServiceAccountModel,
+  );
+
+  const linkedServiceAccounts: ServiceAccountKind[] = useMemo(() => {
+    if (isLoading || !serviceAccounts) return [];
+    return filterLinkedServiceAccounts(secretName, serviceAccounts);
+  }, [secretName, serviceAccounts, isLoading]);
+
+  return {
+    linkedServiceAccounts,
+    isLoading,
+    error,
+  };
+};

--- a/src/types/secret.ts
+++ b/src/types/secret.ts
@@ -162,6 +162,12 @@ export enum SecretType {
   tls = 'kubernetes.io/tls',
 }
 
+export enum LinkableSecretType {
+  dockerconfigjson = 'kubernetes.io/dockerconfigjson',
+  basicAuth = 'kubernetes.io/basic-auth',
+  dockercfg = 'kubernetes.io/dockercfg',
+}
+
 export type ServiceAccountKind = {
   automountServiceAccountToken?: boolean;
   imagePullSecrets?: SecretKind[] | { [key: string]: string }[];


### PR DESCRIPTION
## Fixes 
[KFLUXUI-417](https://issues.redhat.com/browse/KFLUXUI-417)


## Description
The patch is aimed to show the components number linked to the current secret in the secret list page.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
When loaded, the number would be shown. While, when loading, the spinner would be shown:
![Screenshot 2025-04-29 at 17 14 22](https://github.com/user-attachments/assets/f5752b90-6230-447a-a805-c3099a6724fa)

When error happens, the Error would be shown:
![Screenshot 2025-04-22 at 14 15 14](https://github.com/user-attachments/assets/0ba1715b-06f1-429b-822f-21c6e695fed0)

and also the tootips when user mouse over:
<img width="407" alt="Screenshot 2025-05-15 at 19 23 23" src="https://github.com/user-attachments/assets/8e6a2630-2b0e-4056-abbc-b233f6a77a27" />


For those secrets which are not able to link service accounts, the column would be shown as '-':
![Screenshot 2025-04-29 at 17 14 01](https://github.com/user-attachments/assets/cc1cfc79-2cfc-4520-ad48-446147eab255)

## How to test or reproduce?
Add the secrets and choose components to link then check whether the number of component shown in the secret list page is expected.

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->