### PR TITLE
fix(KFLUXUI-515): show correct error message when accessing namespace without access

### DIFF
--- a/src/components/PageAccess/NoAccessState.tsx
+++ b/src/components/PageAccess/NoAccessState.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import {
   Button,
   ButtonVariant,
@@ -13,7 +13,6 @@ import {
 } from '@patternfly/react-core';
 import { LockIcon } from '@patternfly/react-icons/dist/esm/icons/lock-icon';
 import { css } from '@patternfly/react-styles';
-import { useNamespace } from '~/shared/providers/Namespace';
 import { HttpError } from '../../k8s/error';
 
 import '../../shared/components/empty-state/EmptyState.scss';
@@ -25,6 +24,11 @@ type NoAccessStateProps = {
   children?: React.ReactNode;
 } & Omit<EmptyStateProps, 'children'>;
 
+const getAccessedNamespace = (pathname: string) => {
+  const pathnameParts = pathname.split('/');
+  return pathnameParts.length >= 3 && pathnameParts[1] === 'ns' ? pathnameParts[2] : undefined;
+};
+
 const NoAccessState: React.FC<React.PropsWithChildren<NoAccessStateProps>> = ({
   title,
   body,
@@ -33,7 +37,9 @@ const NoAccessState: React.FC<React.PropsWithChildren<NoAccessStateProps>> = ({
   ...props
 }) => {
   const navigate = useNavigate();
-  const namespace = useNamespace();
+  const { pathname } = useLocation();
+  const accessedNamespace = getAccessedNamespace(pathname);
+
   return (
     <EmptyState
       className={css('app-empty-state', className)}
@@ -48,7 +54,9 @@ const NoAccessState: React.FC<React.PropsWithChildren<NoAccessStateProps>> = ({
       />
       <EmptyStateBody>
         {body ||
-          `Ask the administrator or the owner of the ${namespace} namespace for access permissions.`}
+          (accessedNamespace
+            ? `Ask the administrator or the owner of the '${accessedNamespace}' namespace for access permissions.`
+            : "You don't have access to this page.")}
       </EmptyStateBody>
       <EmptyStateFooter>
         {children || (

--- a/src/components/PageAccess/__tests__/NoAccessState.spec.tsx
+++ b/src/components/PageAccess/__tests__/NoAccessState.spec.tsx
@@ -10,6 +10,7 @@ jest.mock('react-router-dom', () => {
   return {
     ...actual,
     useNavigate: jest.fn(),
+    useLocation: () => ({ pathname: '/ns/test-ns' }),
   };
 });
 
@@ -33,7 +34,7 @@ describe('NoAccessState', () => {
     screen.getByTestId('no-access-state');
     screen.getByText(`Let's get you access`);
     screen.getByText(
-      `Ask the administrator or the owner of the test-ns namespace for access permissions.`,
+      `Ask the administrator or the owner of the 'test-ns' namespace for access permissions.`,
     );
     screen.getByText('Go to Overview page');
   });

--- a/src/components/PageAccess/__tests__/PageAccessCheck.spec.tsx
+++ b/src/components/PageAccess/__tests__/PageAccessCheck.spec.tsx
@@ -9,6 +9,7 @@ jest.mock('react-router-dom', () => {
   return {
     ...actual,
     useNavigate: jest.fn(),
+    useLocation: () => ({ pathname: '/ns/test-ns' }),
   };
 });
 


### PR DESCRIPTION
## Fixes 
[KFLUXUI-515](https://issues.redhat.com/browse/KFLUXUI-515)


## Description
The `NoAccessState` page would display user's own namespace when they tried to access a different namespace, where they don't have access.

The error message now correctly show the name of the namespace which the user is trying to access.


## Type of change
<!-- Please delete options that are not relevant. -->

- [X] Bugfix

## How to test or reproduce?
Try to access any namespace, which you do not have access to.

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [X] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->