### PR TITLE
KFLUXUI-424: Add "Manage Linked Secrets" page

### DIFF
--- a/src/components/Components/LinkedSecretsListView/LinkedSecretsListHeader.tsx
+++ b/src/components/Components/LinkedSecretsListView/LinkedSecretsListHeader.tsx
@@ -1,0 +1,28 @@
+import { createTableHeaders } from '../../../shared/components/table/utils';
+
+export const linkedSecretsTableColumnClasses = {
+  secretName: 'pf-m-width-25 wrap-column',
+  type: 'pf-m-width-20',
+  labels: 'pf-m-width-25 wrap-column',
+  actions: 'pf-m-width-25',
+  kebab: 'pf-m-width-5',
+};
+
+export const enum SortableHeaders {
+  secretName,
+  type,
+}
+
+const linkedSecretsColumns = [
+  {
+    title: 'Secret name',
+    className: linkedSecretsTableColumnClasses.secretName,
+    sortable: true,
+  },
+  { title: 'Type', className: linkedSecretsTableColumnClasses.type, sortable: true },
+  { title: 'Labels', className: linkedSecretsTableColumnClasses.labels },
+  { title: 'Actions', className: linkedSecretsTableColumnClasses.actions },
+  { title: ' ', className: linkedSecretsTableColumnClasses.kebab },
+];
+
+export default createTableHeaders(linkedSecretsColumns);

--- a/src/components/Components/LinkedSecretsListView/LinkedSecretsListRow.tsx
+++ b/src/components/Components/LinkedSecretsListView/LinkedSecretsListRow.tsx
@@ -1,0 +1,45 @@
+import { Button, Flex, Label, Text, TextVariants } from '@patternfly/react-core';
+import { RowFunctionArgs, TableData } from '../../../shared';
+import { SecretKind } from '../../../types';
+import { linkedSecretsTableColumnClasses } from './LinkedSecretsListHeader';
+
+import './LinkedSecretsListView.scss';
+
+export const LinkedSecretsListRow: React.FC<RowFunctionArgs<SecretKind>> = ({ obj: secret }) => {
+  return (
+    <>
+      <TableData className={linkedSecretsTableColumnClasses.secretName}>
+        <Text component={TextVariants.p}>{secret.metadata.name}</Text>
+      </TableData>
+
+      <TableData className={linkedSecretsTableColumnClasses.type}>
+        <Text component={TextVariants.p}>{secret.type}</Text>
+      </TableData>
+
+      <TableData className={linkedSecretsTableColumnClasses.labels}>
+        {secret.metadata.labels ? (
+          Object.keys(secret.metadata.labels ?? {}).map((key) => (
+            <Label
+              key={key}
+              className="linked-secrets-list-view__label"
+            >{`${key}=${secret.metadata.labels[key]}`}</Label>
+          ))
+        ) : (
+          <Text component={TextVariants.p}> - </Text>
+        )}
+      </TableData>
+
+      <TableData className={linkedSecretsTableColumnClasses.actions}>
+        {/* TODO: onClick logic will be implemented in another ticket*/}
+        {/* eslint-disable-next-line no-alert */}
+        <Button variant="secondary" onClick={() => alert('TODO')}>
+          Unlink
+        </Button>
+      </TableData>
+
+      <TableData className={linkedSecretsTableColumnClasses.kebab}>
+        <Flex direction={{ default: 'column' }} />
+      </TableData>
+    </>
+  );
+};

--- a/src/components/Components/LinkedSecretsListView/LinkedSecretsListView.scss
+++ b/src/components/Components/LinkedSecretsListView/LinkedSecretsListView.scss
@@ -1,0 +1,5 @@
+.linked-secrets-list-view {
+  &__label:not(:last-child) {
+    margin-bottom: var(--pf-v5-global--spacer--sm);
+  }
+}

--- a/src/components/Components/LinkedSecretsListView/LinkedSecretsListView.tsx
+++ b/src/components/Components/LinkedSecretsListView/LinkedSecretsListView.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import {
+  TextContent,
+  Text,
+  TextVariants,
+  PageSection,
+  PageSectionVariants,
+  Bullseye,
+  Spinner,
+  EmptyStateBody,
+  Button,
+} from '@patternfly/react-core';
+import { SortByDirection } from '@patternfly/react-table';
+import emptyStateImgUrl from '../../../assets/secret.svg';
+import { useComponent } from '../../../hooks/useComponents';
+import { useLinkedSecrets } from '../../../hooks/useLinkedSecrets';
+import { useSortedResources } from '../../../hooks/useSortedResources';
+import { HttpError } from '../../../k8s/error';
+import {
+  COMPONENT_DETAILS_PATH,
+  COMPONENT_LIST_PATH,
+  COMPONENT_LINKED_SECRETS_PATH,
+} from '../../../routes/paths';
+import { RouterParams } from '../../../routes/utils';
+import { Table } from '../../../shared/components';
+import AppEmptyState from '../../../shared/components/empty-state/AppEmptyState';
+import ErrorEmptyState from '../../../shared/components/empty-state/ErrorEmptyState';
+import { useNamespace } from '../../../shared/providers/Namespace';
+import { SecretKind } from '../../../types';
+import { useApplicationBreadcrumbs } from '../../../utils/breadcrumb-utils';
+import PageLayout from '../../PageLayout/PageLayout';
+import getListHeader, { SortableHeaders } from './LinkedSecretsListHeader';
+import { LinkedSecretsListRow } from './LinkedSecretsListRow';
+
+const sortPaths: Record<SortableHeaders, string> = {
+  [SortableHeaders.secretName]: 'metadata.name',
+  [SortableHeaders.type]: 'type',
+};
+
+export const LinkedSecretsListView: React.FC = () => {
+  const { componentName, applicationName } = useParams<RouterParams>();
+  const namespace = useNamespace();
+  const applicationBreadcrumbs = useApplicationBreadcrumbs();
+  const [component, componentLoaded, componentError] = useComponent(namespace, componentName);
+  const [activeSortIndex, setActiveSortIndex] = React.useState<number>(SortableHeaders.secretName);
+  const [activeSortDirection, setActiveSortDirection] = React.useState<SortByDirection>(
+    SortByDirection.asc,
+  );
+  const [linkedSecrets, linkedSecretsLoaded, linkedSecretsError] = useLinkedSecrets(
+    namespace,
+    componentName,
+  );
+
+  const LinkedSecretsListHeader = React.useMemo(
+    () =>
+      getListHeader(activeSortIndex, activeSortDirection, (_, index, direction) => {
+        setActiveSortIndex(index);
+        setActiveSortDirection(direction);
+      }),
+    [activeSortDirection, activeSortIndex],
+  );
+
+  const sortedLinkedSecrets = useSortedResources(
+    linkedSecrets,
+    activeSortIndex,
+    activeSortDirection,
+    sortPaths,
+  );
+
+  if (!componentLoaded || !linkedSecretsLoaded) {
+    return (
+      <Bullseye>
+        <Spinner data-test="spinner" />
+      </Bullseye>
+    );
+  }
+
+  if (componentError || linkedSecretsError) {
+    const error = componentError ?? linkedSecretsError;
+    const httpError = HttpError.fromCode((error as { code: number }).code);
+    return (
+      <ErrorEmptyState
+        data-test="linked-secrets-list-view_error-empty-state"
+        httpError={httpError}
+        title="Unable to load linked secrets"
+        body={httpError?.message.length ? httpError?.message : 'Something went wrong'}
+      />
+    );
+  }
+
+  const NoDataEmptyMessage = () => (
+    <AppEmptyState
+      emptyStateImg={emptyStateImgUrl}
+      title="No linked secrets found"
+      data-test="linked-secrets-list-no-data-empty-message"
+    >
+      <EmptyStateBody>
+        To get started, select link secrets to link already existing secrets
+      </EmptyStateBody>
+      <Button
+        variant="primary"
+        // TODO: the "link secrets" functionality will be implemented in another ticket
+        // eslint-disable-next-line no-alert
+        onClick={() => alert('TODO')}
+        style={{ marginTop: 'var(--pf-v5-global--spacer--md)' }}
+      >
+        Link secrets
+      </Button>
+    </AppEmptyState>
+  );
+
+  return (
+    <>
+      <PageLayout
+        title="Manage linked secrets"
+        description={<>You can add new secrets to this component or unlink existing secrets.</>}
+        breadcrumbs={[
+          ...applicationBreadcrumbs,
+          {
+            path: COMPONENT_LIST_PATH.createPath({
+              workspaceName: namespace,
+              applicationName,
+            }),
+            name: 'components',
+          },
+          {
+            path: COMPONENT_DETAILS_PATH.createPath({
+              workspaceName: namespace,
+              applicationName,
+              componentName,
+            }),
+            name: component.metadata.name,
+          },
+          {
+            path: COMPONENT_LINKED_SECRETS_PATH.createPath({
+              workspaceName: namespace,
+              applicationName,
+              componentName,
+            }),
+            name: 'Manage linked secrets',
+          },
+        ]}
+      >
+        <PageSection variant={PageSectionVariants.light} isFilled>
+          <TextContent>
+            <Text component={TextVariants.p}>Linked secrets</Text>
+          </TextContent>
+
+          <Table
+            virtualize={false}
+            data={sortedLinkedSecrets}
+            unfilteredData={sortedLinkedSecrets}
+            NoDataEmptyMsg={NoDataEmptyMessage}
+            aria-label="Linked Secrets List"
+            Header={LinkedSecretsListHeader}
+            Row={LinkedSecretsListRow}
+            loaded={linkedSecretsLoaded}
+            getRowProps={(obj: SecretKind) => ({
+              id: `${obj.metadata.name}-linked-secret-list-item`,
+              'aria-label': obj.metadata.name,
+            })}
+          />
+        </PageSection>
+      </PageLayout>
+    </>
+  );
+};

--- a/src/components/Components/LinkedSecretsListView/__tests__/LinkedSecretsListView.spec.tsx
+++ b/src/components/Components/LinkedSecretsListView/__tests__/LinkedSecretsListView.spec.tsx
@@ -1,0 +1,85 @@
+import { BrowserRouter } from 'react-router-dom';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { mockedSecret } from '../../../../hooks/__data__/mock-data';
+import { useComponent } from '../../../../hooks/useComponents';
+import { useLinkedSecrets } from '../../../../hooks/useLinkedSecrets';
+import { createTestQueryClient } from '../../../../utils/test-utils';
+import { mockComponentsData } from '../../../ApplicationDetails/__data__';
+import { LinkedSecretsListView } from '../LinkedSecretsListView';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: jest.fn(() => ({ t: (x) => x })),
+}));
+jest.mock('../../../../hooks/useLinkedSecrets', () => ({
+  useLinkedSecrets: jest.fn(),
+}));
+jest.mock('../../../../hooks/useComponents', () => ({
+  useComponent: jest.fn(),
+}));
+
+const useLinkedSecretsMock = useLinkedSecrets as jest.Mock;
+const useComponentMock = useComponent as jest.Mock;
+
+const renderComponent = () => {
+  const queryClient = createTestQueryClient();
+  return render(<LinkedSecretsListView />, {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>{children}</BrowserRouter>
+      </QueryClientProvider>
+    ),
+  });
+};
+
+describe('LinkedSecretsListView', () => {
+  beforeEach(() => {
+    useLinkedSecretsMock.mockReturnValue([
+      [
+        {
+          ...mockedSecret,
+          metadata: {
+            ...mockedSecret.metadata,
+            name: 'build-pipeline-c7814-dockercfg-bksxm',
+            deletionTimestamp: undefined,
+          },
+        },
+      ],
+      true,
+    ]);
+    useComponentMock.mockReturnValue([mockComponentsData[0], true]);
+  });
+
+  it('should render spinner if application data is not loaded', () => {
+    useLinkedSecretsMock.mockReturnValue([[], false]);
+    renderComponent();
+    screen.getByTestId('spinner');
+  });
+
+  it("it should render error empty state component if there's an API error", () => {
+    useLinkedSecretsMock.mockReturnValue([[], true, new Error('Error when fetching secrets')]);
+    renderComponent();
+
+    expect(screen.getByTestId('linked-secrets-list-view_error-empty-state')).toBeInTheDocument();
+  });
+
+  it('should render empty message component if no data is returned', () => {
+    useLinkedSecretsMock.mockReturnValue([[], true]);
+    renderComponent();
+
+    expect(screen.getByTestId('linked-secrets-list-no-data-empty-message')).toBeInTheDocument();
+  });
+
+  it('should render correct columns when linkedSecrets are present', () => {
+    renderComponent();
+    screen.queryByText('Secret name');
+    screen.queryByText('Type');
+    screen.queryByText('Labels');
+    screen.queryAllByText('Actions');
+  });
+
+  it('should render entire linkedSecrets list', () => {
+    renderComponent();
+    expect(screen.queryByText('build-pipeline-c7814-dockercfg-bksxm')).toBeInTheDocument();
+  });
+});

--- a/src/components/Components/LinkedSecretsListView/index.ts
+++ b/src/components/Components/LinkedSecretsListView/index.ts
@@ -1,0 +1,15 @@
+import { K8sQueryListResourceItems } from '../../../k8s';
+import { SecretModel, ServiceAccountModel } from '../../../models';
+import { RouterParams } from '../../../routes/utils';
+import { createLoaderWithAccessCheck } from '../../../utils/rbac';
+
+export const linkedSecretsListViewLoader = createLoaderWithAccessCheck(
+  async ({ params }) => {
+    const ns = params[RouterParams.workspaceName];
+    return await K8sQueryListResourceItems({
+      model: SecretModel,
+      queryOptions: { ns },
+    });
+  },
+  { model: ServiceAccountModel, verb: 'patch' },
+);

--- a/src/components/Components/__data__/mock-data.ts
+++ b/src/components/Components/__data__/mock-data.ts
@@ -171,7 +171,7 @@ export const mockedActions = [
     },
     disabled: false,
     disabledTooltip: "You don't have access to manage linked secrets",
-    id: 'manage-linked-secrets-basic-node-js',
+    id: 'linked-secrets-basic-node-js',
     label: 'Manage linked secrets',
   },
   {

--- a/src/components/Components/component-actions.tsx
+++ b/src/components/Components/component-actions.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useIsOnFeatureFlag } from '../../feature-flags/hooks';
 import { ComponentModel, ServiceAccountModel } from '../../models';
+import { COMPONENT_LINKED_SECRETS_PATH } from '../../routes/paths';
 import { Action } from '../../shared/components/action-menu/types';
 import { useNamespace } from '../../shared/providers/Namespace/useNamespaceInfo';
 import { ComponentKind } from '../../types';
@@ -63,9 +64,13 @@ export const useComponentActions = (component: ComponentKind, name: string): Act
         ? [
             {
               cta: {
-                href: './', // TODO: navigate to "Manage linked secrets" page once it's implemented
+                href: COMPONENT_LINKED_SECRETS_PATH.createPath({
+                  workspaceName: namespace,
+                  applicationName,
+                  componentName: component.metadata.name,
+                }),
               },
-              id: `manage-linked-secrets-${name.toLowerCase()}`,
+              id: `linked-secrets-${name.toLowerCase()}`,
               label: 'Manage linked secrets',
               disabled: !canManageLinkedSecrets,
               disabledTooltip: "You don't have access to manage linked secrets",

--- a/src/hooks/__data__/mock-data.ts
+++ b/src/hooks/__data__/mock-data.ts
@@ -1,3 +1,4 @@
+import { SecretKind, ServiceAccountKind } from '../../types';
 import { LimitRange, SnapshotEnvironmentBinding } from '../../types/coreBuildService';
 import { RouteKind } from '../../types/routes';
 
@@ -514,3 +515,76 @@ export const mockLimitRange: LimitRange = {
     ],
   },
 };
+
+export const mockedServiceAccount: ServiceAccountKind = {
+  kind: 'ServiceAccount',
+  apiVersion: 'v1',
+  metadata: {
+    name: 'build-pipeline-c7814',
+    namespace: 'rh-ee-rgalvao-tenant',
+    uid: '1e50e721-a93d-41d4-8f3a-8da999c67d1c',
+  },
+  secrets: [
+    {
+      name: 'build-pipeline-c7814-dockercfg-bksxm',
+    },
+    {
+      name: 'c7814-image-push',
+    },
+    {
+      name: 'testing-new-secret',
+    },
+    {
+      name: 'aha-new-test',
+    },
+  ],
+  imagePullSecrets: [
+    {
+      name: 'build-pipeline-c7814-dockercfg-bksxm',
+    },
+    {
+      name: 'testing-new-secret',
+    },
+    {
+      name: 'aha-new-test',
+    },
+  ],
+};
+
+export const mockedSecret: SecretKind = {
+  metadata: {
+    name: 'a036c-image-pull',
+    namespace: 'rh-ee-rgalvao-tenant',
+    uid: 'bbb8afad-4043-4eba-93c3-bb51331e88cd',
+    creationTimestamp: '2025-04-14T09:07:41Z',
+    deletionTimestamp: '2025-04-17T12:55:26Z',
+    labels: { 'appstudio.redhat.com/internal': 'true' },
+  },
+  type: 'kubernetes.io/dockerconfigjson',
+  apiVersion: 'v1',
+  kind: 'Secret',
+};
+
+export const mockedSecrets: SecretKind[] = [
+  mockedSecret,
+  {
+    ...mockedSecret,
+    metadata: { ...mockedSecret.metadata, name: 'a342f-image-pull', deletionTimestamp: undefined },
+  },
+  {
+    ...mockedSecret,
+    metadata: {
+      ...mockedSecret.metadata,
+      name: 'build-pipeline-c7814-dockercfg-bksxm',
+      deletionTimestamp: undefined,
+    },
+  },
+  {
+    ...mockedSecret,
+    metadata: {
+      ...mockedSecret.metadata,
+      name: 'build-pipeline-c7814-token-fbljb',
+      deletionTimestamp: undefined,
+    },
+  },
+];

--- a/src/hooks/__tests__/useLinkedSecrets.spec.ts
+++ b/src/hooks/__tests__/useLinkedSecrets.spec.ts
@@ -1,0 +1,76 @@
+import { renderHook } from '@testing-library/react';
+import { createK8sWatchResourceMock } from '../../utils/test-utils';
+import { mockedSecrets, mockedServiceAccount } from '../__data__/mock-data';
+import { useLinkedSecrets } from '../useLinkedSecrets';
+import { useServiceAccount } from '../useServiceAccount';
+
+jest.mock('../useServiceAccount', () => ({
+  useServiceAccount: jest.fn(() => [mockedServiceAccount, true]),
+}));
+const useK8sWatchResourceMock = createK8sWatchResourceMock();
+const useServiceAccountMock = useServiceAccount as jest.Mock;
+
+describe('useLinkedSecrets', () => {
+  beforeEach(() => {
+    useK8sWatchResourceMock.mockReturnValue([mockedSecrets, true, undefined]);
+  });
+
+  it('should return filtered linked secrets', () => {
+    const { result } = renderHook(() => useLinkedSecrets('rh-ee-rgalvao-tenant', 'c7814'));
+
+    const [secrets, loaded] = result.current;
+
+    expect(loaded).toBe(true);
+    expect(secrets.map((tr) => tr.metadata?.name)).toEqual([
+      'build-pipeline-c7814-dockercfg-bksxm',
+    ]);
+  });
+
+  it('should return an empty array when secrets are loading', () => {
+    useK8sWatchResourceMock.mockReturnValue({
+      data: [],
+      isLoading: true,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useLinkedSecrets('rh-ee-rgalvao-tenant', 'c7814'));
+    expect(result.current[0]).toEqual([]);
+    expect(result.current[1]).toBe(false);
+  });
+
+  it('should return an empty array when useServiceAccount is loading', () => {
+    useServiceAccountMock.mockReturnValue([null, false]);
+
+    const { result } = renderHook(() => useLinkedSecrets('rh-ee-rgalvao-tenant', 'c7814'));
+    expect(result.current[0]).toEqual([]);
+    expect(result.current[1]).toBe(false);
+  });
+
+  it('should return an error if secrets API returns error', () => {
+    useK8sWatchResourceMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: new Error('An API error happened'),
+    });
+
+    const { result } = renderHook(() => useLinkedSecrets('rh-ee-rgalvao-tenant', 'c7814'));
+    expect(result.current[0]).toEqual([]);
+    expect(result.current[1]).toBe(false);
+    expect(result.current[2]).toStrictEqual(Error('An API error happened'));
+  });
+
+  it('should return an error if service account API returns error', () => {
+    useServiceAccountMock.mockReturnValue([
+      null,
+      false,
+      new Error('An API error happened when fetching service account'),
+    ]);
+
+    const { result } = renderHook(() => useLinkedSecrets('rh-ee-rgalvao-tenant', 'c7814'));
+    expect(result.current[0]).toEqual([]);
+    expect(result.current[1]).toBe(false);
+    expect(result.current[2]).toStrictEqual(
+      Error('An API error happened when fetching service account'),
+    );
+  });
+});

--- a/src/hooks/__tests__/useServiceAccount.spec.ts
+++ b/src/hooks/__tests__/useServiceAccount.spec.ts
@@ -1,0 +1,52 @@
+import { renderHook } from '@testing-library/react';
+import { createK8sWatchResourceMock } from '../../utils/test-utils';
+import { mockedServiceAccount } from '../__data__/mock-data';
+import { useServiceAccount } from '../useServiceAccount';
+
+const useK8sWatchResourceMock = createK8sWatchResourceMock();
+
+describe('useServiceAccount', () => {
+  beforeEach(() => {
+    useK8sWatchResourceMock.mockReturnValue([mockedServiceAccount, true, undefined]);
+  });
+
+  it('should return service account from provided serviceAccountName', () => {
+    const { result } = renderHook(() =>
+      useServiceAccount('rh-ee-rgalvao-tenant', 'build-pipeline-c7814'),
+    );
+
+    const [serviceAccount, loaded] = result.current;
+
+    expect(loaded).toBe(true);
+    expect(serviceAccount.metadata.name).toBe('build-pipeline-c7814');
+  });
+
+  it('should return null when service account API is loading', () => {
+    useK8sWatchResourceMock.mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+    });
+
+    const { result } = renderHook(() =>
+      useServiceAccount('rh-ee-rgalvao-tenant', 'build-pipeline-c7814'),
+    );
+    expect(result.current[0]).toEqual(null);
+    expect(result.current[1]).toBe(false);
+  });
+
+  it('should return an error if service account API returns error', () => {
+    useK8sWatchResourceMock.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: new Error('An API error happened'),
+    });
+
+    const { result } = renderHook(() =>
+      useServiceAccount('rh-ee-rgalvao-tenant', 'build-pipeline-c78147814'),
+    );
+    expect(result.current[0]).toEqual(null);
+    expect(result.current[1]).toBe(true);
+    expect(result.current[2]).toStrictEqual(Error('An API error happened'));
+  });
+});

--- a/src/hooks/useLinkedSecrets.ts
+++ b/src/hooks/useLinkedSecrets.ts
@@ -1,0 +1,64 @@
+import React from 'react';
+import { PIPELINE_SERVICE_ACCOUNT_PREFIX } from '../consts/pipeline';
+import { useK8sWatchResource } from '../k8s';
+import { SecretGroupVersionKind, SecretModel } from '../models';
+import { SecretKind } from '../types';
+import { useServiceAccount } from './useServiceAccount';
+
+export const useLinkedSecrets = (
+  namespace: string,
+  componentName: string,
+): [SecretKind[], boolean, unknown] => {
+  const {
+    data: secrets,
+    isLoading,
+    error,
+  } = useK8sWatchResource<SecretKind[]>(
+    {
+      groupVersionKind: SecretGroupVersionKind,
+      namespace,
+      isList: true,
+    },
+    SecretModel,
+  );
+
+  const serviceAccountName = `${PIPELINE_SERVICE_ACCOUNT_PREFIX}${componentName}`;
+
+  const [serviceAccount, serviceAccountLoaded, serviceAccountError] = useServiceAccount(
+    namespace,
+    serviceAccountName,
+  );
+
+  const serviceAccountSecrets = React.useMemo(
+    () => serviceAccount?.secrets?.map((s) => s.name) || [],
+    [serviceAccount?.secrets],
+  );
+  const serviceAccountImagePullSecrets = React.useMemo(
+    () => serviceAccount?.imagePullSecrets?.map((ip) => ip.name) || [],
+    [serviceAccount?.imagePullSecrets],
+  );
+
+  return React.useMemo(
+    () => [
+      !isLoading && !error && serviceAccountLoaded && !serviceAccountError
+        ? secrets?.filter((rs) => {
+            const hasLinkedSecret =
+              serviceAccountSecrets.includes(rs.metadata.name) ||
+              serviceAccountImagePullSecrets.includes(rs.metadata.name);
+            return !rs.metadata.deletionTimestamp && hasLinkedSecret;
+          })
+        : [],
+      !isLoading && serviceAccountLoaded,
+      error || serviceAccountError,
+    ],
+    [
+      isLoading,
+      error,
+      serviceAccountLoaded,
+      serviceAccountError,
+      secrets,
+      serviceAccountSecrets,
+      serviceAccountImagePullSecrets,
+    ],
+  );
+};

--- a/src/hooks/useServiceAccount.ts
+++ b/src/hooks/useServiceAccount.ts
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useK8sWatchResource } from '../k8s';
+import { SecretGroupVersionKind, ServiceAccountModel } from '../models';
+import { ServiceAccountKind } from '../types';
+
+export const useServiceAccount = (
+  namespace: string,
+  serviceAccountName: string,
+): [ServiceAccountKind, boolean, unknown] => {
+  const {
+    data: serviceAccount,
+    isLoading,
+    error,
+  } = useK8sWatchResource<ServiceAccountKind>(
+    { groupVersionKind: SecretGroupVersionKind, namespace, name: serviceAccountName },
+    ServiceAccountModel,
+  );
+
+  return React.useMemo(
+    () => [!isLoading && !error ? serviceAccount : null, !isLoading, error],
+    [isLoading, error, serviceAccount],
+  );
+};

--- a/src/routes/page-routes/components.tsx
+++ b/src/routes/page-routes/components.tsx
@@ -4,7 +4,9 @@ import {
   ComponentDetailsViewLayout,
   componentDetailsViewLoader,
 } from '../../components/Components/ComponentDetails';
-import { COMPONENT_DETAILS_PATH } from '../paths';
+import { linkedSecretsListViewLoader } from '../../components/Components/LinkedSecretsListView';
+import { LinkedSecretsListView } from '../../components/Components/LinkedSecretsListView/LinkedSecretsListView';
+import { COMPONENT_DETAILS_PATH, COMPONENT_LINKED_SECRETS_PATH } from '../paths';
 import { RouteErrorBoundry } from '../RouteErrorBoundary';
 import { RouterParams } from '../utils';
 
@@ -28,6 +30,12 @@ const componentRoutes = [
         element: <ComponentActivityTab />,
       },
     ],
+  },
+  {
+    path: COMPONENT_LINKED_SECRETS_PATH.path,
+    element: <LinkedSecretsListView />,
+    loader: linkedSecretsListViewLoader,
+    errorElement: <RouteErrorBoundry />,
   },
 ];
 

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -25,6 +25,8 @@ export const COMPONENT_LIST_PATH = APPLICATION_DETAILS_PATH.extend('components')
 
 export const COMPONENT_DETAILS_PATH = COMPONENT_LIST_PATH.extend(`:${RouterParams.componentName}`);
 
+export const COMPONENT_LINKED_SECRETS_PATH = COMPONENT_DETAILS_PATH.extend(`linked-secrets`);
+
 export const COMPONENT_ACTIVITY_PATH = COMPONENT_DETAILS_PATH.extend('activity');
 
 export const COMPONENT_ACTIVITY_CHILD_TAB_PATH = COMPONENT_ACTIVITY_PATH.extend(


### PR DESCRIPTION
## Fixes 

Fixes https://issues.redhat.com/browse/KFLUXUI-424

## Description

Please, review https://github.com/konflux-ci/konflux-ui/pull/217 first :)

This PR adds the "Manage Linked Secrets" page, which displays all secrets linked to a given component.


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

1. "Manage Linked Secrets" page:

https://github.com/user-attachments/assets/a34d5230-f979-4f3f-b37b-2e98c3636e8f

2.  Adding a new secret ("Secrets" page) and then checking the new secret in the "Manage Linked Secrets" page:

https://github.com/user-attachments/assets/61dcda05-10ab-4ff6-bd90-e1256e13cef7

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1. Link a secret to a given component
2. Go to Components List page
3. Find your component, click on the "three dots" and select the "Manage linked secrets" action
4. You should navigate to the "Manage linked secrets" page
5. ☕ 

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->