### PR TITLE
feat(/KFLUXUI-420): Add ‘Link secrets’ button in Manage Link Secret Page

### DIFF
--- a/src/components/LinkSecret/LinkSecret.tsx
+++ b/src/components/LinkSecret/LinkSecret.tsx
@@ -33,9 +33,9 @@ export const LinkSecret: React.FC<React.PropsWithChildren<DeleteResourceModalPro
   );
 };
 
-export const createDeleteModalLauncher2 = (kind: string) =>
+export const createLinkSecretModalLauncher = () =>
   createModalLauncher(LinkSecret, {
-    'data-test': `delete-${kind}-modal`,
+    'data-test': `link-secret-modal`,
     variant: ModalVariant.small,
     title: `Link Secrets?`,
   });

--- a/src/components/LinkSecret/LinkSecret.tsx
+++ b/src/components/LinkSecret/LinkSecret.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import { ModalVariant } from '@patternfly/react-core';
+import { Formik } from 'formik';
+import { ComponentProps, createModalLauncher } from '../modal/createModalLauncher';
+import { SecretSelector } from './SecretSelector';
+
+type DeleteResourceModalProps = ComponentProps & {
+  obj: string;
+  model?: string;
+  displayName?: string;
+  isEntryNotRequired?: boolean;
+  description?: React.ReactNode;
+  submitCallback?: (obj: unknown, namespace?) => void;
+};
+
+export const LinkSecret: React.FC<React.PropsWithChildren<DeleteResourceModalProps>> = ({
+  onClose,
+}) => {
+  const [data, setData] = React.useState<string[]>([]);
+
+  const onReset = () => {
+    onClose(null, { submitClicked: false });
+    return data;
+    //needs to be removed
+  };
+
+  const linkedSecrets = (value?: string[]) => {
+    // console.log("In Link Secrets",data);
+    setData(value);
+    return value;
+  };
+  const handleSubmit = () => {
+    //   console.log("selected options",data);
+    //   console.log(data,"before api call")
+    //  makeAPICall();
+    onReset();
+  };
+  // const makeAPICall= async ()=>{
+  //   const seceretstolink:SecretKind[]=secrets?.filter((item)=>{
+  //     data?.map( (i)=> {return i===item?.metadata.name})
+  //   })
+  // console.log(secrets[0])
+  // const response=await linkSecretToServiceAccounts(secrets[0],["e035d"],SecretForComponentOption.all);
+  // console.log(seceretstolink[0],"secret")
+  // console.log("Response",response)
+  // }
+
+  return (
+    <Formik onSubmit={() => handleSubmit()} initialValues={{ resourceName: '' }} onReset={onReset}>
+      {() => {
+        // const input = values.resourceName;
+        // const isValid = input === resourceName;
+        // const helpText =
+        //   touched && !input ? (
+        //     <FormHelperText className="pf-m-warning">{obj} name missing</FormHelperText>
+        //   ) : undefined;
+        // const validatedState = touched
+        //   ? !input
+        //     ? ValidatedOptions.warning
+        //     : isValid
+        //       ? ValidatedOptions.success
+        //       : ValidatedOptions.error
+        //   : undefined;
+
+        return (
+          <>
+            <SecretSelector
+              linkedSecrets={linkedSecrets}
+              onClose={onReset}
+              handleSubmit={handleSubmit}
+            />
+            {/* <div style={{marginTop:"1rem", color:"red"}}>{error}</div> */}
+          </>
+        );
+      }}
+    </Formik>
+  );
+};
+
+export const createDeleteModalLauncher2 = (kind: string) =>
+  createModalLauncher(LinkSecret, {
+    'data-test': `delete-${kind}-modal`,
+    variant: ModalVariant.small,
+    title: `Link Secrets?`,
+    // titleIconVariant: 'warning',
+  });

--- a/src/components/LinkSecret/LinkSecret.tsx
+++ b/src/components/LinkSecret/LinkSecret.tsx
@@ -16,60 +16,16 @@ type DeleteResourceModalProps = ComponentProps & {
 export const LinkSecret: React.FC<React.PropsWithChildren<DeleteResourceModalProps>> = ({
   onClose,
 }) => {
-  const [data, setData] = React.useState<string[]>([]);
-
   const onReset = () => {
     onClose(null, { submitClicked: false });
-    return data;
-    //needs to be removed
   };
-
-  const linkedSecrets = (value?: string[]) => {
-    // console.log("In Link Secrets",data);
-    setData(value);
-    return value;
-  };
-  const handleSubmit = () => {
-    //   console.log("selected options",data);
-    //   console.log(data,"before api call")
-    //  makeAPICall();
-    onReset();
-  };
-  // const makeAPICall= async ()=>{
-  //   const seceretstolink:SecretKind[]=secrets?.filter((item)=>{
-  //     data?.map( (i)=> {return i===item?.metadata.name})
-  //   })
-  // console.log(secrets[0])
-  // const response=await linkSecretToServiceAccounts(secrets[0],["e035d"],SecretForComponentOption.all);
-  // console.log(seceretstolink[0],"secret")
-  // console.log("Response",response)
-  // }
 
   return (
-    <Formik onSubmit={() => handleSubmit()} initialValues={{ resourceName: '' }} onReset={onReset}>
+    <Formik onSubmit={() => {}} initialValues={{ resourceName: '' }} onReset={onReset}>
       {() => {
-        // const input = values.resourceName;
-        // const isValid = input === resourceName;
-        // const helpText =
-        //   touched && !input ? (
-        //     <FormHelperText className="pf-m-warning">{obj} name missing</FormHelperText>
-        //   ) : undefined;
-        // const validatedState = touched
-        //   ? !input
-        //     ? ValidatedOptions.warning
-        //     : isValid
-        //       ? ValidatedOptions.success
-        //       : ValidatedOptions.error
-        //   : undefined;
-
         return (
           <>
-            <SecretSelector
-              linkedSecrets={linkedSecrets}
-              onClose={onReset}
-              handleSubmit={handleSubmit}
-            />
-            {/* <div style={{marginTop:"1rem", color:"red"}}>{error}</div> */}
+            <SecretSelector onClose={onReset} />
           </>
         );
       }}
@@ -82,5 +38,4 @@ export const createDeleteModalLauncher2 = (kind: string) =>
     'data-test': `delete-${kind}-modal`,
     variant: ModalVariant.small,
     title: `Link Secrets?`,
-    // titleIconVariant: 'warning',
   });

--- a/src/components/LinkSecret/LinkSecretView.tsx
+++ b/src/components/LinkSecret/LinkSecretView.tsx
@@ -1,12 +1,12 @@
 import { Button } from '@patternfly/react-core';
 import { useModalLauncher } from '../modal/ModalProvider';
-import { createDeleteModalLauncher2 } from './LinkSecret';
+import { createLinkSecretModalLauncher } from './LinkSecret';
 
 export const LinkSecretView = () => {
   const showModal = useModalLauncher();
   return (
     <>
-      <Button onClick={() => showModal(createDeleteModalLauncher2('')())}>Link Secrets</Button>
+      <Button onClick={() => showModal(createLinkSecretModalLauncher()())}>Link Secrets</Button>
     </>
   );
 };

--- a/src/components/LinkSecret/LinkSecretView.tsx
+++ b/src/components/LinkSecret/LinkSecretView.tsx
@@ -1,0 +1,12 @@
+import { Button } from '@patternfly/react-core';
+import { useModalLauncher } from '../modal/ModalProvider';
+import { createDeleteModalLauncher2 } from './LinkSecret';
+
+export const LinkSecretView = () => {
+  const showModal = useModalLauncher();
+  return (
+    <>
+      <Button onClick={() => showModal(createDeleteModalLauncher2('')())}>Link Secrets</Button>
+    </>
+  );
+};

--- a/src/components/LinkSecret/SecretSelectMenu.tsx
+++ b/src/components/LinkSecret/SecretSelectMenu.tsx
@@ -10,7 +10,6 @@ import {
 } from '@patternfly/react-core';
 import { useField } from 'formik';
 import { flatten } from 'lodash-es';
-// import './ComponentSelectMenu.scss';
 import SelectSecretsDropdown from './SelectSeceretsDropdown';
 
 type ComponentSelectMenuProps = {
@@ -46,7 +45,6 @@ export const ComponentSelectMenu: React.FC<ComponentSelectMenuProps> = ({
     return options;
   }, [isGrouped, options]);
 
-  //   console.log("secret selector menu",options)
   const isItemDisabled = (item: string) => disableItem?.(item) || item === sourceComponentName;
   const isSelected = (item: string) =>
     isMulti ? (value as string[])?.includes(item) : (value as string) === item;

--- a/src/components/LinkSecret/SecretSelectMenu.tsx
+++ b/src/components/LinkSecret/SecretSelectMenu.tsx
@@ -10,8 +10,8 @@ import {
 } from '@patternfly/react-core';
 import { useField } from 'formik';
 import { flatten } from 'lodash-es';
-import SelectComponentsDropdown from './SelectComponnetsDropdown';
-import './ComponentSelectMenu.scss';
+// import './ComponentSelectMenu.scss';
+import SelectSecretsDropdown from './SelectSeceretsDropdown';
 
 type ComponentSelectMenuProps = {
   name: string;
@@ -23,7 +23,6 @@ type ComponentSelectMenuProps = {
   defaultToggleText?: string;
   selectedToggleText?: string | ((value: string | string[]) => string);
   title?: string;
-  linkedSecrets?: (data?: string[] | string) => void;
 };
 
 export const ComponentSelectMenu: React.FC<ComponentSelectMenuProps> = ({
@@ -33,9 +32,8 @@ export const ComponentSelectMenu: React.FC<ComponentSelectMenuProps> = ({
   disableItem,
   sourceComponentName,
   includeSelectAll = false,
-  defaultToggleText = 'Select components',
-  selectedToggleText = 'Select components',
-  linkedSecrets,
+  defaultToggleText = 'Select secrets',
+  selectedToggleText = 'Select secrets',
 }) => {
   const [{ value }, , { setValue }] = useField<string[] | string>(name);
   const [searchQuery, setSearchQuery] = React.useState<string>('');
@@ -48,6 +46,7 @@ export const ComponentSelectMenu: React.FC<ComponentSelectMenuProps> = ({
     return options;
   }, [isGrouped, options]);
 
+  //   console.log("secret selector menu",options)
   const isItemDisabled = (item: string) => disableItem?.(item) || item === sourceComponentName;
   const isSelected = (item: string) =>
     isMulti ? (value as string[])?.includes(item) : (value as string) === item;
@@ -56,14 +55,12 @@ export const ComponentSelectMenu: React.FC<ComponentSelectMenuProps> = ({
     if (includeSelectAll && item === 'select-all') {
       if (!isMulti) return;
       const selectable = allItems?.filter((v) => !isItemDisabled(v));
-      const selectedCount = Array.isArray(value) ? value?.length : 0;
+      const selectedCount = Array.isArray(value) ? value.length : 0;
 
-      if (selectedCount === selectable?.length) {
+      if (selectedCount === selectable.length) {
         void setValue([]);
-        linkedSecrets([]);
       } else {
         void setValue(selectable);
-        linkedSecrets(selectable);
       }
     } else {
       if (isMulti) {
@@ -72,10 +69,8 @@ export const ComponentSelectMenu: React.FC<ComponentSelectMenuProps> = ({
           ? selected.filter((v) => v !== item)
           : [...selected, item];
         void setValue(newValue);
-        linkedSecrets(newValue);
       } else {
         void setValue(item);
-        linkedSecrets(item);
       }
     }
   };
@@ -107,7 +102,7 @@ export const ComponentSelectMenu: React.FC<ComponentSelectMenuProps> = ({
 
   return (
     <>
-      <SelectComponentsDropdown
+      <SelectSecretsDropdown
         toggleText={toggleText}
         onSelect={handleSelect}
         closeOnSelect={!isMulti}
@@ -119,15 +114,15 @@ export const ComponentSelectMenu: React.FC<ComponentSelectMenuProps> = ({
               type="text"
               value={searchQuery}
               onChange={(_, v) => setSearchQuery(v)}
-              placeholder="Search components..."
-              aria-label="Search components"
+              placeholder="Search Secrets..."
+              aria-label="Search Secrets"
             />
           </MenuSearchInput>
         </MenuSearch>
         <Divider component="li" />
         {includeSelectAll && isMulti && (
           <>
-            <MenuGroup className="menugroup" label="Components">
+            <MenuGroup className="menugroup" label="Secrets">
               <MenuList>
                 <MenuItem
                   hasCheckbox
@@ -173,8 +168,6 @@ export const ComponentSelectMenu: React.FC<ComponentSelectMenuProps> = ({
               <MenuItem
                 key={item}
                 itemId={item}
-                hasCheckbox={isMulti}
-                isSelected={isSelected(item)}
                 selected={!isMulti && isSelected(item)}
                 isDisabled={isItemDisabled(item)}
               >
@@ -183,7 +176,7 @@ export const ComponentSelectMenu: React.FC<ComponentSelectMenuProps> = ({
             ))}
           </MenuList>
         )}
-      </SelectComponentsDropdown>
+      </SelectSecretsDropdown>
     </>
   );
 };

--- a/src/components/LinkSecret/SecretSelector.tsx
+++ b/src/components/LinkSecret/SecretSelector.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Button, ButtonVariant } from '@patternfly/react-core';
+import { useSecrets } from '~/hooks/useSecrets';
+import { ComponentSelectMenu } from '~/shared/components/component-select-menu/ComponentSelectMenu';
+import { useNamespace } from '~/shared/providers/Namespace';
+// import { SecretKind } from '~/types';
+// import { getLinkedServiceAccounts } from '../Secrets/utils/service-account-utils';
+
+type SecretSelectorProps = {
+  linkedSecrets: (data: string[]) => number;
+  onClose: () => void;
+  handleSubmit: () => void;
+};
+
+export const SecretSelector: React.FC = ({
+  linkedSecrets,
+  onClose,
+  handleSubmit,
+}: SecretSelectorProps) => {
+  const namespace = useNamespace();
+  const secrets = useSecrets(namespace)[0]?.map((item) => item?.metadata?.name);
+  //   const test:SecretKind=useSecrets(namespace)[0][0];
+  const handleClose = () => {
+    onClose();
+  };
+
+  //   const getData=async ()=>{
+  //     const data= await getLinkedServiceAccounts(test);
+  //     return data;
+  //   }
+
+  //    console.log("API call",getData())
+
+  return (
+    <div className="labeled-dropdown-field">
+      <div className="title">Select Secrets:</div>
+      <div className="component-select-menu" data-test="secret-select-menu">
+        <ComponentSelectMenu
+          defaultToggleText="Selecting"
+          selectedToggleText="Secrets"
+          name="relatedSecrets"
+          options={secrets}
+          isMulti={true}
+          includeSelectAll={true}
+          linkedSecrets={linkedSecrets}
+        />
+      </div>
+      <div style={{ marginTop: '2rem' }}>
+        <Button onClick={() => handleSubmit()}>Link Secrets</Button>
+        <Button variant={ButtonVariant.link} onClick={handleClose}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/LinkSecret/SecretSelector.tsx
+++ b/src/components/LinkSecret/SecretSelector.tsx
@@ -1,35 +1,38 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { Button, ButtonVariant } from '@patternfly/react-core';
+import { RouterParams } from '@routes/utils';
+import { useComponent } from '~/hooks/useComponents';
 import { useSecrets } from '~/hooks/useSecrets';
 import { ComponentSelectMenu } from '~/shared/components/component-select-menu/ComponentSelectMenu';
 import { useNamespace } from '~/shared/providers/Namespace';
-// import { SecretKind } from '~/types';
-// import { getLinkedServiceAccounts } from '../Secrets/utils/service-account-utils';
+import { ComponentKind, SecretKind } from '~/types';
+import { linkSecretsToComponent } from './link-secret-utils';
 
 type SecretSelectorProps = {
-  linkedSecrets: (data: string[]) => number;
   onClose: () => void;
-  handleSubmit: () => void;
 };
 
-export const SecretSelector: React.FC = ({
-  linkedSecrets,
-  onClose,
-  handleSubmit,
-}: SecretSelectorProps) => {
+export const SecretSelector: React.FC = ({ onClose }: SecretSelectorProps) => {
   const namespace = useNamespace();
-  const secrets = useSecrets(namespace)[0]?.map((item) => item?.metadata?.name);
-  //   const test:SecretKind=useSecrets(namespace)[0][0];
-  const handleClose = () => {
-    onClose();
+  const secrets: SecretKind[] = useSecrets(namespace)[0];
+  const secretOptions: string[] = secrets?.map((item) => item?.metadata?.name);
+  const [linkedSecretsList, setLinkedSecretsList] = useState<string[]>([]);
+
+  const { componentName } = useParams<RouterParams>();
+  const component: ComponentKind = useComponent(namespace, componentName)[0];
+
+  const linkedSecrets = (value: string[]) => {
+    setLinkedSecretsList(value);
   };
 
-  //   const getData=async ()=>{
-  //     const data= await getLinkedServiceAccounts(test);
-  //     return data;
-  //   }
-
-  //    console.log("API call",getData())
+  const handleSubmit = () => {
+    const secretsTobeLinked: SecretKind[] = linkedSecretsList?.map((item) => {
+      return secrets.find((i) => item === i.metadata.name);
+    });
+    linkSecretsToComponent(secretsTobeLinked, component);
+    onClose();
+  };
 
   return (
     <div className="labeled-dropdown-field">
@@ -39,15 +42,18 @@ export const SecretSelector: React.FC = ({
           defaultToggleText="Selecting"
           selectedToggleText="Secrets"
           name="relatedSecrets"
-          options={secrets}
+          options={secretOptions}
           isMulti={true}
           includeSelectAll={true}
           linkedSecrets={linkedSecrets}
+          searchInputPlaceholder={'Search secrets...'}
         />
       </div>
       <div style={{ marginTop: '2rem' }}>
-        <Button onClick={() => handleSubmit()}>Link Secrets</Button>
-        <Button variant={ButtonVariant.link} onClick={handleClose}>
+        <Button onClick={() => handleSubmit()} disabled={linkedSecretsList.length === 0}>
+          Link Secrets
+        </Button>
+        <Button variant={ButtonVariant.link} onClick={onClose}>
           Cancel
         </Button>
       </div>

--- a/src/components/LinkSecret/SelectSeceretsDropdown.tsx
+++ b/src/components/LinkSecret/SelectSeceretsDropdown.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import { Badge, Menu, MenuContainer, MenuContent, MenuToggle } from '@patternfly/react-core';
+
+type SelectComponentsDropdownProps = {
+  children: React.ReactNode;
+  toggleText: string;
+  onSelect: (item: string | number) => void;
+  closeOnSelect?: boolean;
+  badgeValue?: number;
+};
+
+const SelectSecretsDropdown: React.FC<SelectComponentsDropdownProps> = ({
+  children,
+  toggleText,
+  onSelect,
+  closeOnSelect,
+  badgeValue,
+}) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const toggleRef = React.useRef<HTMLButtonElement>(null);
+  const menuRef = React.useRef<HTMLDivElement>(null);
+
+  return (
+    <MenuContainer
+      isOpen={isOpen}
+      onOpenChange={(open) => setIsOpen(open)}
+      toggle={
+        <MenuToggle
+          ref={toggleRef}
+          isExpanded={isOpen}
+          onClick={() => setIsOpen(!isOpen)}
+          id="toggle-component-menu"
+          aria-label="toggle secret menu"
+          badge={badgeValue ? <Badge isRead>{badgeValue}</Badge> : null}
+          isFullWidth
+        >
+          {toggleText}
+        </MenuToggle>
+      }
+      menu={
+        <Menu
+          title="Secrets"
+          ref={menuRef}
+          id="component-menu"
+          isScrollable
+          onSelect={(_, itemId) => {
+            onSelect(itemId as string);
+            if (closeOnSelect) {
+              setIsOpen(false);
+            }
+          }}
+        >
+          <MenuContent>{children}</MenuContent>
+        </Menu>
+      }
+      toggleRef={toggleRef}
+      menuRef={menuRef}
+    />
+  );
+};
+
+export default SelectSecretsDropdown;

--- a/src/components/LinkSecret/link-secret-utils.ts
+++ b/src/components/LinkSecret/link-secret-utils.ts
@@ -1,0 +1,15 @@
+import { ComponentKind, SecretKind } from '~/types';
+import { linkSecretToServiceAccount } from '../Secrets/utils/service-account-utils';
+
+export const linkSecretsToComponent = (secrets: SecretKind[], component: ComponentKind) => {
+  Promise.all(
+    secrets.map((item) => {
+      return linkSecretToServiceAccount(item, component);
+    }),
+  )
+    .then()
+    .catch((err) => {
+      // eslint-disable-next-line no-console
+      console.warn(err);
+    });
+};

--- a/src/shared/components/component-select-menu/ComponentSelectMenu.tsx
+++ b/src/shared/components/component-select-menu/ComponentSelectMenu.tsx
@@ -22,6 +22,8 @@ type ComponentSelectMenuProps = {
   includeSelectAll?: boolean;
   defaultToggleText?: string;
   selectedToggleText?: string | ((value: string | string[]) => string);
+  searchInputPlaceholder?: string;
+  defaultInputAriaLabel?: string;
   title?: string;
   linkedSecrets?: (data?: string[] | string) => void;
 };
@@ -35,6 +37,8 @@ export const ComponentSelectMenu: React.FC<ComponentSelectMenuProps> = ({
   includeSelectAll = false,
   defaultToggleText = 'Select components',
   selectedToggleText = 'Select components',
+  searchInputPlaceholder = 'Search components...',
+  defaultInputAriaLabel = 'Search components',
   linkedSecrets,
 }) => {
   const [{ value }, , { setValue }] = useField<string[] | string>(name);
@@ -119,8 +123,8 @@ export const ComponentSelectMenu: React.FC<ComponentSelectMenuProps> = ({
               type="text"
               value={searchQuery}
               onChange={(_, v) => setSearchQuery(v)}
-              placeholder="Search components..."
-              aria-label="Search components"
+              placeholder={searchInputPlaceholder}
+              aria-label={defaultInputAriaLabel}
             />
           </MenuSearchInput>
         </MenuSearch>


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
Link Secret Modal is added on Manage Link Secrets Page, this feature helps to link component to multiple secrets.



## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

<!--## Screen shots / Gifs for design review -->
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


<!-- ## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->