### PR TITLE
fix(KFLUXUI-431): namespaces order

### DIFF
--- a/src/components/NamespaceList/NamespaceListView.tsx
+++ b/src/components/NamespaceList/NamespaceListView.tsx
@@ -36,10 +36,7 @@ const NamespaceListView: React.FC<React.PropsWithChildren<unknown>> = () => {
 
   const [nameFilter, setNameFilter] = useSearchParam('name', '');
 
-  namespaces?.sort(
-    (app1, app2) =>
-      +new Date(app2.metadata?.creationTimestamp) - +new Date(app1.metadata?.creationTimestamp),
-  );
+  namespaces?.sort((app1, app2) => app1.metadata.name.localeCompare(app2.metadata.name));
   const filteredNamespaces = React.useMemo(() => {
     const lowerCaseNameFilter = nameFilter.toLowerCase();
     return namespaces?.filter((app) => app.metadata.name.includes(lowerCaseNameFilter));


### PR DESCRIPTION
## Fixes 
Fixes: https://issues.redhat.com/browse/KFLUXUI-431


## Description
Fixed namespaces to be sorted alphabetically instead of date.


## Type of change
- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
Before ordering alphabetically:
![Screenshot From 2025-05-22 15-41-18](https://github.com/user-attachments/assets/a56f466f-de93-42e1-8d0f-80a0b6e6fbd9)
After ordering alphabetically:
![Screenshot From 2025-05-22 13-08-43](https://github.com/user-attachments/assets/a2392b5f-6b3a-49e3-80d0-4bb6ee6e4f79)



## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
Open the website. Navigate to Namespace page -> notice that the table is now ordered alphabetically.

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->