### PR TITLE
KFLUXUI-435 - Fix: PipelineRuns not sorted in PipelineRunsListView

### DIFF
--- a/src/components/PipelineRun/PipelineRunListView/PipelineRunsListView.tsx
+++ b/src/components/PipelineRun/PipelineRunListView/PipelineRunsListView.tsx
@@ -66,28 +66,45 @@ const PipelineRunsListView: React.FC<React.PropsWithChildren<PipelineRunsListVie
       ),
     );
 
+  const sortedPipelineRuns = React.useMemo((): PipelineRunKind[] => {
+    if (!pipelineRuns) return [];
+
+    // @ts-expect-error: toSorted might not be in TS yet
+    if (typeof pipelineRuns.toSorted === 'function') {
+      // @ts-expect-error: toSorted might not be in TS yet
+      return pipelineRuns.toSorted((a, b) =>
+        b.status?.startTime?.localeCompare(a.status?.startTime),
+      );
+    }
+
+    return [...pipelineRuns].sort((a, b) =>
+      b.status?.startTime?.localeCompare(a.status?.startTime),
+    );
+  }, [pipelineRuns]);
+
   const statusFilterObj = React.useMemo(
-    () => createFilterObj(pipelineRuns, (plr) => pipelineRunStatus(plr), statuses, customFilter),
-    [pipelineRuns, customFilter],
+    () =>
+      createFilterObj(sortedPipelineRuns, (plr) => pipelineRunStatus(plr), statuses, customFilter),
+    [sortedPipelineRuns, customFilter],
   );
 
   const typeFilterObj = React.useMemo(
     () =>
       createFilterObj(
-        pipelineRuns,
+        sortedPipelineRuns,
         (plr) => plr?.metadata.labels[PipelineRunLabel.PIPELINE_TYPE],
         pipelineRunTypes,
         customFilter,
       ),
-    [pipelineRuns, customFilter],
+    [sortedPipelineRuns, customFilter],
   );
 
   const filteredPLRs = React.useMemo(
-    () => filterPipelineRuns(pipelineRuns, filters, customFilter),
-    [pipelineRuns, filters, customFilter],
+    () => filterPipelineRuns(sortedPipelineRuns, filters, customFilter),
+    [sortedPipelineRuns, filters, customFilter],
   );
 
-  const vulnerabilities = usePLRVulnerabilities(name ? filteredPLRs : pipelineRuns);
+  const vulnerabilities = usePLRVulnerabilities(name ? filteredPLRs : sortedPipelineRuns);
 
   const EmptyMsg = () => <FilteredEmptyState onClearFilters={() => onClearFilters()} />;
   const NoDataEmptyMsg = () => <PipelineRunEmptyState applicationName={applicationName} />;
@@ -107,7 +124,7 @@ const PipelineRunsListView: React.FC<React.PropsWithChildren<PipelineRunsListVie
 
   return (
     <>
-      {(isFiltered || pipelineRuns.length > 0) && (
+      {(isFiltered || sortedPipelineRuns.length > 0) && (
         <PipelineRunsFilterToolbar
           filters={filters}
           setFilters={setFilters}
@@ -118,7 +135,7 @@ const PipelineRunsListView: React.FC<React.PropsWithChildren<PipelineRunsListVie
       )}
       <Table
         data={filteredPLRs}
-        unfilteredData={pipelineRuns}
+        unfilteredData={sortedPipelineRuns}
         EmptyMsg={isFiltered ? EmptyMsg : NoDataEmptyMsg}
         aria-label="Pipeline run List"
         customData={vulnerabilities}

--- a/src/components/TabsLayout/TabsLayout.tsx
+++ b/src/components/TabsLayout/TabsLayout.tsx
@@ -34,8 +34,8 @@ export const TabsLayout: React.FC<TabsLayoutProps> = ({
   const basePath = baseURL ?? resolveBase.pathname;
   const currentTab = tabs
     // @ts-expect-error Array types doesn't include toReversed
-    .toReversed()
-    .find((t: TabProps) =>
+    ?.toReversed()
+    ?.find?.((t: TabProps) =>
       location.pathname.includes(resolvePath(getRouteFromKey(t.key), basePath).pathname),
     )?.key;
 


### PR DESCRIPTION
## Fixes 

Fixes https://issues.redhat.com/browse/KFLUXUI-435


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR addresses an issue where the list of PipelineRuns was not consistently sorted in the UI.

During investigation, I found that the `useRuns` hook does sort the `runs` array (based on `metadata.creationTimestamp`). However, the final list (`rResources`) is created by merging `runs` with Tekton Results (`trResources`) using:

```typescript
const rResources =
  runs && trResources
    ? uniqBy([...runs, ...trResources], (r) => r.metadata.name)
    : runs || trResources;
```

This merge can affect the original sorting. I thought about sorting the merged result inside `useRuns`, but since that hook is used in many places, I thought it could introduce unintended side effects.

To keep the change localized, I sorted the `pipelineRuns` array directly in `PipelineRunsListView` to make sure the runs show up in the right order — most recent first, based on `status.startTime` :)

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Issue before this fix:

https://github.com/user-attachments/assets/3070a166-f224-4745-acbb-78347fa3335f

With this PR's changes:

https://github.com/user-attachments/assets/2c6b2bec-8b34-467f-8816-c466802da53e

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

I'm not sure how to "force" such scenario. If needed I can add you to my namespace :)

1. Go to Activity -> Pipeline runs tab
2. Notice the runs show up in the right order — most recent first
3. ☕ ☕ 

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->