### PR TITLE
KFLUXUI-521: [CommitsListView] show component-specific commits when applicable

### DIFF
--- a/src/components/Commits/CommitsListPage/CommitsListView.tsx
+++ b/src/components/Commits/CommitsListPage/CommitsListView.tsx
@@ -23,6 +23,7 @@ interface CommitsListViewProps {
 
 const CommitsListView: React.FC<React.PropsWithChildren<CommitsListViewProps>> = ({
   applicationName,
+  componentName,
 }) => {
   const namespace = useNamespace();
   const { filters: unparsedFilters, setFilters, onClearFilters } = React.useContext(FilterContext);
@@ -34,7 +35,13 @@ const CommitsListView: React.FC<React.PropsWithChildren<CommitsListViewProps>> =
   const { name: nameFilter, status: statusFilter } = filters;
 
   const [pipelineRuns, loaded, error, getNextPage, { isFetchingNextPage, hasNextPage }] =
-    useBuildPipelines(namespace, applicationName, undefined);
+    useBuildPipelines(
+      namespace,
+      applicationName,
+      undefined,
+      !!componentName,
+      componentName ? [componentName] : undefined,
+    );
 
   const commits = React.useMemo(
     () => (loaded && pipelineRuns && getCommitsFromPLRs(pipelineRuns)) || [],

--- a/src/components/Commits/CommitsListPage/__tests__/CommitsListView.spec.tsx
+++ b/src/components/Commits/CommitsListPage/__tests__/CommitsListView.spec.tsx
@@ -249,4 +249,20 @@ describe('CommitsListView', () => {
     render(<CommitsList />);
     expect(screen.getByTestId('data-table-skeleton')).toBeVisible();
   });
+
+  it('should call useBuildPipelines with componentName when provided', () => {
+    render(
+      <FilterContextProvider filterParams={['name', 'status']}>
+        <CommitsListView applicationName="purple-mermaid-app" componentName="sample-component" />
+      </FilterContextProvider>,
+    );
+
+    expect(useBuildPipelinesMock).toHaveBeenCalledWith(
+      'test-ns', // namespace
+      'purple-mermaid-app', // applicationName
+      undefined, // commit
+      true, // includeComponents
+      ['sample-component'], // componentNames
+    );
+  });
 });

--- a/src/hooks/__tests__/useBuildPipelines.spec.ts
+++ b/src/hooks/__tests__/useBuildPipelines.spec.ts
@@ -51,4 +51,55 @@ describe('useBuildPipelines', () => {
     expect(loaded).toBe(true);
     expect(pipelineRuns.map((tr) => tr.metadata?.name)).toEqual(['test-caseqfvdj']);
   });
+
+  it('should filter build pipelines by component name when includeComponents is true', () => {
+    useK8sWatchResourceMock.mockReturnValue([[], true, undefined]);
+
+    useTRPipelineRunsMock.mockReturnValue([
+      [
+        {
+          kind: 'PipelineRun',
+          metadata: {
+            name: 'pipeline-a',
+            labels: {
+              'appstudio.openshift.io/component': 'component-a',
+              'appstudio.openshift.io/application': 'test',
+              'pipelinesascode.tekton.dev/event-type': 'push',
+            },
+          },
+        },
+        {
+          kind: 'PipelineRun',
+          metadata: {
+            name: 'pipeline-b',
+            labels: {
+              'appstudio.openshift.io/component': 'component-b',
+              'appstudio.openshift.io/application': 'test',
+              'pipelinesascode.tekton.dev/event-type': 'push',
+            },
+          },
+        },
+      ],
+      true,
+      undefined,
+      undefined,
+      { isFetchingNextPage: false, hasNextPage: false },
+    ]);
+
+    const { result } = renderHook(() =>
+      useBuildPipelines(
+        'test-ns',
+        'test',
+        undefined,
+        true,
+        ['component-b'], // should only match pipeline-b
+      ),
+    );
+
+    const [pipelineRuns, loaded] = result.current;
+
+    expect(loaded).toBe(true);
+    expect(pipelineRuns).toHaveLength(1);
+    expect(pipelineRuns[0].metadata?.name).toBe('pipeline-b');
+  });
 });


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

Fixes https://issues.redhat.com/browse/KFLUXUI-521

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR updates the `CommitsListView` component to forward the `componentName` prop to the `useBuildPipelines` hook. When provided, this ensures only the PipelineRuns related to the specified component are shown.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

1. **Before the fix:** the Commits tab shows commits unrelated to the `ea2e53` component.

https://github.com/user-attachments/assets/445fd628-2888-4eb9-a6d2-22e9c4acf3a8

2. **After the fix:** only commits associated with the `ea2e53` component are shown.

![commits-component-specific-FIX](https://github.com/user-attachments/assets/723304c1-596e-4721-8647-4dde38ed98cc)

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

1. use an application that has multiple components; this increases the chance of having commits unrelated to a specific component.
2. navigate to the "Component Details → Activity" tab, then select the "Commits" sub-tab.
3. confirm that only commits related to the selected component are displayed.
4. :coffee:

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->