### PR TITLE
fix(KONFLUX-7862): sort using last build date

### DIFF
--- a/src/components/Components/ComponentsListView/ComponentListView.tsx
+++ b/src/components/Components/ComponentsListView/ComponentListView.tsx
@@ -121,6 +121,24 @@ const ComponentListView: React.FC<React.PropsWithChildren<ComponentListViewProps
     [componentsWithLatestBuild, statusFilter, nameFilter],
   );
 
+  // Sort the components by completion time - new to old
+  const sortedFilteredComponents = React.useMemo(() => {
+    return filteredComponents.sort((a, b) => {
+      const dateA = a.latestBuildPipelineRun?.status?.completionTime;
+      const dateB = b.latestBuildPipelineRun?.status?.completionTime;
+
+      // If both dates are undefined, maintain original order
+      if (!dateA && !dateB) return 0;
+      // If only dateA is undefined, move it to the end
+      if (!dateA) return 1;
+      // If only dateB is undefined, move it to the end
+      if (!dateB) return -1;
+
+      // Both dates exist, compare them using string comparison for ISO 8601 timestamps
+      return dateB.localeCompare(dateA);
+    });
+  }, [filteredComponents]);
+
   const statusFilterObj = React.useMemo(
     () =>
       createFilterObj(
@@ -297,7 +315,7 @@ const ComponentListView: React.FC<React.PropsWithChildren<ComponentListViewProps
       <div data-test="component-list">
         <Table
           virtualize={false}
-          data={filteredComponents}
+          data={sortedFilteredComponents}
           unfilteredData={componentsWithLatestBuild}
           EmptyMsg={EmptyMessage}
           NoDataEmptyMsg={NoDataEmptyMessage}


### PR DESCRIPTION
## Fixes 
[KONFLUX-7862](https://issues.redhat.com/browse/KONFLUX-7862)

## Description
Konflux UI shows a very old component build as a latest one

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

https://github.com/user-attachments/assets/9a6b4515-f45d-4c3b-8a37-eab73b01fffc



## How to test or reproduce?
Switch branch to main and go to the components where builds are not sorted

## Browser conformance: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


## Checklist:

- [x] Code follows the style guidelines
- [x] Self-reviewed the code
- [x] Added comments in hard-to-understand areas
