### PR TITLE
chore(KFLUXUI-421): unlink secret modal added

### DIFF
--- a/src/components/UnlinkSecret/UnlinkSecret.tsx
+++ b/src/components/UnlinkSecret/UnlinkSecret.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { useParams } from 'react-router-dom';
+import { Button, ModalVariant } from '@patternfly/react-core';
+import { Formik } from 'formik';
+import { RouterParams } from '@routes/utils';
+import { useComponent } from '~/hooks/useComponents';
+import { useNamespace } from '~/shared/providers/Namespace';
+import { ComponentKind, SecretKind } from '~/types';
+import { ComponentProps, createModalLauncher } from '../modal/createModalLauncher';
+import { unlinkSecretFromComponent } from './unlink-secret-utils';
+
+type UnlinkSecretModalProps = ComponentProps & {
+  secret: SecretKind;
+  onClose: () => void;
+};
+
+export const UnlinkSecret: React.FC<React.PropsWithChildren<UnlinkSecretModalProps>> = ({
+  onClose,
+  secret,
+}) => {
+  const namespace = useNamespace();
+  const { componentName } = useParams<RouterParams>();
+  const component: ComponentKind = useComponent(namespace, componentName)[0];
+  const onReset = () => {
+    onClose(null, { submitClicked: false });
+  };
+
+  const handleSubmit = () => {
+    unlinkSecretFromComponent(secret, component);
+    onReset();
+  };
+
+  return (
+    <Formik onSubmit={() => {}} initialValues={{}} onReset={onReset}>
+      {() => {
+        return (
+          <>
+            {secret?.metadata?.name} will be unlinked from {component?.metadata?.name}
+            <div style={{ marginTop: '1rem' }}>
+              <Button variant="primary" onClick={handleSubmit}>
+                Unlink Secret
+              </Button>
+              <Button variant="tertiary" onClick={() => onReset()}>
+                Cancel
+              </Button>
+            </div>
+          </>
+        );
+      }}
+    </Formik>
+  );
+};
+
+export const createUnlinkSecretModalLauncher = () =>
+  createModalLauncher(UnlinkSecret, {
+    'data-test': `unlink-secret-modal`,
+    variant: ModalVariant.small,
+    title: `Unlink Secrets?`,
+    titleIconVariant: 'warning',
+  });

--- a/src/components/UnlinkSecret/UnlinkSecretView.tsx
+++ b/src/components/UnlinkSecret/UnlinkSecretView.tsx
@@ -1,0 +1,19 @@
+import { Button } from '@patternfly/react-core';
+import { useModalLauncher } from '../modal/ModalProvider';
+import { createUnlinkSecretModalLauncher } from './UnlinkSecret';
+
+const UnlinkSecretView = () => {
+  const showModal = useModalLauncher();
+  return (
+    <>
+      <Button
+        onClick={() => {
+          showModal(createUnlinkSecretModalLauncher()());
+        }}
+      >
+        Unlink Secret
+      </Button>
+    </>
+  );
+};
+export default UnlinkSecretView;

--- a/src/components/UnlinkSecret/unlink-secret-utils.ts
+++ b/src/components/UnlinkSecret/unlink-secret-utils.ts
@@ -1,0 +1,11 @@
+import { ComponentKind, SecretKind } from '~/types';
+import { unLinkSecretFromServiceAccount } from '../Secrets/utils/service-account-utils';
+
+export const unlinkSecretFromComponent = (secret: SecretKind, component: ComponentKind) => {
+  unLinkSecretFromServiceAccount(secret, component)
+    .then()
+    .catch((err) => {
+      // eslint-disable-next-line no-console
+      console.warn(err);
+    });
+};


### PR DESCRIPTION
## Fixes 
<a  href="https://issues.redhat.com/browse/KFLUXUI-421">KFLUXUI-421</a>


## Description
Unlinks secret from the component.


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Go to Component tab, select manage secret link from dropdown options, which takes you to Managed link secrets page.

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->