### PR TITLE
KFLUXUI-419: [Manage linked secrets] Add filtering by name

### DIFF
--- a/src/components/Components/LinkedSecretsListView/LinkedSecretsListRow.tsx
+++ b/src/components/Components/LinkedSecretsListView/LinkedSecretsListRow.tsx
@@ -8,7 +8,10 @@ import './LinkedSecretsListView.scss';
 export const LinkedSecretsListRow: React.FC<RowFunctionArgs<SecretKind>> = ({ obj: secret }) => {
   return (
     <>
-      <TableData className={linkedSecretsTableColumnClasses.secretName}>
+      <TableData
+        className={linkedSecretsTableColumnClasses.secretName}
+        data-test="linked-secrets-list-item"
+      >
         <Text component={TextVariants.p}>{secret.metadata.name}</Text>
       </TableData>
 

--- a/src/components/Components/LinkedSecretsListView/LinkedSecretsListView.tsx
+++ b/src/components/Components/LinkedSecretsListView/LinkedSecretsListView.tsx
@@ -183,7 +183,7 @@ export const LinkedSecretsListView: React.FC = () => {
             Row={LinkedSecretsListRow}
             loaded={linkedSecretsLoaded}
             getRowProps={(obj: SecretKind) => ({
-              id: `${obj.metadata.name}-linked-secret-list-item`,
+              id: `${obj.metadata.name}-linked-secrets-list-item`,
               'aria-label': obj.metadata.name,
             })}
           />

--- a/src/components/Components/LinkedSecretsListView/LinkedSecretsToolbar.tsx
+++ b/src/components/Components/LinkedSecretsListView/LinkedSecretsToolbar.tsx
@@ -1,0 +1,28 @@
+import { SearchInput, Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
+import { useSearchParam } from '../../../hooks/useSearchParam';
+
+export const LinkedSecretsToolbar: React.FC = () => {
+  const [nameFilter, setNameFilter] = useSearchParam('name', '');
+
+  return (
+    <Toolbar
+      data-test="linked-secrets-list-toolbar"
+      clearFiltersButtonText="Clear filters"
+      clearAllFilters={() => setNameFilter('')}
+    >
+      <ToolbarContent>
+        <ToolbarItem>
+          <SearchInput
+            name="nameInput"
+            data-test="name-input-filter"
+            type="search"
+            aria-label="name filter"
+            placeholder="Filter by name..."
+            onChange={(_, name) => setNameFilter(name)}
+            value={nameFilter}
+          />
+        </ToolbarItem>
+      </ToolbarContent>
+    </Toolbar>
+  );
+};


### PR DESCRIPTION
## Fixes 

Fixes https://issues.redhat.com/browse/KFLUXUI-419

## Description

Please, review https://github.com/konflux-ci/konflux-ui/pull/221 first :)

This PR introduces logic to filter linked secrets by name on the "Manage linked secrets" page.


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

https://github.com/user-attachments/assets/7edf1f92-42a2-484d-bc45-636b6f8619b2


## How to test or reproduce?


<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

1. Go to Components List page
2. Find a component, click on the "three dots" and select the "Manage linked secrets" action
3. You should navigate to the "Manage linked secrets" page
4. Interact with the "Filter by name" input
5. ☕ 

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->