### PR TITLE
fix(KFLUXUI-520): make subjects in role binding optional

### DIFF
--- a/e2e-tests/tests/basic-happy-path.spec.ts
+++ b/e2e-tests/tests/basic-happy-path.spec.ts
@@ -69,7 +69,11 @@ describe('Basic Happy Path', () => {
   it('Create an Application with a component', () => {
     Applications.createApplication(applicationName);
     Applications.createComponent(publicRepo, componentName, pipeline);
-    Applications.checkComponentInListView(componentName, applicationName, 'Build not started');
+    Applications.checkComponentInListView(
+      componentName,
+      applicationName,
+      /Build not started|Build running/,
+    );
   });
 
   it('Check default Integration Test', () => {

--- a/e2e-tests/utils/Applications.ts
+++ b/e2e-tests/utils/Applications.ts
@@ -96,7 +96,7 @@ export class Applications {
   static checkComponentInListView(
     componentName: string,
     applicationName: string,
-    componentStatus: string,
+    componentStatus: string | RegExp,
   ) {
     this.createdComponentExists(componentName, applicationName);
     this.checkComponentStatus(componentName, componentStatus);
@@ -110,7 +110,7 @@ export class Applications {
     ComponentsTabPage.getComponentListItem(componentName).should('exist');
   }
 
-  static checkComponentStatus(componentName: string, componentStatus: string) {
+  static checkComponentStatus(componentName: string, componentStatus: string | RegExp) {
     cy.get(componentsTabPO.componentListItem(componentName)).contains(componentStatus, {
       timeout: 80000,
     });

--- a/src/components/UserAccess/RBListRow.tsx
+++ b/src/components/UserAccess/RBListRow.tsx
@@ -15,7 +15,9 @@ export const RBListRow: React.FC<React.PropsWithChildren<RowFunctionArgs<RoleBin
 
   return (
     <>
-      <TableData className={rbTableColumnClasses.username}>{obj.subjects[0]?.name}</TableData>
+      <TableData className={rbTableColumnClasses.username}>
+        {obj.subjects ? obj.subjects[0]?.name : '-'}
+      </TableData>
       <TableData className={rbTableColumnClasses.role}>
         {!loaded ? <Skeleton width="200px" height="20px" /> : roleMap?.roleMap[obj.roleRef.name]}
       </TableData>

--- a/src/components/UserAccess/UserAccessForm/UserAccessForm.tsx
+++ b/src/components/UserAccess/UserAccessForm/UserAccessForm.tsx
@@ -11,10 +11,12 @@ import { UsernameSection } from './UsernameSection';
 
 type Props = FormikProps<UserAccessFormValues> & {
   edit?: boolean;
+  missingSubjects?: boolean;
 };
 
 export const UserAccessForm: React.FC<React.PropsWithChildren<Props>> = ({
   edit,
+  missingSubjects = false,
   isSubmitting,
   dirty,
   errors, // The errors is caculated by formik automatically.
@@ -57,7 +59,7 @@ export const UserAccessForm: React.FC<React.PropsWithChildren<Props>> = ({
     >
       <PageSection isFilled variant={PageSectionVariants.light}>
         <Form onSubmit={handleSubmit}>
-          <UsernameSection disabled={edit} />
+          <UsernameSection disabled={!missingSubjects && edit} />
           <RoleSection />
         </Form>
       </PageSection>

--- a/src/components/UserAccess/UserAccessForm/UserAccessFormPage.tsx
+++ b/src/components/UserAccess/UserAccessForm/UserAccessFormPage.tsx
@@ -81,7 +81,7 @@ export const UserAccessFormPage: React.FC<React.PropsWithChildren<Props>> = ({
   }
 
   const initialValues: UserAccessFormValues = {
-    usernames: existingRb ? existingRb.subjects.map((sub) => sub.name) : [],
+    usernames: existingRb && existingRb.subjects ? existingRb.subjects.map((sub) => sub.name) : [],
     role: roleMap?.roleMap[existingRb?.roleRef.name] as NamespaceRole,
     roleMap,
   };
@@ -93,7 +93,13 @@ export const UserAccessFormPage: React.FC<React.PropsWithChildren<Props>> = ({
       initialValues={initialValues}
       validationSchema={userAccessFormSchema}
     >
-      {(props) => <UserAccessForm {...props} edit={edit} />}
+      {(props) => (
+        <UserAccessForm
+          {...props}
+          edit={edit}
+          missingSubjects={initialValues.usernames.length === 0}
+        />
+      )}
     </Formik>
   );
 };

--- a/src/components/UserAccess/UserAccessForm/__tests__/UserAccessFormPage.spec.tsx
+++ b/src/components/UserAccess/UserAccessForm/__tests__/UserAccessFormPage.spec.tsx
@@ -95,4 +95,13 @@ describe('UserAccessFormPage', () => {
       mockRoleBinding,
     );
   });
+
+  it('should handle undefined subjects in role bindings', () => {
+    namespaceRenderer(
+      <UserAccessFormPage existingRb={{ ...mockRoleBinding, subjects: undefined }} edit />,
+      'test-ns',
+    );
+    expect(screen.getByText('Edit access to namespace, test-ns')).toBeVisible();
+    expect(screen.getByRole('searchbox')).not.toBeDisabled();
+  });
 });

--- a/src/components/UserAccess/UserAccessForm/form-utils.ts
+++ b/src/components/UserAccess/UserAccessForm/form-utils.ts
@@ -114,8 +114,7 @@ export const editRB = async (
   roleBinding: RoleBinding,
   dryRun?: boolean,
 ): Promise<RoleBinding[]> => {
-  const usernames = roleBinding.subjects.map((subject) => subject.name);
-  const { role, roleMap } = values;
+  const { usernames, role, roleMap } = values;
 
   if (!dryRun) {
     await deleteRB(roleBinding, dryRun);

--- a/src/components/UserAccess/UserAccessListView.tsx
+++ b/src/components/UserAccess/UserAccessListView.tsx
@@ -71,10 +71,12 @@ export const UserAccessListView: React.FC<React.PropsWithChildren<unknown>> = ()
 
   const filterRBs = React.useMemo(
     () =>
-      roleBindings.filter((rb) =>
-        rb.subjects.some((subject) =>
-          subject.name.toLowerCase().includes(usernameFilter.toLowerCase()),
-        ),
+      roleBindings.filter(
+        (rb) =>
+          !rb.subjects ||
+          rb.subjects?.some((subject) =>
+            subject.name.toLowerCase().includes(usernameFilter.toLowerCase()),
+          ),
       ),
     [roleBindings, usernameFilter],
   );

--- a/src/components/UserAccess/__tests__/UserAccessListView.spec.tsx
+++ b/src/components/UserAccess/__tests__/UserAccessListView.spec.tsx
@@ -127,4 +127,12 @@ describe('UserAccessListView', () => {
     const grantAccessButton = screen.getByText('Grant access');
     expect(grantAccessButton.getAttribute('aria-disabled')).toEqual('true');
   });
+
+  it('should handle undefined subjects in role bindings', () => {
+    useRoleBindingsMock.mockReturnValue([[{ ...mockRoleBinding, subjects: undefined }], true]);
+    const r = render(UserAccessList);
+    const rows = r.getAllByRole('row');
+    expect(rows.length).toBe(2);
+    expect(rows[1]).toHaveTextContent('-');
+  });
 });

--- a/src/types/role-binding.ts
+++ b/src/types/role-binding.ts
@@ -6,7 +6,7 @@ export type RoleBinding = K8sResourceCommon & {
     kind: string;
     name: string;
   };
-  subjects: {
+  subjects?: {
     apiGroup: string;
     kind: string;
     name: string;


### PR DESCRIPTION
## Fixes 
[KFLUXUI-520](https://issues.redhat.com/browse/KFLUXUI-520)


## Description
As per [slack thread](https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1746196905597379), a role binding without the `subjects` field is valid and should be supported. This PR makes the `subjects` field optional and handles cases when it is missing.


## Type of change
<!-- Please delete options that are not relevant. -->

- [X] Bugfix


<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [X] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->