### PR TITLE
build(KONFLUX-3835): init the release monitor dashboard

### DIFF
--- a/src/AppRoot/AppRoot.tsx
+++ b/src/AppRoot/AppRoot.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Outlet } from 'react-router-dom';
 import { Page, PageSection } from '@patternfly/react-core';
-import { NAMESPACE_LIST_PATH } from '@routes/paths';
+import { NAMESPACE_LIST_PATH, RELEASE_MONITOR_PATH } from '@routes/paths';
 import { KonfluxBanner } from '~/components/KonfluxBanner/KonfluxBanner';
 import SidePanelHost from '~/components/SidePanel/SidePanelHost';
 import { usePreventWindowCloseIfTaskRunning } from '~/shared/hooks/usePreventWindowClose';
@@ -11,7 +11,11 @@ import ActivePageAlert from './ActivePageAlert';
 import { AppHeader } from './AppHeader';
 import { AppSideBar } from './AppSideBar';
 
-const namespaceSwitcherNotAllowedRoutes = [NAMESPACE_LIST_PATH.path, '/'];
+const namespaceSwitcherNotAllowedRoutes = [
+  RELEASE_MONITOR_PATH.path,
+  NAMESPACE_LIST_PATH.path,
+  '/',
+];
 
 export const AppRoot: React.FC = () => {
   const [isSideBarOpen, setSideBarOpen] = React.useState<boolean>(true);

--- a/src/AppRoot/AppSideBar.tsx
+++ b/src/AppRoot/AppSideBar.tsx
@@ -5,10 +5,12 @@ import { css } from '@patternfly/react-styles';
 import {
   APPLICATION_LIST_PATH,
   NAMESPACE_LIST_PATH,
+  RELEASE_MONITOR_PATH,
   RELEASE_SERVICE_PATH,
   SECRET_LIST_PATH,
   USER_ACCESS_LIST_PAGE,
 } from '@routes/paths';
+import { IfFeature } from '~/feature-flags/hooks';
 import { useActiveRouteChecker } from '../../src/hooks/useActiveRouteChecker';
 import { useNamespace } from '../shared/providers/Namespace';
 
@@ -34,6 +36,16 @@ export const AppSideBar: React.FC<{ isOpen: boolean }> = ({ isOpen }) => {
             >
               <NavLink to={NAMESPACE_LIST_PATH.createPath({} as never)}>Namespaces</NavLink>
             </NavItem>
+
+            <IfFeature flag="release-monitor">
+              <NavItem
+                isActive={isActive(RELEASE_MONITOR_PATH.path, {
+                  exact: true,
+                })}
+              >
+                <NavLink to={RELEASE_MONITOR_PATH.createPath({} as never)}>Release Monitor</NavLink>
+              </NavItem>
+            </IfFeature>
 
             <NavItem
               className={css({ 'app-side-bar__nav-item--disabled': disabled })}

--- a/src/components/Overview/IntroBanner.tsx
+++ b/src/components/Overview/IntroBanner.tsx
@@ -12,7 +12,8 @@ import {
   Button,
 } from '@patternfly/react-core';
 import OverviewBannerSvg from '../../assets/overview/overview-banner.svg';
-import { NAMESPACE_LIST_PATH } from '../../routes/paths';
+import { IfFeature } from '../../feature-flags/hooks';
+import { NAMESPACE_LIST_PATH, RELEASE_MONITOR_PATH } from '../../routes/paths';
 
 import './IntroBanner.scss';
 
@@ -48,6 +49,18 @@ const IntroBanner: React.FC = () => {
             >
               View my namespaces
             </Button>
+            <IfFeature flag="release-monitor">
+              <Button
+                className="intro-banner__cta"
+                component={(props) => (
+                  <Link {...props} to={RELEASE_MONITOR_PATH.createPath({} as never)} />
+                )}
+                variant="secondary"
+                size="lg"
+              >
+                Release Monitor Board
+              </Button>
+            </IfFeature>
           </CardBody>
         </Card>
       </FlexItem>

--- a/src/components/ReleaseMonitor/ApplicationFilter.tsx
+++ b/src/components/ReleaseMonitor/ApplicationFilter.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import {
+  Menu,
+  MenuContent,
+  MenuList,
+  MenuItem,
+  MenuToggle,
+  Badge,
+  MenuContainer,
+} from '@patternfly/react-core';
+import { FilterIcon } from '@patternfly/react-icons/dist/esm/icons/filter-icon';
+
+interface ApplicationFilterProps {
+  applications: string[];
+  onSelectionsChange: (selections: string[]) => void;
+}
+
+export const ApplicationFilter: React.FC<ApplicationFilterProps> = ({
+  applications,
+  onSelectionsChange,
+}) => {
+  const [selections, setSelections] = React.useState<string[]>([]);
+  const [isOpen, setIsOpen] = React.useState(false);
+  const toggleRef = React.useRef<HTMLButtonElement>(null);
+  const menuRef = React.useRef<HTMLDivElement>(null);
+
+  const onToggleClick = (ev: React.MouseEvent) => {
+    ev.stopPropagation();
+    setIsOpen(!isOpen);
+  };
+
+  const onSelect = (itemId: string | number | undefined) => {
+    if (itemId === undefined) {
+      setSelections([]);
+      onSelectionsChange([]);
+      return;
+    }
+    const itemStr = itemId.toString();
+    const newSelections = selections.includes(itemStr)
+      ? selections.filter((selection) => selection !== itemStr)
+      : [itemStr, ...selections];
+    setSelections(newSelections);
+    onSelectionsChange(newSelections);
+  };
+
+  const toggle = (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={onToggleClick}
+      isExpanded={isOpen}
+      icon={<FilterIcon />}
+      badge={selections.length > 0 ? <Badge isRead>{selections.length}</Badge> : undefined}
+    >
+      Filter by application
+    </MenuToggle>
+  );
+
+  const menu = (
+    <Menu ref={menuRef} onSelect={(_, itemId) => onSelect(itemId)}>
+      <MenuContent>
+        <MenuList>
+          {applications.map((application) => (
+            <MenuItem
+              key={application}
+              itemId={application}
+              isSelected={selections.includes(application)}
+            >
+              {application}
+            </MenuItem>
+          ))}
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+
+  return (
+    <MenuContainer
+      isOpen={isOpen}
+      onOpenChange={(open) => setIsOpen(open)}
+      toggle={toggle}
+      menu={menu}
+      toggleRef={toggleRef}
+      menuRef={menuRef}
+    />
+  );
+};

--- a/src/components/ReleaseMonitor/ReleaseFilters.tsx
+++ b/src/components/ReleaseMonitor/ReleaseFilters.tsx
@@ -1,0 +1,182 @@
+import * as React from 'react';
+import {
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+  ToolbarToggleGroup,
+  ToolbarGroup,
+  ToolbarFilter,
+  Menu,
+  MenuContent,
+  MenuList,
+  MenuItem,
+  MenuToggle,
+  MenuContainer,
+} from '@patternfly/react-core';
+import { FilterIcon } from '@patternfly/react-icons/dist/esm/icons/filter-icon';
+import { ApplicationFilter } from './ApplicationFilter';
+import { SearchFilter } from './SearchFilter';
+import { StatusFilter } from './StatusFilter';
+import { TenantFilter } from './TenantFilter';
+
+interface ReleaseFiltersProps {
+  applications: string[];
+  tenants: string[];
+  applicationSelections: string[];
+  tenantSelections: string[];
+  statusSelection: string;
+  searchValue: string;
+  onSearchChange: (value: string) => void;
+  onApplicationSelectionsChange: (selections: string[]) => void;
+  onTenantSelect: (itemId: string | number | undefined) => void;
+  onStatusSelect: (itemId: string | number | undefined) => void;
+  onClearFilters: () => void;
+}
+
+type AttributeMenuType = 'Application' | 'Namespace' | 'Release Plan' | 'Status';
+
+export const ReleaseFilters: React.FC<ReleaseFiltersProps> = ({
+  applications,
+  tenants,
+  applicationSelections,
+  tenantSelections,
+  statusSelection,
+  searchValue,
+  onSearchChange,
+  onApplicationSelectionsChange,
+  onTenantSelect,
+  onStatusSelect,
+  onClearFilters,
+}) => {
+  const [activeAttributeMenu, setActiveAttributeMenu] =
+    React.useState<AttributeMenuType>('Application');
+  const [isAttributeMenuOpen, setIsAttributeMenuOpen] = React.useState(false);
+  const attributeToggleRef = React.useRef<HTMLButtonElement>(null);
+  const attributeMenuRef = React.useRef<HTMLDivElement>(null);
+  const attributeContainerRef = React.useRef<HTMLDivElement>(null);
+
+  const onAttributeToggleClick = (ev: React.MouseEvent) => {
+    ev.stopPropagation();
+    setTimeout(() => {
+      if (attributeMenuRef.current) {
+        const firstElement = attributeMenuRef.current.querySelector('li > button:not(:disabled)');
+        firstElement && (firstElement as HTMLElement).focus();
+      }
+    }, 0);
+    setIsAttributeMenuOpen(!isAttributeMenuOpen);
+  };
+
+  const attributeToggle = (
+    <MenuToggle
+      ref={attributeToggleRef}
+      onClick={onAttributeToggleClick}
+      isExpanded={isAttributeMenuOpen}
+      icon={<FilterIcon />}
+    >
+      {activeAttributeMenu}
+    </MenuToggle>
+  );
+
+  const attributeMenu = (
+    <Menu
+      ref={attributeMenuRef}
+      onSelect={(_ev, itemId) => {
+        setActiveAttributeMenu(itemId?.toString() as AttributeMenuType);
+        setIsAttributeMenuOpen(!isAttributeMenuOpen);
+      }}
+    >
+      <MenuContent>
+        <MenuList>
+          <MenuItem itemId="Application">Application</MenuItem>
+          <MenuItem itemId="Namespace">Namespace</MenuItem>
+          <MenuItem itemId="Release Plan">Release Plan</MenuItem>
+          <MenuItem itemId="Status">Status</MenuItem>
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+
+  const attributeDropdown = (
+    <MenuContainer
+      isOpen={isAttributeMenuOpen}
+      onOpenChange={(open) => setIsAttributeMenuOpen(open)}
+      toggle={attributeToggle}
+      menu={attributeMenu}
+      toggleRef={attributeToggleRef}
+      menuRef={attributeContainerRef}
+    />
+  );
+
+  const renderActiveFilter = () => {
+    switch (activeAttributeMenu) {
+      case 'Application':
+        return (
+          <ToolbarFilter
+            chips={applicationSelections}
+            deleteChip={(_, chip) =>
+              onApplicationSelectionsChange(applicationSelections.filter((s) => s !== chip))
+            }
+            deleteChipGroup={() => onApplicationSelectionsChange([])}
+            categoryName="application"
+          >
+            <ApplicationFilter
+              applications={applications}
+              onSelectionsChange={onApplicationSelectionsChange}
+            />
+          </ToolbarFilter>
+        );
+      case 'Namespace':
+        return (
+          <ToolbarFilter
+            chips={tenantSelections}
+            deleteChip={() => onTenantSelect(undefined)}
+            deleteChipGroup={() => onTenantSelect(undefined)}
+            categoryName="tenant"
+          >
+            <TenantFilter
+              tenants={tenants}
+              selections={tenantSelections}
+              onSelect={onTenantSelect}
+            />
+          </ToolbarFilter>
+        );
+      case 'Release Plan':
+        return (
+          <ToolbarFilter
+            chips={searchValue !== '' ? [searchValue] : []}
+            deleteChip={() => onSearchChange('')}
+            deleteChipGroup={() => onSearchChange('')}
+            categoryName="releaseplan"
+          >
+            <SearchFilter value={searchValue} onChange={onSearchChange} />
+          </ToolbarFilter>
+        );
+      case 'Status':
+        return (
+          <ToolbarFilter
+            chips={statusSelection !== '' ? [statusSelection] : []}
+            deleteChip={() => onStatusSelect(undefined)}
+            deleteChipGroup={() => onStatusSelect(undefined)}
+            categoryName="status"
+          >
+            <StatusFilter selection={statusSelection} onSelect={onStatusSelect} />
+          </ToolbarFilter>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Toolbar id="attribute-search-filter-toolbar" clearAllFilters={onClearFilters}>
+      <ToolbarContent>
+        <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">
+          <ToolbarGroup variant="filter-group">
+            <ToolbarItem>{attributeDropdown}</ToolbarItem>
+            {renderActiveFilter()}
+          </ToolbarGroup>
+        </ToolbarToggleGroup>
+      </ToolbarContent>
+    </Toolbar>
+  );
+};

--- a/src/components/ReleaseMonitor/ReleaseListHeader.tsx
+++ b/src/components/ReleaseMonitor/ReleaseListHeader.tsx
@@ -1,0 +1,27 @@
+import { createTableHeaders } from '../../shared/components/table/utils';
+
+export const releaseTableColumnClasses = {
+  name: 'pf-m-width-20 ',
+  status: 'pf-m-width-10',
+  completionTime: 'pf-m-width-10',
+  component: 'pf-m-width-20',
+  application: 'pf-m-width-10',
+  releasePlan: 'pf-m-width-20',
+  namespace: 'pf-m-width-10 ',
+};
+
+export enum SortableHeaders {
+  completionTime,
+}
+
+const releaseColumns = [
+  { title: 'Release Name', className: releaseTableColumnClasses.name },
+  { title: 'Status', className: releaseTableColumnClasses.status },
+  { title: 'Completion Time', className: releaseTableColumnClasses.completionTime, sortable: true },
+  { title: 'Component', className: releaseTableColumnClasses.component },
+  { title: 'Application', className: releaseTableColumnClasses.application },
+  { title: 'Release Plan', className: releaseTableColumnClasses.releasePlan },
+  { title: 'Namespace', className: releaseTableColumnClasses.namespace },
+];
+
+export default createTableHeaders(releaseColumns);

--- a/src/components/ReleaseMonitor/ReleaseListRow.tsx
+++ b/src/components/ReleaseMonitor/ReleaseListRow.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { PipelineRunLabel } from '~/consts/pipelinerun';
+import { useReleaseStatus } from '~/hooks/useReleaseStatus';
+import {
+  APPLICATION_DETAILS_PATH,
+  APPLICATION_RELEASE_DETAILS_PATH,
+  COMPONENT_DETAILS_PATH,
+  RELEASEPLAN_PATH,
+} from '../../routes/paths';
+import { RowFunctionArgs, TableData } from '../../shared/components/table';
+import { Timestamp } from '../../shared/components/timestamp/Timestamp';
+import { MonitoredReleaseKind } from '../../types';
+import { StatusIconWithText } from '../StatusIcon/StatusIcon';
+import { releaseTableColumnClasses } from './ReleaseListHeader';
+
+const ReleaseListRow: React.FC<RowFunctionArgs<MonitoredReleaseKind>> = ({ obj }) => {
+  const status = useReleaseStatus(obj);
+
+  return (
+    <>
+      <TableData className={releaseTableColumnClasses.name}>
+        <Link
+          to={APPLICATION_RELEASE_DETAILS_PATH.createPath({
+            workspaceName: obj.metadata.namespace,
+            applicationName: obj.metadata.labels?.[PipelineRunLabel.APPLICATION],
+            releaseName: obj.metadata.name,
+          })}
+        >
+          {obj.metadata.name}
+        </Link>
+      </TableData>
+
+      <TableData className={releaseTableColumnClasses.status}>
+        <StatusIconWithText status={status} />
+      </TableData>
+
+      <TableData className={releaseTableColumnClasses.completionTime}>
+        <Timestamp timestamp={obj.status?.completionTime ?? ''} />
+      </TableData>
+
+      <TableData className={releaseTableColumnClasses.component}>
+        <Link
+          to={COMPONENT_DETAILS_PATH.createPath({
+            workspaceName: obj.metadata.namespace,
+            applicationName: obj.metadata.labels?.[PipelineRunLabel.APPLICATION],
+            componentName: obj.metadata.labels?.[PipelineRunLabel.COMPONENT],
+          })}
+        >
+          {obj.metadata.labels?.[PipelineRunLabel.COMPONENT]}
+        </Link>
+      </TableData>
+
+      <TableData className={releaseTableColumnClasses.application}>
+        <Link
+          to={APPLICATION_DETAILS_PATH.createPath({
+            workspaceName: obj.metadata.namespace,
+            applicationName: obj.metadata.labels?.[PipelineRunLabel.APPLICATION],
+          })}
+        >
+          {obj.metadata.labels?.[PipelineRunLabel.APPLICATION]}
+        </Link>
+      </TableData>
+
+      <TableData className={releaseTableColumnClasses.releasePlan}>
+        <Link to={RELEASEPLAN_PATH.createPath({ workspaceName: obj.metadata.namespace })}>
+          {obj.spec.releasePlan}
+        </Link>
+      </TableData>
+
+      <TableData className={releaseTableColumnClasses.namespace}>
+        {obj.metadata.namespace}
+      </TableData>
+    </>
+  );
+};
+
+export default ReleaseListRow;

--- a/src/components/ReleaseMonitor/ReleaseMonitor.tsx
+++ b/src/components/ReleaseMonitor/ReleaseMonitor.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react';
+import { PageSection, PageSectionVariants } from '@patternfly/react-core';
+import { PipelineRunLabel } from '~/consts/pipelinerun';
+import { HttpError } from '~/k8s/error';
+import ErrorEmptyState from '~/shared/components/empty-state/ErrorEmptyState';
+import { useGetAllReleases } from '../../hooks/useGetAllReleases';
+import { MonitoredReleaseKind } from '../../types';
+import PageLayout from '../PageLayout/PageLayout';
+import { ReleaseFilters } from './ReleaseFilters';
+import { ReleaseTable } from './ReleaseTable';
+
+const ReleaseMonitor: React.FunctionComponent = () => {
+  const [searchValue, setSearchValue] = React.useState('');
+  const [applicationSelections, setApplicationSelections] = React.useState<string[]>([]);
+  const [tenantSelections, setTenantSelections] = React.useState<string[]>([]);
+  const [statusSelection, setStatusSelection] = React.useState('');
+  const { releases, loading, error } = useGetAllReleases();
+  const applications = React.useMemo(() => {
+    return Array.from(
+      new Set(releases.map((release) => release.metadata.labels?.[PipelineRunLabel.APPLICATION])),
+    );
+  }, [releases]);
+  const tenants = React.useMemo(() => {
+    return Array.from(new Set(releases.map((release) => release.metadata.namespace)));
+  }, [releases]);
+
+  const onFilter = React.useCallback(
+    (release: MonitoredReleaseKind) => {
+      const matchesSearchValue = release.spec.releasePlan.includes(searchValue);
+      const matchesTenantValue = tenantSelections.includes(release.metadata.namespace);
+      const matchesApplicationValue = applicationSelections.includes(
+        release.metadata.labels?.[PipelineRunLabel.APPLICATION],
+      );
+      const matchesStatusValue =
+        (release.status?.conditions[0].reason ?? 'Failed').toLowerCase() ===
+        statusSelection.toLowerCase();
+
+      return (
+        (searchValue === '' || matchesSearchValue) &&
+        (tenantSelections.length === 0 || matchesTenantValue) &&
+        (applicationSelections.length === 0 || matchesApplicationValue) &&
+        (statusSelection === '' || matchesStatusValue)
+      );
+    },
+    [searchValue, tenantSelections, applicationSelections, statusSelection],
+  );
+
+  const filteredReleases = React.useMemo(() => {
+    return releases.filter(onFilter);
+  }, [releases, onFilter]);
+
+  if (error) {
+    return (
+      <ErrorEmptyState
+        httpError={HttpError.fromCode(500)}
+        title="Unable to load release"
+        body={(error as { message: string }).message}
+      />
+    );
+  }
+
+  const onApplicationSelectionsChange = (selections: string[]) => {
+    setApplicationSelections(selections);
+  };
+
+  const onTenantSelect = (itemId: string | number | undefined) => {
+    if (itemId === undefined) {
+      setTenantSelections([]);
+      return;
+    }
+    const itemStr = itemId.toString();
+    setTenantSelections(
+      tenantSelections.includes(itemStr)
+        ? tenantSelections.filter((selection) => selection !== itemStr)
+        : [itemStr, ...tenantSelections],
+    );
+  };
+
+  const onStatusSelect = (itemId: string | number | undefined) => {
+    if (itemId === undefined) {
+      setStatusSelection('');
+      return;
+    }
+    const itemStr = itemId.toString();
+    setStatusSelection(statusSelection === itemStr ? '' : itemStr);
+  };
+
+  const onClearFilters = () => {
+    setSearchValue('');
+    setApplicationSelections([]);
+    setTenantSelections([]);
+    setStatusSelection('');
+  };
+
+  return (
+    <PageLayout title="Release Monitor" description="The dashboard to monitor your cared releases">
+      <PageSection padding={{ default: 'noPadding' }} variant={PageSectionVariants.light} isFilled>
+        <ReleaseFilters
+          applications={applications}
+          tenants={tenants}
+          applicationSelections={applicationSelections}
+          tenantSelections={tenantSelections}
+          statusSelection={statusSelection}
+          searchValue={searchValue}
+          onSearchChange={setSearchValue}
+          onApplicationSelectionsChange={onApplicationSelectionsChange}
+          onTenantSelect={onTenantSelect}
+          onStatusSelect={onStatusSelect}
+          onClearFilters={onClearFilters}
+        />
+        <ReleaseTable releases={filteredReleases} loading={loading} />
+      </PageSection>
+    </PageLayout>
+  );
+};
+
+export default ReleaseMonitor;

--- a/src/components/ReleaseMonitor/ReleaseTable.tsx
+++ b/src/components/ReleaseMonitor/ReleaseTable.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import { Bullseye, EmptyStateBody, Spinner, Text, TextVariants } from '@patternfly/react-core';
+import { SortByDirection } from '@patternfly/react-table';
+import { useSortedResources } from '~/hooks/useSortedResources';
+import emptyStateImgUrl from '../../assets/Release.svg';
+import { Table } from '../../shared';
+import AppEmptyState from '../../shared/components/empty-state/AppEmptyState';
+import { MonitoredReleaseKind } from '../../types';
+import getReleasesListHeader, { SortableHeaders } from './ReleaseListHeader';
+import ReleaseListRow from './ReleaseListRow';
+
+interface ReleaseTableProps {
+  releases: MonitoredReleaseKind[];
+  loading: boolean;
+}
+
+const sortPaths: Record<SortableHeaders, string> = {
+  [SortableHeaders.completionTime]: 'status.completionTime',
+};
+
+const ReleasesEmptyState: React.FC<React.PropsWithChildren<unknown>> = () => (
+  <AppEmptyState emptyStateImg={emptyStateImgUrl} title="No releases found">
+    <EmptyStateBody>
+      <Text component={TextVariants.p}>
+        You don&apos;t have available releases matching the current filters. Please try adjusting
+        the filter conditions, or you may not have any releases in the selected namespaces, or your
+        old releases were archived.
+      </Text>
+    </EmptyStateBody>
+  </AppEmptyState>
+);
+
+export const ReleaseTable: React.FC<ReleaseTableProps> = ({ releases, loading }) => {
+  const [activeSortIndex, setActiveSortIndex] = React.useState<number>(
+    SortableHeaders.completionTime,
+  );
+  const [activeSortDirection, setActiveSortDirection] = React.useState<SortByDirection>(
+    SortByDirection.asc,
+  );
+  const ReleaseListHeader = React.useMemo(
+    () =>
+      getReleasesListHeader(activeSortIndex, activeSortDirection, (_, index, direction) => {
+        setActiveSortIndex(index);
+        setActiveSortDirection(direction);
+      }),
+    [activeSortDirection, activeSortIndex],
+  );
+
+  const sortedReleases = useSortedResources(
+    releases,
+    activeSortIndex,
+    activeSortDirection,
+    sortPaths,
+  );
+
+  return (
+    <>
+      {loading ? (
+        <Bullseye>
+          <Spinner /> Loading..
+        </Bullseye>
+      ) : (
+        <>
+          {!sortedReleases?.length ? (
+            <ReleasesEmptyState />
+          ) : (
+            <Table
+              data={sortedReleases}
+              aria-label="Release List"
+              Header={ReleaseListHeader}
+              Row={ReleaseListRow}
+              loaded={releases.length > 0}
+            />
+          )}
+        </>
+      )}
+    </>
+  );
+};

--- a/src/components/ReleaseMonitor/SearchFilter.tsx
+++ b/src/components/ReleaseMonitor/SearchFilter.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { SearchInput } from '@patternfly/react-core';
+interface SearchFilterProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export const SearchFilter: React.FC<SearchFilterProps> = ({ value, onChange }) => {
+  return (
+    <SearchInput
+      placeholder="Search by release plan"
+      value={value}
+      onChange={(_, v) => onChange(v)}
+      onClear={() => onChange('')} // clear and debunce
+    />
+  );
+};

--- a/src/components/ReleaseMonitor/StatusFilter.tsx
+++ b/src/components/ReleaseMonitor/StatusFilter.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import {
+  Menu,
+  MenuContent,
+  MenuList,
+  MenuItem,
+  MenuToggle,
+  MenuContainer,
+} from '@patternfly/react-core';
+import { FilterIcon } from '@patternfly/react-icons/dist/esm/icons/filter-icon';
+
+interface StatusFilterProps {
+  selection: string;
+  onSelect: (itemId: string | number | undefined) => void;
+}
+
+export const StatusFilter: React.FC<StatusFilterProps> = ({ selection, onSelect }) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const toggleRef = React.useRef<HTMLButtonElement>(null);
+  const menuRef = React.useRef<HTMLDivElement>(null);
+
+  const onToggleClick = (ev: React.MouseEvent) => {
+    ev.stopPropagation();
+    setIsOpen(!isOpen);
+  };
+
+  const toggle = (
+    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen} icon={<FilterIcon />}>
+      Filter by status
+    </MenuToggle>
+  );
+
+  const menu = (
+    <Menu ref={menuRef} onSelect={(_, itemId) => onSelect(itemId)}>
+      <MenuContent>
+        <MenuList>
+          <MenuItem key="Succeeded" itemId="Succeeded" isSelected={selection === 'Succeeded'}>
+            Succeeded
+          </MenuItem>
+          <MenuItem key="Failed" itemId="Failed" isSelected={selection === 'Failed'}>
+            Failed
+          </MenuItem>
+          <MenuItem key="Progressing" itemId="Progressing" isSelected={selection === 'Progressing'}>
+            Progressing
+          </MenuItem>
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+
+  return (
+    <MenuContainer
+      isOpen={isOpen}
+      onOpenChange={(open) => setIsOpen(open)}
+      toggle={toggle}
+      menu={menu}
+      toggleRef={toggleRef}
+      menuRef={menuRef}
+    />
+  );
+};

--- a/src/components/ReleaseMonitor/TenantFilter.tsx
+++ b/src/components/ReleaseMonitor/TenantFilter.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import {
+  Menu,
+  MenuContent,
+  MenuList,
+  MenuItem,
+  MenuToggle,
+  Badge,
+  MenuContainer,
+} from '@patternfly/react-core';
+import { FilterIcon } from '@patternfly/react-icons/dist/esm/icons/filter-icon';
+
+interface TenantFilterProps {
+  tenants: string[];
+  selections: string[];
+  onSelect: (itemId: string | number | undefined) => void;
+}
+
+export const TenantFilter: React.FC<TenantFilterProps> = ({ tenants, selections, onSelect }) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const toggleRef = React.useRef<HTMLButtonElement>(null);
+  const menuRef = React.useRef<HTMLDivElement>(null);
+
+  const onToggleClick = (ev: React.MouseEvent) => {
+    ev.stopPropagation();
+    setIsOpen(!isOpen);
+  };
+
+  const toggle = (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={onToggleClick}
+      isExpanded={isOpen}
+      icon={<FilterIcon />}
+      badge={selections.length > 0 ? <Badge isRead>{selections.length}</Badge> : undefined}
+    >
+      Filter by namespace
+    </MenuToggle>
+  );
+
+  const menu = (
+    <Menu ref={menuRef} onSelect={(_, itemId) => onSelect(itemId)}>
+      <MenuContent>
+        <MenuList>
+          {tenants.map((tenant) => (
+            <MenuItem key={tenant} itemId={tenant} isSelected={selections.includes(tenant)}>
+              {tenant}
+            </MenuItem>
+          ))}
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+
+  return (
+    <MenuContainer
+      isOpen={isOpen}
+      onOpenChange={(open) => setIsOpen(open)}
+      toggle={toggle}
+      menu={menu}
+      toggleRef={toggleRef}
+      menuRef={menuRef}
+    />
+  );
+};

--- a/src/components/ReleaseMonitor/__data__/mock-release-data.ts
+++ b/src/components/ReleaseMonitor/__data__/mock-release-data.ts
@@ -1,0 +1,106 @@
+import { K8sResourceCommon } from '~/types/k8s';
+import { ReleaseKind, ReleaseCondition } from '~/types/release';
+
+export const mockReleases: ReleaseKind[] = [
+  {
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    kind: 'Release',
+    metadata: {
+      name: 'test-release-1',
+      creationTimestamp: '2023-02-01T10:30:00Z',
+      labels: {
+        'appstudio.openshift.io/application': 'foo',
+        'appstudio.openshift.io/component': 'foo-component',
+      },
+      namespace: 'namespace-1',
+    },
+    spec: {
+      releasePlan: 'test-plan',
+      snapshot: 'test-snapshot',
+    },
+    status: {
+      startTime: '2023-01-01T10:30:00Z',
+      target: 'test-target',
+      conditions: [
+        {
+          message: '',
+          reason: 'Progressing',
+          status: 'False',
+          type: ReleaseCondition.Released,
+        },
+      ],
+    },
+  },
+  {
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    kind: 'Release',
+    metadata: {
+      name: 'test-release-2',
+      creationTimestamp: '2023-03-01T10:30:00Z',
+      labels: {
+        'appstudio.openshift.io/application': 'test',
+        'appstudio.openshift.io/component': 'test-01-component',
+      },
+      namespace: 'namespace-1',
+    },
+    spec: {
+      releasePlan: 'test-plan-2',
+      snapshot: 'test-snapshot-2',
+    },
+    status: {
+      startTime: '2023-01-01T10:30:00Z',
+      completionTime: '2023-01-01T10:30:10Z',
+      target: 'test-target',
+      conditions: [
+        {
+          message: '',
+          reason: 'Succeeded',
+          status: 'True',
+          type: ReleaseCondition.Released,
+        },
+      ],
+    },
+  },
+  {
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    kind: 'Release',
+    metadata: {
+      name: 'test-release-3',
+      creationTimestamp: '2023-01-01T10:30:00Z',
+      labels: {
+        'appstudio.openshift.io/application': 'foo',
+        'appstudio.openshift.io/component': 'bar-01-component',
+      },
+      namespace: 'namespace-2',
+    },
+    spec: {
+      releasePlan: 'test-plan-3',
+      snapshot: 'test-snapshot-3',
+    },
+    status: {
+      startTime: '2023-01-01T10:30:00Z',
+      completionTime: '2023-01-01T10:30:10Z',
+      target: 'test-target',
+      conditions: [
+        {
+          message: 'Release processing failed on managed pipelineRun',
+          reason: 'Failed',
+          status: 'False',
+          type: ReleaseCondition.Released,
+        },
+      ],
+    },
+  },
+];
+
+export const mockNamespaceData = {
+  namespace: '',
+  namespaceResource: undefined,
+  namespacesLoaded: false,
+  namespaces: [],
+  lastUsedNamespace: '',
+};
+
+export const mockNamespaces = [
+  { metadata: { name: 'namespace-1', creationTimestamp: '2023-12-01T00:00:00Z' } },
+] as K8sResourceCommon[];

--- a/src/components/ReleaseMonitor/__tests__/ReleaseMonitor.spec.tsx
+++ b/src/components/ReleaseMonitor/__tests__/ReleaseMonitor.spec.tsx
@@ -1,0 +1,223 @@
+import '@testing-library/jest-dom';
+import { Table as PfTable, TableHeader } from '@patternfly/react-table/deprecated';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { mockNamespaceHooks } from '../../../unit-test-utils/mock-namespace';
+import { createK8sUtilMock } from '../../../utils/test-utils';
+import { mockReleases, mockNamespaceData, mockNamespaces } from '../__data__/mock-release-data';
+import ReleaseListRow from '../ReleaseListRow';
+import ReleaseMonitor from '../ReleaseMonitor';
+
+const mockUseNamespaceInfo = mockNamespaceHooks('useNamespaceInfo', mockNamespaceData);
+
+jest.mock('react-i18next', () => ({
+  useTranslation: jest.fn(() => ({ t: (x) => x })),
+}));
+
+jest.mock('react-router-dom', () => ({
+  Link: (props) => <a href={props.to}>{props.children}</a>,
+}));
+
+const k8sUtilMock = createK8sUtilMock('K8sQueryListResourceItems');
+k8sUtilMock.mockResolvedValue(mockReleases);
+
+jest.mock('../../../shared/components/table', () => {
+  const actual = jest.requireActual('../../../shared/components/table');
+  return {
+    ...actual,
+    Table: (props) => {
+      const { data, filters, selected, match, kindObj } = props;
+      const cProps = { data, filters, selected, match, kindObj };
+      const columns = props.Header(cProps);
+      return (
+        <PfTable role="table" aria-label="table" cells={columns} variant="compact" borders={false}>
+          <TableHeader role="rowgroup" />
+          <tbody>
+            {props.data.map((obj, i) => (
+              <tr key={i}>
+                <ReleaseListRow
+                  obj={obj}
+                  columns={null}
+                  customData={{ applicationName: 'test-app' }}
+                />
+              </tr>
+            ))}
+          </tbody>
+        </PfTable>
+      );
+    },
+  };
+});
+
+describe('ReleaseMonitor', () => {
+  it('should render all columns and releases', async () => {
+    mockUseNamespaceInfo.mockReturnValue({
+      ...mockNamespaceData,
+      namespaces: mockNamespaces,
+      namespacesLoaded: true,
+    });
+
+    const expectedHeaders = [
+      'Application',
+      'Component',
+      'Status',
+      'Release Name',
+      'Release Plan',
+      'Completion Time',
+      'Namespace',
+    ];
+
+    render(<ReleaseMonitor />);
+
+    // Wait for data to load and releases to appear
+    await waitFor(() => {
+      expect(screen.getByText('foo-component')).toBeInTheDocument();
+      ['foo-component', 'test-01-component', 'bar-01-component'].forEach((component) => {
+        expect(screen.getByText(component)).toBeInTheDocument();
+      });
+      expectedHeaders.forEach((header) => {
+        expect(screen.getAllByText(header).length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  it('should filter releases by application', async () => {
+    mockUseNamespaceInfo.mockReturnValue({
+      ...mockNamespaceData,
+      namespaces: mockNamespaces,
+      namespacesLoaded: true,
+    });
+
+    render(<ReleaseMonitor />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('foo-component')).toBeInTheDocument();
+    });
+    const applicationToggle = screen.getByRole('button', { name: 'Filter by application' });
+    fireEvent.click(applicationToggle);
+    const applicationMenuItems = screen.getAllByText('foo');
+    fireEvent.click(applicationMenuItems[0]);
+    await waitFor(() => {
+      expect(screen.queryByText('test-01-component')).not.toBeInTheDocument();
+      ['foo-component', 'bar-01-component'].map((component) => {
+        expect(screen.queryByText(component)).toBeInTheDocument();
+      });
+    });
+  });
+
+  it('should filter releases by namespace', async () => {
+    mockUseNamespaceInfo.mockReturnValue({
+      ...mockNamespaceData,
+      namespaces: mockNamespaces,
+      namespacesLoaded: true,
+    });
+
+    render(<ReleaseMonitor />);
+
+    await waitFor(() => {
+      expect(screen.queryByText('foo-component')).toBeInTheDocument();
+    });
+    const attributeToggle = screen.getByRole('button', { name: 'Application' });
+    fireEvent.click(attributeToggle);
+    const namespaceMenuItem = screen.getByRole('menuitem', { name: 'Namespace' });
+    fireEvent.click(namespaceMenuItem);
+    const tenantToggle = screen.getByRole('button', { name: 'Filter by namespace' });
+    fireEvent.click(tenantToggle);
+    const tenantMenuItem = screen.getByRole('menuitem', { name: 'namespace-1' });
+    fireEvent.click(tenantMenuItem);
+    await waitFor(() => {
+      ['foo-component', 'test-01-component'].map((component) => {
+        expect(screen.queryByText(component)).toBeInTheDocument();
+      });
+    });
+  });
+
+  it('should filter releases by status', async () => {
+    mockUseNamespaceInfo.mockReturnValue({
+      ...mockNamespaceData,
+      namespaces: mockNamespaces,
+      namespacesLoaded: true,
+    });
+    render(<ReleaseMonitor />);
+    await waitFor(() => {
+      expect(screen.queryByText('foo-component')).toBeInTheDocument();
+    });
+    const attributeToggle = screen.getByRole('button', { name: 'Application' });
+    fireEvent.click(attributeToggle);
+    const statusMenuItem = screen.getByRole('menuitem', { name: 'Status' });
+    fireEvent.click(statusMenuItem);
+    const statusToggle = screen.getByRole('button', { name: 'Filter by status' });
+    fireEvent.click(statusToggle);
+    const succeededMenuItem = screen.getByRole('menuitem', { name: 'Succeeded' });
+    fireEvent.click(succeededMenuItem);
+    await waitFor(() => {
+      expect(screen.queryByText('test-01-component')).toBeInTheDocument();
+      ['foo-component', 'bar-01-component'].map((component) => {
+        expect(screen.queryByText(component)).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  it('should show empty state when no releases match filters', async () => {
+    mockUseNamespaceInfo.mockReturnValue({
+      ...mockNamespaceData,
+      namespaces: mockNamespaces,
+      namespacesLoaded: true,
+    });
+    render(<ReleaseMonitor />);
+    await waitFor(() => {
+      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    });
+    const attributeToggle = screen.getByRole('button', { name: 'Application' });
+    fireEvent.click(attributeToggle);
+    const rpMenuItem = screen.getByRole('menuitem', { name: 'Release Plan' });
+    fireEvent.click(rpMenuItem);
+    const rpText = screen.getByPlaceholderText('Search by release plan');
+    fireEvent.change(rpText, { target: { value: 'test-no-exit' } });
+    await waitFor(() => {
+      expect(screen.queryByText('No releases found')).toBeInTheDocument();
+    });
+  });
+
+  it('should change visible filter input when attribute dropdown is clicked', async () => {
+    mockUseNamespaceInfo.mockReturnValue({
+      ...mockNamespaceData,
+      namespaces: mockNamespaces,
+      namespacesLoaded: true,
+    });
+    render(<ReleaseMonitor />);
+    await waitFor(() => {
+      expect(screen.queryByText('foo-component')).toBeInTheDocument();
+    });
+    const attributeToggle = screen.getByRole('button', { name: 'Application' });
+    fireEvent.click(attributeToggle);
+    const statusMenuItem = screen.getByRole('menuitem', { name: 'Status' });
+    fireEvent.click(statusMenuItem);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Filter by status' })).toBeVisible();
+    });
+  });
+
+  it('should filter releases by release plan', async () => {
+    mockUseNamespaceInfo.mockReturnValue({
+      ...mockNamespaceData,
+      namespaces: mockNamespaces,
+      namespacesLoaded: true,
+    });
+    render(<ReleaseMonitor />);
+    await waitFor(() => {
+      expect(screen.queryByText('foo-component')).toBeInTheDocument();
+    });
+    const attributeToggle = screen.getByRole('button', { name: 'Application' });
+    fireEvent.click(attributeToggle);
+    const rpMenuItem = screen.getByRole('menuitem', { name: 'Release Plan' });
+    fireEvent.click(rpMenuItem);
+    const rpText = screen.getByPlaceholderText('Search by release plan');
+    fireEvent.change(rpText, { target: { value: 'test-plan-3' } });
+    await waitFor(() => {
+      expect(screen.queryByText('bar-01-component')).toBeInTheDocument();
+      ['foo-component', 'test-01-component'].map((component) => {
+        expect(screen.queryByText(component)).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/components/ReleaseMonitor/index.ts
+++ b/src/components/ReleaseMonitor/index.ts
@@ -1,0 +1,1 @@
+export { default as ReleaseMonitor } from './ReleaseMonitor';

--- a/src/feature-flags/flags.ts
+++ b/src/feature-flags/flags.ts
@@ -47,6 +47,13 @@ export const FLAGS: Record<string, FeatureFlagDefinition> = {
     defaultEnabled: false,
     status: 'wip',
   },
+  'release-monitor': {
+    key: 'release-monitor',
+    description:
+      'New release monitor page that make user see all the related releases of viable namespaces',
+    defaultEnabled: false,
+    status: 'wip',
+  },
 };
 
 export type FlagKey = keyof typeof FLAGS;

--- a/src/hooks/useGetAllReleases.ts
+++ b/src/hooks/useGetAllReleases.ts
@@ -1,0 +1,49 @@
+import React from 'react';
+import { PipelineRunLabel } from '../consts/pipelinerun';
+import { K8sQueryListResourceItems } from '../k8s';
+import { ReleaseModel } from '../models';
+import { useNamespaceInfo } from '../shared/providers/Namespace';
+import { MonitoredReleaseKind } from '../types';
+
+/**
+ * Get all the valid releases across the namespaces that you can see.
+ *
+ * @returns the array of the MonitoredReleaseKind.
+ */
+export const useGetAllReleases = () => {
+  const [releases, setData] = React.useState<MonitoredReleaseKind[]>([]);
+  const [loading, setloading] = React.useState(true);
+  const [error, setError] = React.useState<Error | null>(null);
+  const { namespaces, namespacesLoaded: loaded } = useNamespaceInfo();
+
+  const fetchAll = React.useCallback(async () => {
+    try {
+      const results: MonitoredReleaseKind[] = [];
+      const namespacePromises = namespaces.map(async (namespace) => {
+        const nsReleases = await K8sQueryListResourceItems<MonitoredReleaseKind[]>({
+          model: ReleaseModel,
+          queryOptions: { ns: namespace.metadata.name },
+        });
+        nsReleases.forEach((re) => {
+          const componentName = re.metadata?.labels?.[PipelineRunLabel.COMPONENT] ?? '';
+          if (componentName) {
+            results.push(re);
+          }
+        });
+      });
+      await Promise.all(namespacePromises);
+      setData(results);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setloading(false);
+    }
+  }, [namespaces]);
+
+  React.useEffect(() => {
+    if (!loaded) return;
+    void fetchAll();
+  }, [loaded, fetchAll]);
+
+  return { releases, loading, error };
+};

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -13,6 +13,7 @@ import integrationTestRoutes from './page-routes/integration-test';
 import workspaceRoutes from './page-routes/namespace';
 import pipelineRoutes from './page-routes/pipeline';
 import releaseRoutes from './page-routes/release';
+import releaseMonitorRoutes from './page-routes/release-monitor';
 import releaseServiceRoutes from './page-routes/release-service';
 import secretRoutes from './page-routes/secrets';
 import snapshotRoutes from './page-routes/snapshots';
@@ -41,6 +42,7 @@ export const router = createBrowserRouter([
         element: <Overview />,
       },
       ...workspaceRoutes,
+      ...releaseMonitorRoutes,
       ...applicationRoutes,
       ...componentRoutes,
       ...releaseRoutes,

--- a/src/routes/page-routes/release-monitor.tsx
+++ b/src/routes/page-routes/release-monitor.tsx
@@ -1,0 +1,15 @@
+import { RELEASE_MONITOR_PATH } from '../paths';
+import { RouteErrorBoundry } from '../RouteErrorBoundary';
+
+const releaseMonitorRoutes = [
+  {
+    path: RELEASE_MONITOR_PATH.path,
+    errorElement: <RouteErrorBoundry />,
+    async lazy() {
+      const { ReleaseMonitor } = await import('../../components/ReleaseMonitor');
+      return { element: <ReleaseMonitor /> };
+    },
+  },
+];
+
+export default releaseMonitorRoutes;

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -1,9 +1,13 @@
 import { buildRoute, type RouteDefinition, RouterParams } from './utils';
 
 type NamespacePath = 'ns';
+type ReleaseMonitorPath = 'releasemonitor';
 
 /* Namespace/Workspace Paths */
 export const NAMESPACE_LIST_PATH: RouteDefinition<NamespacePath> = buildRoute('ns');
+
+export const RELEASE_MONITOR_PATH: RouteDefinition<ReleaseMonitorPath> =
+  buildRoute('releasemonitor');
 
 export const WORKSPACE_PATH = NAMESPACE_LIST_PATH.extend(`:${RouterParams.workspaceName}`);
 

--- a/src/types/release.ts
+++ b/src/types/release.ts
@@ -97,3 +97,11 @@ export type ReleaseKind = K8sResourceCommon & {
     }[];
   };
 };
+
+// Keep the release kind separated for adding more RAP related spec
+// prodcut, product_version etc.
+export type MonitoredReleaseKind = ReleaseKind & {
+  product: string;
+  product_version: string;
+  rpa: string;
+};


### PR DESCRIPTION

## Fixes 
https://issues.redhat.com/browse/RHELWF-11638
https://issues.redhat.com/browse/KONFLUX-3835


## Description

* Add a new page next to Namespaces which is called Release Monitor
* Check all the valid Release records under Namespaces you can see
* Add filter status, application, releaseplan and tenant

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

![Screenshot 2025-06-26 at 14 50 44](https://github.com/user-attachments/assets/2c7ac330-b928-4820-87ad-ef971edea21d)
![Screenshot 2025-06-26 at 14 51 11](https://github.com/user-attachments/assets/6b35a678-7491-4f7d-9735-cadf9f96c603)
![Screenshot 2025-06-26 at 14 51 24](https://github.com/user-attachments/assets/6acb7001-3ce0-40a7-bf6c-26d27facac25)
![Screenshot 2025-06-26 at 14 51 42](https://github.com/user-attachments/assets/22c03cd0-de38-4084-b3c4-966e28f86090)
![Screenshot 2025-06-26 at 14 51 50](https://github.com/user-attachments/assets/8683556b-14a8-47d8-8b84-459531e8b782)
![Screenshot 2025-06-26 at 14 52 08](https://github.com/user-attachments/assets/ef5b2c1e-8319-4e63-8b14-5c9655590ceb)


## How to test or reproduce?

yarn test --coverage src/components/ReleaseMonitor/__tests__/ReleaseMonitor.spec.tsx


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a Release Monitor dashboard for tracking and filtering releases across namespaces.
  * Added a sidebar navigation link and an introductory banner button for the Release Monitor (visible when the feature flag is enabled).
  * Implemented filtering capabilities by application, tenant, status, and release plan, with interactive dropdowns and search.
  * Added a sortable, filterable release table with detailed rows and empty state messaging.

* **Bug Fixes**
  * Improved logic to hide the namespace switcher on the Release Monitor route.

* **Tests**
  * Added comprehensive tests for Release Monitor rendering and filtering behaviors.

* **Chores**
  * Added mock data and a new feature flag for controlled rollout of the Release Monitor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->