### PR TITLE
KONFLUX-6148: Fix 'cosign download sbom' command failing due to missing image tag

### DIFF
--- a/src/components/Components/ComponentDetails/tabs/ComponentLatestBuild.tsx
+++ b/src/components/Components/ComponentDetails/tabs/ComponentLatestBuild.tsx
@@ -21,7 +21,6 @@ import { Timestamp } from '../../../../shared/components/timestamp/Timestamp';
 import { useNamespace } from '../../../../shared/providers/Namespace/useNamespaceInfo';
 import { ComponentKind } from '../../../../types';
 import { getCommitsFromPLRs } from '../../../../utils/commits-utils';
-import { getLastestImage } from '../../../../utils/component-utils';
 import CommitLabel from '../../../Commits/commit-label/CommitLabel';
 import { useBuildLogViewerModal } from '../../../LogViewer/BuildLogViewer';
 import ScanDescriptionListGroup from '../../../PipelineRun/PipelineRunDetailsView/tabs/ScanDescriptionListGroup';
@@ -45,7 +44,9 @@ const ComponentLatestBuild: React.FC<React.PropsWithChildren<ComponentLatestBuil
   const [taskRuns, taskRunsLoaded] = useTaskRuns(namespace, pipelineRun?.metadata?.name);
   const buildLogsModal = useBuildLogViewerModal(component);
 
-  const containerImage = getLastestImage(component);
+  // Avoid getLastestImage fallback to spec.containerImage, which lacks image tag
+  // and causes 'cosign download sbom' to fail. Use lastPromotedImage explicitly.
+  const containerImage = component?.status?.lastPromotedImage;
 
   if (error) {
     const httpError = HttpError.fromCode((error as { code: number }).code);


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

Fixes https://issues.redhat.com/browse/KONFLUX-6148

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The `cosign download sbom` command was failing because the component did not yet have the `status.lastPromotedImage` set. Previously, we used the `getLastestImage()` utility, which falls back to `spec.containerImage` when `status.lastPromotedImage` is unavailable.

However, `spec.containerImage` does not include an image tag, and without a tag, the `cosign download sbom` command fails.

This PR fixes the issue by explicitly using `status.lastPromotedImage` in the `ComponentLatestBuild` component, avoiding the fallback and ensuring the command is executed with a properly tagged image.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

1. Example of broken SBOM command (due to missing image tag in containerImage):

![sbom-command-without-image-tag](https://github.com/user-attachments/assets/dc4c5d15-a580-4509-bb59-b0e5211b4d7f)

```
cosign download sbom quay.io/redhat-user-workloads-stage/kkanova-tenant/katka-test-cosign-dd573 
```

2. If we remove the fallback, this command would no longer be displayed:

![sbom-no-command-display](https://github.com/user-attachments/assets/969713a7-ff67-443e-ba9a-89d09ba09ab4)

3. And for components where `status.lastPromotedImage` is correctly set, the SBOM command displays and works:

![sbom-correct-command-with-image-tag](https://github.com/user-attachments/assets/e75ff513-586f-45da-bae4-14f59c7b9e62)

```
cosign download sbom quay.io/redhat-user-workloads-stage/kkanova-tenant/testc@sha256:e3d15797e5537846aeb168be35f367e4388b688a87e4ce45f11cab3bf7e1ecc2
```

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

This issue seems to be happening in some edge cases. The scenario in which we found the issue to be reproduced was when creating a new component and not merging the PR created by PAC. 

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->