### PR TITLE
fix: uploading test results to Sealights

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -118,9 +118,9 @@ run_test() {
         TEST_RUN=1
     fi
 
-    podman run --network host --userns=keep-id --group-add keep-groups -v "$PWD/artifacts:/artifacts" --workdir /artifacts -e NODE_DEBUG=sl \
+    podman run --network host --userns=keep-id --group-add keep-groups -v "$PWD:/konflux-ui" --workdir /konflux-ui -e NODE_DEBUG=sl \
         $NODEJS_AGENT_IMAGE \
-        /bin/bash -cx "slnodejs uploadReports --teststage ${TEST_STAGE_NAME} --buildsessionidfile buildSessionId --reportfile \$(ls *.xml) --token ${SEALIGHTS_TOKEN}"
+        /bin/bash -cx "slnodejs uploadReports --teststage ${TEST_STAGE_NAME} --buildsessionidfile buildSessionId --reportfile \$(ls ./artifacts/*.xml) --token ${SEALIGHTS_TOKEN}"
 
     podman run --network host --userns=keep-id --group-add keep-groups -v "$PWD:/konflux-ui" --workdir /konflux-ui -e NODE_DEBUG=sl \
         $NODEJS_AGENT_IMAGE \


### PR DESCRIPTION
## Fixes 
fixes an issue with uploading test results to Sealights

## Description

Fixes this error seen in the log:
```
+ slnodejs uploadReports --teststage konflux-ui-e2e --buildsessionidfile buildSessionId --reportfile junit-0253c5255f4a0c4df6d47b77c3693736.xml --token ***
10:10:41.025Z INFO NodeJS-Agent: Starting sealights agent with command 'startExecution',  agentId: xxx
10:10:41.087Z ERROR NodeJS-Agent: Failed to read buildsessionidfile. Error Error: ENOENT: no such file or directory, open 'buildSessionId'
```

## Verification

See the log of this PR's e2e check run:
```
+ slnodejs uploadReports --teststage konflux-ui-e2e --buildsessionidfile buildSessionId --reportfile ./artifacts/junit-106a4f25bae42b65f65d915c0211da40.xml --token ***
05:11:17.844Z INFO NodeJS-Agent: Starting sealights agent with command 'startExecution',  agentId: xxx
...
05:11:22.135Z INFO NodeJS-Agent: [END EXECUTION] execution ended successfully
05:11:22.137Z INFO NodeJS-Agent: Sending POST request. Url: 'https://redhat.sealights.co/api/v3/agents/agent-events/'
05:11:22.265Z INFO NodeJS-Agent: Submitted '1' events successfully
```


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [X] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):