### PR TITLE
KONFLUX-5940 - Add "Test result" column to PipelineRun List View

### DIFF
--- a/src/__data__/pipelinerun-data.ts
+++ b/src/__data__/pipelinerun-data.ts
@@ -191,6 +191,11 @@ export enum DataState {
   STATUS_WITH_EMPTY_CONDITIONS = 'StatusWithEmptyCondition',
   STATUS_WITHOUT_CONDITION_TYPE = 'StatusWithoutConditionType',
   STATUS_WITH_UNKNOWN_REASON = 'StatusWithUnknownReason',
+  STATUS_WITH_TEST_OUTPUT_ERROR = 'StatusWithTestOutputError',
+  STATUS_WITHOUT_TEST_OUTPUT_INFO = 'StatusWithoutTestOutputInfo',
+  STATUS_WITH_INVALID_TEST_OUTPUT_RESULT = 'StatusWithInvalidTestOutputResult',
+  STATUS_WITH_TEST_OUTPUT_SUCCESS = 'StatusWithTestOutputSuccess',
+  STATUS_WITH_INVALID_TEST_OUTPUT_JSON_VALUE = 'StatusWithInvalidTestOutputJsonValue',
 }
 
 type TestPipelineRuns = { [key in DataState]?: PipelineRunKind };
@@ -927,6 +932,69 @@ export const testPipelineRuns: TestPipelineRuns = {
     status: {
       pipelineSpec: samplePipelineSpec,
       conditions: [{ type: 'Succeeded', status: 'False', reason: 'Unknown' }],
+    },
+  },
+  [DataState.STATUS_WITH_TEST_OUTPUT_ERROR]: {
+    ...samplePipelineRun,
+    status: {
+      ...samplePipelineRun.status,
+      results: [
+        {
+          name: 'TEST_OUTPUT',
+          value:
+            '{ "result": "ERROR", "namespace": "example-namespace", "timestamp": "2025-05-05T10:24:33Z", "successes": 0, "failures": 1, "warnings": 0, "note": "Simulated failure for testing TEST_OUTPUT reporting" }',
+        },
+      ],
+    },
+  },
+  [DataState.STATUS_WITHOUT_TEST_OUTPUT_INFO]: {
+    ...samplePipelineRun,
+    status: {
+      ...samplePipelineRun.status,
+      results: [
+        {
+          name: 'RANDOM_RESULT',
+          value: 'random result value',
+        },
+      ],
+    },
+  },
+  [DataState.STATUS_WITH_INVALID_TEST_OUTPUT_RESULT]: {
+    ...samplePipelineRun,
+    status: {
+      ...samplePipelineRun.status,
+      results: [
+        {
+          name: 'TEST_OUTPUT',
+          value:
+            '{ "result": null, "namespace": "example-namespace", "timestamp": "2025-05-05T10:24:33Z", "successes": 0, "failures": 1, "warnings": 0, "note": "Simulated failure for testing TEST_OUTPUT reporting" }',
+        },
+      ],
+    },
+  },
+  [DataState.STATUS_WITH_TEST_OUTPUT_SUCCESS]: {
+    ...samplePipelineRun,
+    status: {
+      ...samplePipelineRun.status,
+      results: [
+        {
+          name: 'TEST_OUTPUT',
+          value:
+            '{ "result": "SUCCESS", "namespace": "example-namespace", "timestamp": "2025-05-05T10:24:33Z", "successes": 1, "failures": 0, "warnings": 0, "note": "Simulated success for testing TEST_OUTPUT reporting" }',
+        },
+      ],
+    },
+  },
+  [DataState.STATUS_WITH_INVALID_TEST_OUTPUT_JSON_VALUE]: {
+    ...samplePipelineRun,
+    status: {
+      ...samplePipelineRun.status,
+      results: [
+        {
+          name: 'TEST_OUTPUT',
+          value: '{ invalid json',
+        },
+      ],
     },
   },
 };

--- a/src/components/Activity/ActivityTab.tsx
+++ b/src/components/Activity/ActivityTab.tsx
@@ -51,7 +51,7 @@ export const ActivityTab: React.FC = () => {
   return (
     <>
       <Title size="xl" headingLevel="h3" className="pf-v5-c-title pf-v5-u-mt-lg pf-v5-u-mb-sm">
-        Activity By
+        Activity by
       </Title>
       <Text className="pf-v5-u-mb-sm">
         Monitor your commits and their pipeline progression across all components.

--- a/src/components/Activity/__tests__/ActivityTab.spec.tsx
+++ b/src/components/Activity/__tests__/ActivityTab.spec.tsx
@@ -44,7 +44,7 @@ describe('Activity Tab', () => {
 
   it('should render Activity Tab', () => {
     routerRenderer(<ActivityTab />);
-    screen.getByText('Activity By');
+    screen.getByText('Activity by');
   });
 
   it('should render two tabs under activity', () => {

--- a/src/components/PipelineRun/PipelineRunListView/PipelineRunListHeader.tsx
+++ b/src/components/PipelineRun/PipelineRunListView/PipelineRunListHeader.tsx
@@ -1,7 +1,8 @@
 export const pipelineRunTableColumnClasses = {
-  name: 'pf-m-width-40 pf-m-width-20-on-xl wrap-column',
-  status: 'pf-m-width-20 pf-m-width-10-on-xl',
-  started: 'pf-m-width-30 pf-m-width-10-on-xl',
+  name: 'pf-m-width-30 pf-m-width-20-on-xl wrap-column',
+  status: 'pf-m-width-10 pf-m-width-5-on-xl',
+  testResultStatus: 'pf-m-width-10 pf-m-width-5-on-xl',
+  started: 'pf-m-width-20 pf-m-width-10-on-xl',
   vulnerabilities: 'pf-m-hidden pf-m-visible-on-xl pf-m-width-15',
   type: 'pf-m-hidden pf-m-visible-on-xl pf-m-width-10',
   duration: 'pf-m-hidden pf-m-visible-on-xl pf-m-width-10',
@@ -13,7 +14,9 @@ const createPipelineRunListHeader = (showVulnerabilities: boolean) => () => {
   return [
     {
       title: 'Name',
-      props: { className: pipelineRunTableColumnClasses.name },
+      props: {
+        className: pipelineRunTableColumnClasses.name,
+      },
     },
     {
       title: 'Started',
@@ -22,7 +25,7 @@ const createPipelineRunListHeader = (showVulnerabilities: boolean) => () => {
     ...(showVulnerabilities
       ? [
           {
-            title: 'Fixable Vulnerabilities',
+            title: 'Fixable vulnerabilities',
             props: { className: pipelineRunTableColumnClasses.vulnerabilities },
           },
         ]
@@ -34,6 +37,15 @@ const createPipelineRunListHeader = (showVulnerabilities: boolean) => () => {
     {
       title: 'Status',
       props: { className: pipelineRunTableColumnClasses.status },
+    },
+    {
+      title: <div>Test result</div>,
+      props: {
+        className: 'pf-m-width-10 pf-m-width-5-on-xl',
+        info: {
+          popover: 'The test result is the TEST_OUTPUT of the pipeline run integration test.',
+        },
+      },
     },
     {
       title: 'Type',

--- a/src/components/PipelineRun/PipelineRunListView/PipelineRunListRow.tsx
+++ b/src/components/PipelineRun/PipelineRunListView/PipelineRunListRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Skeleton } from '@patternfly/react-core';
+import { Popover, Skeleton } from '@patternfly/react-core';
 import { PIPELINE_RUNS_DETAILS_PATH, COMPONENT_DETAILS_PATH } from '~/routes/paths';
 import { useNamespace } from '~/shared/providers/Namespace';
 import { PipelineRunLabel } from '../../../consts/pipelinerun';
@@ -9,7 +9,12 @@ import ActionMenu from '../../../shared/components/action-menu/ActionMenu';
 import { RowFunctionArgs, TableData } from '../../../shared/components/table';
 import { Timestamp } from '../../../shared/components/timestamp/Timestamp';
 import { PipelineRunKind } from '../../../types';
-import { calculateDuration, pipelineRunStatus } from '../../../utils/pipeline-utils';
+import {
+  calculateDuration,
+  getPipelineRunStatusResults,
+  pipelineRunStatus,
+  taskTestResultStatus,
+} from '../../../utils/pipeline-utils';
 import { StatusIconWithText } from '../../StatusIcon/StatusIcon';
 import { usePipelinerunActions } from './pipelinerun-actions';
 import { pipelineRunTableColumnClasses } from './PipelineRunListHeader';
@@ -46,6 +51,11 @@ const BasePipelineRunListRow: React.FC<React.PropsWithChildren<BasePipelineRunLi
     obj.metadata.labels = {};
   }
   const applicationName = obj.metadata?.labels[PipelineRunLabel.APPLICATION];
+
+  const testStatus = React.useMemo(() => {
+    const results = getPipelineRunStatusResults(obj);
+    return taskTestResultStatus(results);
+  }, [obj]);
 
   return (
     <>
@@ -92,6 +102,16 @@ const BasePipelineRunListRow: React.FC<React.PropsWithChildren<BasePipelineRunLi
       </TableData>
       <TableData className={pipelineRunTableColumnClasses.status}>
         <StatusIconWithText status={status} />
+      </TableData>
+      <TableData className={pipelineRunTableColumnClasses.testResultStatus}>
+        <Popover
+          triggerAction="hover"
+          aria-label="error popover"
+          bodyContent={testStatus?.note}
+          isVisible={testStatus?.note ? undefined : false}
+        >
+          <div>{testStatus?.result ? testStatus.result : '-'}</div>
+        </Popover>
       </TableData>
       <TableData className={pipelineRunTableColumnClasses.type}>
         {capitalize(obj.metadata?.labels[PipelineRunLabel.PIPELINE_TYPE])}

--- a/src/components/PipelineRun/PipelineRunListView/__tests__/PipelineRunListRow.spec.tsx
+++ b/src/components/PipelineRun/PipelineRunListView/__tests__/PipelineRunListRow.spec.tsx
@@ -27,7 +27,7 @@ describe('Pipeline run Row', () => {
       <PipelineRunListRowWithVulnerabilities obj={runningPipelineRun} columns={[]} />,
     );
 
-    expect(row.getByText('-')).toBeDefined();
+    expect(row.getAllByText('-')).toBeDefined();
     expect(row.getByText('Running')).toBeDefined();
   });
 
@@ -45,7 +45,7 @@ describe('Pipeline run Row', () => {
       />,
     );
 
-    expect(row.getByText('-')).toBeDefined();
+    expect(row.getAllByText('-')).toBeDefined();
     expect(row.getByText('Succeeded')).toBeDefined();
   });
 
@@ -118,5 +118,39 @@ describe('Pipeline run Row', () => {
       row.getByText('Stop');
       row.getByText('Cancel');
     });
+  });
+
+  it('should return "ERROR" when test output result is ERROR', () => {
+    const plrWithTestOutputError = testPipelineRuns[DataState.STATUS_WITH_TEST_OUTPUT_ERROR];
+    const plrName = plrWithTestOutputError.metadata.name;
+    const row = render(
+      <PipelineRunListRowWithVulnerabilities
+        obj={plrWithTestOutputError}
+        customData={{
+          fetchedPipelineRuns: [plrName],
+          vulnerabilities: [{ [plrName]: {} }] as any,
+        }}
+        columns={[]}
+      />,
+    );
+
+    expect(row.getByText('ERROR')).toBeDefined();
+  });
+
+  it('should return "SUCCESS" when test output result is SUCCESS', () => {
+    const plrWithTestOutputError = testPipelineRuns[DataState.STATUS_WITH_TEST_OUTPUT_SUCCESS];
+    const plrName = plrWithTestOutputError.metadata.name;
+    const row = render(
+      <PipelineRunListRowWithVulnerabilities
+        obj={plrWithTestOutputError}
+        customData={{
+          fetchedPipelineRuns: [plrName],
+          vulnerabilities: [{ [plrName]: {} }] as any,
+        }}
+        columns={[]}
+      />,
+    );
+
+    expect(row.getByText('SUCCESS')).toBeDefined();
   });
 });

--- a/src/shared/components/table/Table.tsx
+++ b/src/shared/components/table/Table.tsx
@@ -25,7 +25,9 @@ export type InfiniteLoaderProps = {
   isRowLoaded: (params: { index: number }) => boolean;
 };
 
-export type HeaderFunc = (componentProps: ComponentProps) => { title: string; props: ThProps }[];
+export type HeaderFunc = (
+  componentProps: ComponentProps,
+) => { title: string | React.ReactNode; props: ThProps }[];
 
 export type TableProps<D = unknown, C = unknown> = Partial<ComponentProps<D>> & {
   customData?: C;

--- a/src/utils/pipeline-utils.ts
+++ b/src/utils/pipeline-utils.ts
@@ -229,6 +229,31 @@ export const conditionsRunStatus = (conditions: Condition[], specStatus?: string
   }
 };
 
+type TaskTestResult = {
+  result: string;
+  note?: string;
+};
+export const taskTestResultStatus = (
+  taskResults: TektonResultsRun[],
+): TaskTestResult | undefined => {
+  const testOutput = taskResults?.find(
+    (result) => result.name === 'HACBS_TEST_OUTPUT' || result.name === 'TEST_OUTPUT',
+  );
+
+  if (!testOutput) return;
+
+  try {
+    const outputValues = JSON.parse(testOutput.value);
+    if (!outputValues.result) return;
+    return { result: outputValues.result, note: outputValues.note ?? undefined };
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn('Error when trying to parse testOutput.value');
+  }
+
+  return;
+};
+
 export const taskResultsStatus = (taskResults: TektonResultsRun[]): runStatus => {
   const testOutput = taskResults?.find(
     (result) => result.name === 'HACBS_TEST_OUTPUT' || result.name === 'TEST_OUTPUT',


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

Fixes https://issues.redhat.com/browse/KONFLUX-5940

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds a new column, **"Test result"**, to the PipelineRun List View. It displays the test result parsed from either the `TEST_OUTPUT` or `HACBS_TEST_OUTPUT` status result of the PipelineRun.

To understand some of the choices made in this PR, please check the comments on the JIRA ticket — there were helpful discussions there. 🙂

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Example of how these changes look like with different `TEST_OUTPUT` results:

https://github.com/user-attachments/assets/b410aa1b-ca1f-4c0b-b3e4-f832a4ebc101

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

1. You can go to Applications -> select one application -> Activity -> Pipeline runs tab
2. You'll be able to see a new column (`Test result`)
3. If you wanna try to test different types of results as `TEST_OUTPUT`, I have a simple task example:

```yaml
- name: simulate-success
  image: registry.access.redhat.com/ubi8/ubi-minimal
  script: |
    #!/bin/sh

    timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
    cat <<EOF > $(results.TEST_OUTPUT.path)
    {
      "result": "SUCCESS",
      "namespace": "example-namespace",
      "timestamp": "$timestamp",
      "successes": 0,
      "failures": 1,
      "warnings": 0,
      "note": "Simulated SUCCESS for testing TEST_OUTPUT reporting"
    }
    EOF
    exit 0
```

this example above will simulate a `TEST_OUTPUT` with a `SUCCESS` result. You can simply update it to be either of the following result status to simulate different scenarios: https://github.com/konflux-ci/architecture/blob/main/ADR/0030-tekton-results-naming-convention.md#results-for-test-like-tasks (e.g. `ERROR`, `FAILURE`, etc)


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->