### PR TITLE
fix(KFLUXUI-473): filter correctly pipelineRuns from GitLab

### DIFF
--- a/src/consts/pipelinerun.ts
+++ b/src/consts/pipelinerun.ts
@@ -49,6 +49,7 @@ export enum PipelineRunType {
 
 export enum PipelineRunEventType {
   PUSH = 'push',
+  GITLAB_PUSH = 'Push',
   PULL = 'pull_request',
   INCOMING = 'incoming',
   RETEST = 'retest-all-comment',

--- a/src/hooks/usePACStatesForComponents.ts
+++ b/src/hooks/usePACStatesForComponents.ts
@@ -83,7 +83,6 @@ const usePACStatesForComponents = (components: ComponentKind[]): PacStatesForCom
           matchLabels: {
             [PipelineRunLabel.PIPELINE_TYPE]: PipelineRunType.BUILD,
             [PipelineRunLabel.APPLICATION]: applicationName,
-            [PipelineRunLabel.COMMIT_EVENT_TYPE_LABEL]: PipelineRunEventType.PUSH,
           },
           matchExpressions: [
             { key: PipelineRunLabel.PULL_REQUEST_NUMBER_LABEL, operator: 'DoesNotExist' },
@@ -109,6 +108,8 @@ const usePACStatesForComponents = (components: ComponentKind[]): PacStatesForCom
         const runsForComponent = pipelineBuildRuns?.filter(
           (p) =>
             p.metadata.labels?.[PipelineRunLabel.COMPONENT] === componentName &&
+            p.metadata.labels?.[PipelineRunLabel.COMMIT_EVENT_TYPE_LABEL]?.toLowerCase() ===
+              PipelineRunEventType.PUSH &&
             (configurationTime
               ? new Date(p.metadata.creationTimestamp) > new Date(configurationTime)
               : true),

--- a/src/hooks/usePACStatesForComponents.ts
+++ b/src/hooks/usePACStatesForComponents.ts
@@ -86,6 +86,11 @@ const usePACStatesForComponents = (components: ComponentKind[]): PacStatesForCom
           },
           matchExpressions: [
             { key: PipelineRunLabel.PULL_REQUEST_NUMBER_LABEL, operator: 'DoesNotExist' },
+            {
+              key: PipelineRunLabel.COMMIT_EVENT_TYPE_LABEL,
+              operator: 'In',
+              values: [PipelineRunEventType.PUSH, PipelineRunEventType.GITLAB_PUSH],
+            },
           ],
         },
       }),
@@ -108,8 +113,6 @@ const usePACStatesForComponents = (components: ComponentKind[]): PacStatesForCom
         const runsForComponent = pipelineBuildRuns?.filter(
           (p) =>
             p.metadata.labels?.[PipelineRunLabel.COMPONENT] === componentName &&
-            p.metadata.labels?.[PipelineRunLabel.COMMIT_EVENT_TYPE_LABEL]?.toLowerCase() ===
-              PipelineRunEventType.PUSH &&
             (configurationTime
               ? new Date(p.metadata.creationTimestamp) > new Date(configurationTime)
               : true),


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
[KFLUXUI-473](https://issues.redhat.com/browse/KFLUXUI-473)


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
WIP

Fix k8s query selection for pipelineRuns of component form GitLab


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
Before:
![image](https://github.com/user-attachments/assets/501f7779-1421-4336-aef1-cb2c9d964aa2)


After:
![image](https://github.com/user-attachments/assets/adf8d3ff-2965-4048-aa64-6bb69f2c9904)



## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
1. Create a component from GitLab
2. No warning message should appear at the top Component List page

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->