### PR TITLE
KONFLUX-6019: update releasePlan.references to be a string array instead of single string

### DIFF
--- a/src/components/ReleaseService/ReleasePlan/TriggerRelease/TriggerReleaseForm.tsx
+++ b/src/components/ReleaseService/ReleasePlan/TriggerRelease/TriggerReleaseForm.tsx
@@ -1,7 +1,17 @@
 import * as React from 'react';
-import { Form, PageSection, PageSectionVariants } from '@patternfly/react-core';
+import {
+  Button,
+  Form,
+  Grid,
+  GridItem,
+  PageSection,
+  PageSectionVariants,
+  TextInput,
+  TextInputTypes,
+} from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 import { FormikProps, useField } from 'formik';
-import { TextAreaField } from 'formik-pf';
+import { InputField, TextAreaField } from 'formik-pf';
 import isEmpty from 'lodash-es/isEmpty';
 import { FilterContextProvider } from '~/components/Filter/generic/FilterContext';
 import { useReleasePlans } from '../../../../../src/hooks/useReleasePlans';
@@ -9,6 +19,7 @@ import PageLayout from '../../../../components/PageLayout/PageLayout';
 import { RELEASE_SERVICE_PATH } from '../../../../routes/paths';
 import { FormFooter } from '../../../../shared';
 import KeyValueField from '../../../../shared/components/formik-fields/key-value-input-field/KeyValueInputField';
+import TextColumnField from '../../../../shared/components/formik-fields/text-column-field/TextColumnField';
 import { useNamespace } from '../../../../shared/providers/Namespace';
 import { IssueType } from './AddIssueSection/AddIssueModal';
 import { AddIssueSection } from './AddIssueSection/AddIssueSection';
@@ -39,6 +50,9 @@ export const TriggerReleaseForm: React.FC<Props> = ({
   const [{ value: labels }] = useField<TriggerReleaseFormValues['labels']>('labels');
   const [releasePlans, loaded] = useReleasePlans(namespace);
   const [selectedReleasePlanField] = useField('releasePlan');
+  const [reference, setReference] = React.useState<string>('');
+  const [references, , { setValue }] =
+    useField<TriggerReleaseFormValues['references']>('references');
 
   const applicationName = getApplicationNameForReleasePlan(
     releasePlans,
@@ -107,11 +121,43 @@ export const TriggerReleaseForm: React.FC<Props> = ({
 
           <TextAreaField name="description" label="Description" />
           <TextAreaField name="solution" label="Solution" />
-          <TextAreaField
+          <TextColumnField
             name="references"
             label="References"
-            helperText="Please enter at least 1 reference"
+            noFooter
+            isReadOnly
+            onChange={(v) => setValue(references.value.filter?.((r) => v.includes(r)))}
+          >
+            {(props) => {
+              return (
+                <Grid>
+                  <GridItem span={6}>
+                    <InputField name={props.name} type={TextInputTypes.text} isDisabled />
+                  </GridItem>
+                  <GridItem span={6}>{props.removeButton}</GridItem>
+                </Grid>
+              );
+            }}
+          </TextColumnField>
+          <TextInput
+            name="reference"
+            type={TextInputTypes.text}
+            onChange={(_, val) => setReference(val)}
+            value={reference}
           />
+          <Button
+            data-test="add-reference-button"
+            variant="link"
+            onClick={() => {
+              void setValue([...references.value, reference]);
+              setReference('');
+            }}
+            icon={<PlusCircleIcon />}
+            isInline
+            isDisabled={!reference}
+          >
+            {'Add reference'}
+          </Button>
           <KeyValueField
             name="labels"
             label="Labels"

--- a/src/components/ReleaseService/ReleasePlan/TriggerRelease/TriggerReleaseFormPage.tsx
+++ b/src/components/ReleaseService/ReleasePlan/TriggerRelease/TriggerReleaseFormPage.tsx
@@ -68,7 +68,7 @@ export const TriggerReleaseFormPage: React.FC = () => {
     synopsis: '',
     description: '',
     topic: '',
-    references: '',
+    references: [],
     labels: [{ key: '', value: '' }],
   };
 

--- a/src/components/ReleaseService/ReleasePlan/TriggerRelease/__tests__/TriggerReleaseForm.spec.tsx
+++ b/src/components/ReleaseService/ReleasePlan/TriggerRelease/__tests__/TriggerReleaseForm.spec.tsx
@@ -62,7 +62,9 @@ describe('TriggerReleaseForm', () => {
     expect(result.getByRole('textbox', { name: 'Synopsis' })).toBeVisible();
     expect(result.getByRole('textbox', { name: 'Description' })).toBeVisible();
     expect(result.getByRole('textbox', { name: 'Topic' })).toBeVisible();
-    expect(result.getByRole('textbox', { name: 'References' })).toBeVisible();
+
+    screen.getByText('References');
+    screen.getByTestId('add-reference-button');
   });
 
   it('should show release & snapshot dropdown in loading state', () => {

--- a/src/components/ReleaseService/ReleasePlan/TriggerRelease/__tests__/TriggerReleaseFormPage.spec.tsx
+++ b/src/components/ReleaseService/ReleasePlan/TriggerRelease/__tests__/TriggerReleaseFormPage.spec.tsx
@@ -57,7 +57,7 @@ describe('TriggerReleaseFormPage', () => {
       expect.objectContaining({
         description: '',
         labels: [{ key: '', value: '' }],
-        references: '',
+        references: [],
         releasePlan: 'rp1',
         snapshot: '',
         synopsis: '',

--- a/src/components/ReleaseService/ReleasePlan/TriggerRelease/__tests__/form-utils.spec.ts
+++ b/src/components/ReleaseService/ReleasePlan/TriggerRelease/__tests__/form-utils.spec.ts
@@ -36,7 +36,7 @@ describe('triggerReleasePlan', () => {
         releasePlan: 'test-releasePlan',
         description: 'short description',
         topic: 'topic of release',
-        references: 'references',
+        references: ['reference1', 'reference2'],
         labels: [],
       },
       'test-ns',
@@ -46,6 +46,7 @@ describe('triggerReleasePlan', () => {
         synopsis: 'synopsis',
         topic: 'topic of release',
         description: 'short description',
+        references: ['reference1', 'reference2'],
       }),
     );
   });
@@ -58,7 +59,7 @@ describe('triggerReleasePlan', () => {
         releasePlan: 'test-releasePlan',
         description: 'short description',
         topic: 'topic of release',
-        references: 'references',
+        references: ['reference1', 'reference2'],
         issues: [
           { id: 'RHTAP-5560', summary: 'summary1', source: 'test-url' },
           { id: 'RHTAP-5561', summary: 'summary2', source: 'test-url2' },
@@ -87,7 +88,7 @@ describe('triggerReleasePlan', () => {
         releasePlan: 'test-releasePlan',
         description: 'short description',
         topic: 'topic of release',
-        references: 'references',
+        references: ['reference1', 'reference2'],
         cves: [
           {
             issueKey: 'cve1',

--- a/src/components/ReleaseService/ReleasePlan/TriggerRelease/form-utils.ts
+++ b/src/components/ReleaseService/ReleasePlan/TriggerRelease/form-utils.ts
@@ -22,7 +22,7 @@ export type TriggerReleaseFormValues = {
   topic: string;
   description?: string;
   solution?: string;
-  references?: string;
+  references?: string[];
   issues?: object[];
   cves?: CVE[];
   labels?: { key: string; value: string }[];

--- a/src/types/coreBuildService.ts
+++ b/src/types/coreBuildService.ts
@@ -103,7 +103,7 @@ export type ReleaseSpec = {
       fixed: { id: string; source: string }[];
       cves: CVE[];
       solution?: string;
-      references?: string;
+      references?: string[];
     };
   };
 };


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

Fixes https://issues.redhat.com/browse/KONFLUX-6019

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The `releasePlan.references` is supposed to be a string array instead of a single string. This PR is making the necessary changes to fix it.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before the fix: `references` was being set as a single string and it was making the `check-data-keys` TaskRun to fail:

![release-trigger-references-string](https://github.com/user-attachments/assets/600b73a0-a161-4105-8c17-c28debbeb386)

![check-data-keys-fail](https://github.com/user-attachments/assets/6daf1cd6-3ae4-45e9-85b7-1885c4eef261)

After the fix: `references` is being considered as a string array. Now, `check-data-keys` TaskRun pass successfully:


https://github.com/user-attachments/assets/3b0ed14d-73ea-4cb6-9502-3ec507fb20cb

![check-data-keys-success](https://github.com/user-attachments/assets/8098f676-2fe5-4a18-8a9b-c90178b95c9c)


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

1. You can try to replicate the scenario by making a release that uses a PipelineRun that uses the `check-data-keys` TaskRun. If it's too much work to set it up, you can ask me and I'll invite you to my namespace to check it out :D
2. When triggering the release, add one (or several) references and notice that they will be send as an array
3. The `check-data-keys` TaskRun should pass successfully
4. ☕️

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->