### PR TITLE
fix(KONFLUX-8558): don't redirect public instance users to internal docs

### DIFF
--- a/src/components/NamespaceList/NamespaceListView.tsx
+++ b/src/components/NamespaceList/NamespaceListView.tsx
@@ -11,7 +11,10 @@ import {
 import { QuestionCircleIcon } from '@patternfly/react-icons/dist/js/icons/question-circle-icon';
 import { GETTING_ACCESS_INTERNAL } from '~/consts/documentation';
 import { useInstanceVisibility } from '~/hooks/useUIInstance';
-import { KonfluxPublicInfoVisibility } from '~/types/konflux-public-info';
+import {
+  KonfluxInstanceVisibility,
+  KonfluxInstanceVisibilityType,
+} from '~/types/konflux-public-info';
 import emptyStateImgUrl from '../../assets/namespace.svg';
 import { ExternalLink, Table, useDeepCompareMemoize } from '../../shared';
 import AppEmptyState from '../../shared/components/empty-state/AppEmptyState';
@@ -25,12 +28,12 @@ import { NamespaceListHeader } from './NamespaceListHeader';
 import NamespaceListRow from './NamespaceListRow';
 
 type NamespaceCreateButtonProps = {
-  instanceVisibility: KonfluxPublicInfoVisibility;
+  instanceVisibility: KonfluxInstanceVisibilityType;
 };
 
 const NamespaceCreateButton: React.FC<NamespaceCreateButtonProps> = React.memo(
   ({ instanceVisibility }) => {
-    if (instanceVisibility === 'private') {
+    if (instanceVisibility === KonfluxInstanceVisibility.PRIVATE) {
       return (
         <ExternalLink variant="primary" href={GETTING_ACCESS_INTERNAL}>
           Go to create namespace instructions

--- a/src/components/NamespaceList/NamespaceListView.tsx
+++ b/src/components/NamespaceList/NamespaceListView.tsx
@@ -8,6 +8,7 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { QuestionCircleIcon } from '@patternfly/react-icons/dist/js/icons/question-circle-icon';
+import { GETTING_ACCESS_INTERNAL } from '~/consts/documentation';
 import { useInstanceVisibility } from '~/hooks/useUIInstance';
 import emptyStateImgUrl from '../../assets/namespace.svg';
 import { ExternalLink, Table, useDeepCompareMemoize } from '../../shared';
@@ -23,10 +24,7 @@ import NamespaceListRow from './NamespaceListRow';
 
 const NamespaceCreateButton = () =>
   useInstanceVisibility() === 'private' ? (
-    <ExternalLink
-      variant="primary"
-      href={'https://konflux.pages.redhat.com/docs/users/getting-started/getting-access-new.html'}
-    >
+    <ExternalLink variant="primary" href={GETTING_ACCESS_INTERNAL}>
       Go to create namespace instructions
     </ExternalLink>
   ) : (

--- a/src/components/NamespaceList/NamespaceListView.tsx
+++ b/src/components/NamespaceList/NamespaceListView.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {
   Bullseye,
   EmptyStateBody,
+  Flex,
   PageSection,
   PageSectionVariants,
   Spinner,
@@ -10,6 +11,7 @@ import {
 import { QuestionCircleIcon } from '@patternfly/react-icons/dist/js/icons/question-circle-icon';
 import { GETTING_ACCESS_INTERNAL } from '~/consts/documentation';
 import { useInstanceVisibility } from '~/hooks/useUIInstance';
+import { KonfluxPublicInfoVisibility } from '~/types/konflux-public-info';
 import emptyStateImgUrl from '../../assets/namespace.svg';
 import { ExternalLink, Table, useDeepCompareMemoize } from '../../shared';
 import AppEmptyState from '../../shared/components/empty-state/AppEmptyState';
@@ -22,21 +24,33 @@ import PageLayout from '../PageLayout/PageLayout';
 import { NamespaceListHeader } from './NamespaceListHeader';
 import NamespaceListRow from './NamespaceListRow';
 
-const NamespaceCreateButton = () =>
-  useInstanceVisibility() === 'private' ? (
-    <ExternalLink variant="primary" href={GETTING_ACCESS_INTERNAL}>
-      Go to create namespace instructions
-    </ExternalLink>
-  ) : (
-    <Tooltip content={<>Contact your platform engineer to create a new namespace.</>}>
-      <div className="pf-v5-u-mt-xs" data-testid="namespace-create-tooltip">
-        <QuestionCircleIcon />
-      </div>
-    </Tooltip>
-  );
+type NamespaceCreateButtonProps = {
+  instanceVisibility: KonfluxPublicInfoVisibility;
+};
+
+const NamespaceCreateButton: React.FC<NamespaceCreateButtonProps> = React.memo(
+  ({ instanceVisibility }) => {
+    if (instanceVisibility === 'private') {
+      return (
+        <ExternalLink variant="primary" href={GETTING_ACCESS_INTERNAL}>
+          Go to create namespace instructions
+        </ExternalLink>
+      );
+    }
+
+    return (
+      <Tooltip content={<>Contact your platform engineer to create a new namespace.</>}>
+        <Flex className="pf-v5-u-mt-sm" data-testid="namespace-create-tooltip">
+          <QuestionCircleIcon />
+        </Flex>
+      </Tooltip>
+    );
+  },
+);
 
 const NamespaceListView: React.FC<React.PropsWithChildren<unknown>> = () => {
   const { namespaces, namespacesLoaded: loaded } = useNamespaceInfo();
+  const instanceVisibility = useInstanceVisibility();
 
   const { filters: unparsedFilters, setFilters, onClearFilters } = React.useContext(FilterContext);
   const filters = useDeepCompareMemoize({
@@ -78,7 +92,7 @@ const NamespaceListView: React.FC<React.PropsWithChildren<unknown>> = () => {
                 <br />
                 To create a namespace using GitOps, follow the instruction.
               </EmptyStateBody>
-              <NamespaceCreateButton />
+              <NamespaceCreateButton instanceVisibility={instanceVisibility} />
             </AppEmptyState>
           ) : (
             <>
@@ -89,7 +103,7 @@ const NamespaceListView: React.FC<React.PropsWithChildren<unknown>> = () => {
                 onClearFilters={onClearFilters}
                 dataTest="namespace-list-toolbar"
               >
-                <NamespaceCreateButton />
+                <NamespaceCreateButton instanceVisibility={instanceVisibility} />
               </BaseTextFilterToolbar>
               {filteredNamespaces.length !== 0 ? (
                 <Table

--- a/src/components/NamespaceList/NamespaceListView.tsx
+++ b/src/components/NamespaceList/NamespaceListView.tsx
@@ -5,7 +5,10 @@ import {
   PageSection,
   PageSectionVariants,
   Spinner,
+  Tooltip,
 } from '@patternfly/react-core';
+import { QuestionCircleIcon } from '@patternfly/react-icons/dist/js/icons/question-circle-icon';
+import { useInstanceVisibility } from '~/hooks/useUIInstance';
 import emptyStateImgUrl from '../../assets/namespace.svg';
 import { ExternalLink, Table, useDeepCompareMemoize } from '../../shared';
 import AppEmptyState from '../../shared/components/empty-state/AppEmptyState';
@@ -18,14 +21,21 @@ import PageLayout from '../PageLayout/PageLayout';
 import { NamespaceListHeader } from './NamespaceListHeader';
 import NamespaceListRow from './NamespaceListRow';
 
-const NamespaceCreateButton = () => (
-  <ExternalLink
-    variant="primary"
-    href="https://konflux.pages.redhat.com/docs/users/getting-started/getting-access-new.html"
-  >
-    Go to create namespace instructions
-  </ExternalLink>
-);
+const NamespaceCreateButton = () =>
+  useInstanceVisibility() === 'private' ? (
+    <ExternalLink
+      variant="primary"
+      href={'https://konflux.pages.redhat.com/docs/users/getting-started/getting-access-new.html'}
+    >
+      Go to create namespace instructions
+    </ExternalLink>
+  ) : (
+    <Tooltip content={<>Contact your platform engineer to create a new namespace.</>}>
+      <div className="pf-v5-u-mt-xs" data-testid="namespace-create-tooltip">
+        <QuestionCircleIcon />
+      </div>
+    </Tooltip>
+  );
 
 const NamespaceListView: React.FC<React.PropsWithChildren<unknown>> = () => {
   const { namespaces, namespacesLoaded: loaded } = useNamespaceInfo();

--- a/src/components/NamespaceList/NamespaceListView.tsx
+++ b/src/components/NamespaceList/NamespaceListView.tsx
@@ -11,10 +11,7 @@ import {
 import { QuestionCircleIcon } from '@patternfly/react-icons/dist/js/icons/question-circle-icon';
 import { GETTING_ACCESS_INTERNAL } from '~/consts/documentation';
 import { useInstanceVisibility } from '~/hooks/useUIInstance';
-import {
-  KonfluxInstanceVisibility,
-  KonfluxInstanceVisibilityType,
-} from '~/types/konflux-public-info';
+import { KonfluxInstanceVisibility } from '~/types/konflux-public-info';
 import emptyStateImgUrl from '../../assets/namespace.svg';
 import { ExternalLink, Table, useDeepCompareMemoize } from '../../shared';
 import AppEmptyState from '../../shared/components/empty-state/AppEmptyState';
@@ -27,33 +24,28 @@ import PageLayout from '../PageLayout/PageLayout';
 import { NamespaceListHeader } from './NamespaceListHeader';
 import NamespaceListRow from './NamespaceListRow';
 
-type NamespaceCreateButtonProps = {
-  instanceVisibility: KonfluxInstanceVisibilityType;
-};
+const NamespaceCreateButton = React.memo(() => {
+  const instanceVisibility = useInstanceVisibility();
 
-const NamespaceCreateButton: React.FC<NamespaceCreateButtonProps> = React.memo(
-  ({ instanceVisibility }) => {
-    if (instanceVisibility === KonfluxInstanceVisibility.PRIVATE) {
-      return (
-        <ExternalLink variant="primary" href={GETTING_ACCESS_INTERNAL}>
-          Go to create namespace instructions
-        </ExternalLink>
-      );
-    }
-
+  if (instanceVisibility === KonfluxInstanceVisibility.PRIVATE) {
     return (
-      <Tooltip content={<>Contact your platform engineer to create a new namespace.</>}>
-        <Flex className="pf-v5-u-mt-sm" data-testid="namespace-create-tooltip">
-          <QuestionCircleIcon />
-        </Flex>
-      </Tooltip>
+      <ExternalLink variant="primary" href={GETTING_ACCESS_INTERNAL}>
+        Go to create namespace instructions
+      </ExternalLink>
     );
-  },
-);
+  }
+
+  return (
+    <Tooltip content={<>Contact your platform engineer to create a new namespace.</>}>
+      <Flex className="pf-v5-u-mt-sm" data-testid="namespace-create-tooltip">
+        <QuestionCircleIcon />
+      </Flex>
+    </Tooltip>
+  );
+});
 
 const NamespaceListView: React.FC<React.PropsWithChildren<unknown>> = () => {
   const { namespaces, namespacesLoaded: loaded } = useNamespaceInfo();
-  const instanceVisibility = useInstanceVisibility();
 
   const { filters: unparsedFilters, setFilters, onClearFilters } = React.useContext(FilterContext);
   const filters = useDeepCompareMemoize({
@@ -95,7 +87,7 @@ const NamespaceListView: React.FC<React.PropsWithChildren<unknown>> = () => {
                 <br />
                 To create a namespace using GitOps, follow the instruction.
               </EmptyStateBody>
-              <NamespaceCreateButton instanceVisibility={instanceVisibility} />
+              <NamespaceCreateButton />
             </AppEmptyState>
           ) : (
             <>
@@ -106,7 +98,7 @@ const NamespaceListView: React.FC<React.PropsWithChildren<unknown>> = () => {
                 onClearFilters={onClearFilters}
                 dataTest="namespace-list-toolbar"
               >
-                <NamespaceCreateButton instanceVisibility={instanceVisibility} />
+                <NamespaceCreateButton />
               </BaseTextFilterToolbar>
               {filteredNamespaces.length !== 0 ? (
                 <Table

--- a/src/components/NamespaceList/__tests__/NamespaceListView.spec.tsx
+++ b/src/components/NamespaceList/__tests__/NamespaceListView.spec.tsx
@@ -234,13 +234,7 @@ describe('NamespaceListView', () => {
     });
     mockUseInstanceVisibility.mockReturnValue('public');
 
-    render(
-      <MemoryRouter>
-        <FilterContextProvider filterParams={['name']}>
-          <NamespaceListView />
-        </FilterContextProvider>
-      </MemoryRouter>,
-    );
+    render(NamespaceList);
 
     expect(screen.queryByText('Go to create namespace instructions')).not.toBeInTheDocument();
   });

--- a/src/components/NamespaceList/__tests__/NamespaceListView.spec.tsx
+++ b/src/components/NamespaceList/__tests__/NamespaceListView.spec.tsx
@@ -5,6 +5,7 @@ import { screen, fireEvent, waitFor, render } from '@testing-library/react';
 import { FilterContextProvider } from '~/components/Filter/generic/FilterContext';
 import { useInstanceVisibility } from '~/hooks/useUIInstance';
 import { NamespaceKind } from '~/types';
+import { KonfluxInstanceVisibility } from '~/types/konflux-public-info';
 import { mockNamespaceHooks, mockUseNamespaceHook } from '~/unit-test-utils/mock-namespace';
 import {
   createReactRouterMock,
@@ -74,7 +75,7 @@ describe('NamespaceListView', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseInstanceVisibility.mockReturnValue('private');
+    mockUseInstanceVisibility.mockReturnValue(KonfluxInstanceVisibility.PRIVATE);
   });
 
   it('should render a spinner while loading namespaces', () => {
@@ -232,7 +233,7 @@ describe('NamespaceListView', () => {
       namespaces: mockNamespaces,
       namespacesLoaded: true,
     });
-    mockUseInstanceVisibility.mockReturnValue('public');
+    mockUseInstanceVisibility.mockReturnValue(KonfluxInstanceVisibility.PUBLIC);
 
     render(NamespaceList);
 

--- a/src/consts/documentation.ts
+++ b/src/consts/documentation.ts
@@ -5,3 +5,5 @@ export const LEARN_MORE_GITLAB_URL =
 export const LEARN_MORE_SNAPSHOTS = 'https://konflux-ci.dev/docs/testing/integration/snapshots/';
 export const CREATING_SOURCE_CONTROL_SECRETS =
   'https://konflux-ci.dev/docs/building/creating-secrets/#creating-source-control-secrets';
+export const GETTING_ACCESS_INTERNAL =
+  'https://konflux.pages.redhat.com/docs/users/getting-started/getting-access-new.html';

--- a/src/hooks/__tests__/useUIInstance.spec.ts
+++ b/src/hooks/__tests__/useUIInstance.spec.ts
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react';
+import { KonfluxInstanceVisibility } from '~/types/konflux-public-info';
 import { mockLocation } from '../../utils/test-utils';
 import { useKonfluxPublicInfo } from '../useKonfluxPublicInfo';
 import {
@@ -131,17 +132,21 @@ describe('useBombinoUrl', () => {
 
   describe('useInstanceVisibility', () => {
     it('should return the correct instance visibility', () => {
-      (useKonfluxPublicInfo as jest.Mock).mockReturnValue([{ visibility: 'public' }, true, null]);
+      (useKonfluxPublicInfo as jest.Mock).mockReturnValue([
+        { visibility: KonfluxInstanceVisibility.PUBLIC },
+        true,
+        null,
+      ]);
 
       const { result } = renderHook(() => useInstanceVisibility());
-      expect(result.current).toBe('public');
+      expect(result.current).toBe(KonfluxInstanceVisibility.PUBLIC);
     });
 
     it('should return "public" if the instance is not specified', () => {
       (useKonfluxPublicInfo as jest.Mock).mockReturnValue([{ visibility: undefined }, true, null]);
 
       const { result } = renderHook(() => useInstanceVisibility());
-      expect(result.current).toBe('public');
+      expect(result.current).toBe(KonfluxInstanceVisibility.PUBLIC);
     });
   });
 });

--- a/src/hooks/__tests__/useUIInstance.spec.ts
+++ b/src/hooks/__tests__/useUIInstance.spec.ts
@@ -136,5 +136,12 @@ describe('useBombinoUrl', () => {
       const { result } = renderHook(() => useInstanceVisibility());
       expect(result.current).toBe('public');
     });
+
+    it('should return "public" if the instance is not specified', () => {
+      (useKonfluxPublicInfo as jest.Mock).mockReturnValue([{ visibility: undefined }, true, null]);
+
+      const { result } = renderHook(() => useInstanceVisibility());
+      expect(result.current).toBe('public');
+    });
   });
 });

--- a/src/hooks/__tests__/useUIInstance.spec.ts
+++ b/src/hooks/__tests__/useUIInstance.spec.ts
@@ -7,6 +7,7 @@ import {
   useSbomUrl,
   useBombinoUrl,
   useUIInstance,
+  useInstanceVisibility,
 } from '../useUIInstance';
 
 jest.mock('../useKonfluxPublicInfo');
@@ -126,5 +127,14 @@ describe('useBombinoUrl', () => {
 
     const { result } = renderHook(() => useBombinoUrl());
     expect(result.current).toBe('https://custom-bombino-url.com');
+  });
+
+  describe('useInstanceVisibility', () => {
+    it('should return the correct instance visibility', () => {
+      (useKonfluxPublicInfo as jest.Mock).mockReturnValue([{ visibility: 'public' }, true, null]);
+
+      const { result } = renderHook(() => useInstanceVisibility());
+      expect(result.current).toBe('public');
+    });
   });
 });

--- a/src/hooks/useUIInstance.ts
+++ b/src/hooks/useUIInstance.ts
@@ -86,3 +86,11 @@ export const useNotifications = (): SBOMEventNotification[] => {
   }
   return [];
 };
+
+export const useInstanceVisibility = (): 'public' | 'private' => {
+  const [konfluxPublicInfo, loaded, error] = useKonfluxPublicInfo();
+  if (loaded && !error && konfluxPublicInfo) {
+    return konfluxPublicInfo.visibility;
+  }
+  return 'public';
+};

--- a/src/hooks/useUIInstance.ts
+++ b/src/hooks/useUIInstance.ts
@@ -1,5 +1,9 @@
 import { PLACEHOLDER, REPO_PUSH, SBOM_EVENT_TO_BOMBINO } from '../consts/constants';
-import { KonfluxPublicInfoVisibility, SBOMEventNotification } from '../types/konflux-public-info';
+import {
+  KonfluxInstanceVisibility,
+  KonfluxInstanceVisibilityType,
+  SBOMEventNotification,
+} from '../types/konflux-public-info';
 import { useKonfluxPublicInfo } from './useKonfluxPublicInfo';
 
 export enum ConsoleDotEnvironments {
@@ -87,10 +91,10 @@ export const useNotifications = (): SBOMEventNotification[] => {
   return [];
 };
 
-export const useInstanceVisibility = (): KonfluxPublicInfoVisibility => {
+export const useInstanceVisibility = (): KonfluxInstanceVisibilityType => {
   const [konfluxPublicInfo, loaded, error] = useKonfluxPublicInfo();
   if (loaded && !error && konfluxPublicInfo) {
-    return konfluxPublicInfo.visibility || 'public';
+    return konfluxPublicInfo.visibility || KonfluxInstanceVisibility.PUBLIC;
   }
-  return 'public';
+  return KonfluxInstanceVisibility.PUBLIC;
 };

--- a/src/hooks/useUIInstance.ts
+++ b/src/hooks/useUIInstance.ts
@@ -1,5 +1,5 @@
 import { PLACEHOLDER, REPO_PUSH, SBOM_EVENT_TO_BOMBINO } from '../consts/constants';
-import { SBOMEventNotification } from '../types/konflux-public-info';
+import { KonfluxPublicInfoVisibility, SBOMEventNotification } from '../types/konflux-public-info';
 import { useKonfluxPublicInfo } from './useKonfluxPublicInfo';
 
 export enum ConsoleDotEnvironments {
@@ -87,10 +87,10 @@ export const useNotifications = (): SBOMEventNotification[] => {
   return [];
 };
 
-export const useInstanceVisibility = (): 'public' | 'private' => {
+export const useInstanceVisibility = (): KonfluxPublicInfoVisibility => {
   const [konfluxPublicInfo, loaded, error] = useKonfluxPublicInfo();
   if (loaded && !error && konfluxPublicInfo) {
-    return konfluxPublicInfo.visibility;
+    return konfluxPublicInfo.visibility || 'public';
   }
   return 'public';
 };

--- a/src/types/konflux-public-info.ts
+++ b/src/types/konflux-public-info.ts
@@ -35,9 +35,11 @@ export type KonfluxPublicInfoIntegrations = {
   };
 };
 
+export type KonfluxPublicInfoVisibility = 'public' | 'private';
+
 export type KonfluxPublicInfo = {
   environment?: string;
   integrations?: KonfluxPublicInfoIntegrations;
   rbac: KonfluxRbacItem[];
-  visibility?: 'public' | 'private';
+  visibility?: KonfluxPublicInfoVisibility;
 };

--- a/src/types/konflux-public-info.ts
+++ b/src/types/konflux-public-info.ts
@@ -35,11 +35,17 @@ export type KonfluxPublicInfoIntegrations = {
   };
 };
 
-export type KonfluxPublicInfoVisibility = 'public' | 'private';
+export const KonfluxInstanceVisibility = {
+  PUBLIC: 'public',
+  PRIVATE: 'private',
+} as const;
+
+export type KonfluxInstanceVisibilityType =
+  (typeof KonfluxInstanceVisibility)[keyof typeof KonfluxInstanceVisibility];
 
 export type KonfluxPublicInfo = {
   environment?: string;
   integrations?: KonfluxPublicInfoIntegrations;
   rbac: KonfluxRbacItem[];
-  visibility?: KonfluxPublicInfoVisibility;
+  visibility?: KonfluxInstanceVisibilityType;
 };

--- a/src/types/konflux-public-info.ts
+++ b/src/types/konflux-public-info.ts
@@ -39,4 +39,5 @@ export type KonfluxPublicInfo = {
   environment?: string;
   integrations?: KonfluxPublicInfoIntegrations;
   rbac: KonfluxRbacItem[];
+  visibility?: 'public' | 'private';
 };


### PR DESCRIPTION
## Fixes
[KONFLUX-8558](https://issues.redhat.com/browse/KONFLUX-8558)


## Description
Currently, the `Go to create namespace instruction` button on the Namespace list page redirects all users to the internal Konflux docs.

Proposed solution:
Check if the current instance is internal (or local dev), if it is, link to the internal docs as is, otherwise link to external docs.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [X] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The "Create Namespace" button now adapts based on your environment's visibility, showing tailored instructions or guidance.
* **Bug Fixes**
  * Enhanced UI accuracy for different instance visibility settings.
* **Tests**
  * Added and updated tests to verify UI behavior and hook functionality for public and private environments.
* **Documentation**
  * Added an internal documentation link for private environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->