### PR TITLE
KFLUXUI-528: [Manage Linked Secrets] fix columns alignment

### DIFF
--- a/src/components/Components/LinkedSecretsListView/LinkedSecretsListHeader.tsx
+++ b/src/components/Components/LinkedSecretsListView/LinkedSecretsListHeader.tsx
@@ -2,10 +2,9 @@ import { createTableHeaders } from '../../../shared/components/table/utils';
 
 export const linkedSecretsTableColumnClasses = {
   secretName: 'pf-m-width-25 wrap-column',
-  type: 'pf-m-width-20',
+  type: 'pf-m-width-25',
   labels: 'pf-m-width-25 wrap-column',
   actions: 'pf-m-width-25',
-  kebab: 'pf-m-width-5',
 };
 
 export const enum SortableHeaders {
@@ -22,7 +21,6 @@ const linkedSecretsColumns = [
   { title: 'Type', className: linkedSecretsTableColumnClasses.type, sortable: true },
   { title: 'Labels', className: linkedSecretsTableColumnClasses.labels },
   { title: 'Actions', className: linkedSecretsTableColumnClasses.actions },
-  { title: ' ', className: linkedSecretsTableColumnClasses.kebab },
 ];
 
 export default createTableHeaders(linkedSecretsColumns);

--- a/src/components/Components/LinkedSecretsListView/LinkedSecretsListRow.tsx
+++ b/src/components/Components/LinkedSecretsListView/LinkedSecretsListRow.tsx
@@ -1,4 +1,4 @@
-import { Flex, Label, Text, TextVariants } from '@patternfly/react-core';
+import { Label, Text, TextVariants } from '@patternfly/react-core';
 import UnlinkSecretView from '~/components/Components/UnlinkSecret/UnlinkSecretView';
 import { RowFunctionArgs, TableData } from '../../../shared';
 import { SecretKind } from '../../../types';
@@ -34,10 +34,6 @@ export const LinkedSecretsListRow: React.FC<RowFunctionArgs<SecretKind>> = ({ ob
 
       <TableData className={linkedSecretsTableColumnClasses.actions}>
         <UnlinkSecretView secret={secret} />
-      </TableData>
-
-      <TableData className={linkedSecretsTableColumnClasses.kebab}>
-        <Flex direction={{ default: 'column' }} />
       </TableData>
     </>
   );


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

Fixes https://issues.redhat.com/browse/KFLUXUI-528

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR is fixing a "column misalignment" issue in the "Manage Linked Secrets" page.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

![manage-linked-secrets-columns-alignment-ISSUE](https://github.com/user-attachments/assets/05ffc450-f74d-4c37-b0c4-c326c78a1bd1)

After: 

![manage-linked-secrets-columns-alignment-FIX](https://github.com/user-attachments/assets/33417a38-7a5b-491f-8f06-4bf4dc5967df)


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

* go to a component's "Manage Linked Secrets" page and check the columns alignment
* :coffee:

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->