### PR TITLE
fix: handle case where runAfterTasks is undefined

### DIFF
--- a/src/components/PipelineRun/PipelineRunDetailsView/visualization/utils/pipelinerun-graph-utils.ts
+++ b/src/components/PipelineRun/PipelineRunDetailsView/visualization/utils/pipelinerun-graph-utils.ts
@@ -379,7 +379,7 @@ const getGraphDataModel = (
   // Remove extraneous dependencies
   nodes.forEach(
     (taskNode) =>
-      (taskNode.runAfterTasks = taskNode.runAfterTasks.filter(
+      (taskNode.runAfterTasks = taskNode.runAfterTasks?.filter(
         (dep) => !hasParentDep(dep, taskNode.runAfterTasks, nodes),
       )),
   );


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
I heard from a user that they get stacktrace when trying to view pipelinerun details of an ITS pipeline they kicked off on the cluster:

![image](https://github.com/user-attachments/assets/38d3e883-080e-4c20-a403-0b58a0ff4bc7)


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

I'm not sure. I wasn't able to reproduce the failure yet. Perhaps this should be dropped and a test-driven development approach should be taken. Can you advise where in the tests we could try to reproduce the failure before speculating on a fix?

To be clear - I am only *guessing* that the patch here fixes the issue seen by the user in the stacktrace listed above. This may be off the mark.