### PR TITLE
feat(KFLUXUI-530): show more exact content for secret link option whe…

### DIFF
--- a/src/components/ImportForm/GitImportForm.tsx
+++ b/src/components/ImportForm/GitImportForm.tsx
@@ -4,6 +4,7 @@ import { Form, PageSection } from '@patternfly/react-core';
 import { Formik, FormikHelpers } from 'formik';
 import { FLAGS } from '~/feature-flags/flags';
 import { useIsOnFeatureFlag } from '~/feature-flags/hooks';
+import { CurrentComponentRef } from '~/types';
 import { useNotifications } from '../../hooks/useUIInstance';
 import { APPLICATION_DETAILS_PATH } from '../../routes/paths';
 import { useNamespace } from '../../shared/providers/Namespace';
@@ -110,7 +111,14 @@ export const GitImportForm: React.FC<{ applicationName: string }> = ({ applicati
                 <>
                   <ComponentSection />
                   <PipelineSection />
-                  <SecretSection />
+                  <SecretSection
+                    currentComponent={
+                      {
+                        componentName: formikProps.values.componentName,
+                        applicationName: formikProps.values.application,
+                      } as CurrentComponentRef
+                    }
+                  />
                 </>
               ) : null}
             </PageSection>

--- a/src/components/ImportForm/SecretSection/SecretSection.tsx
+++ b/src/components/ImportForm/SecretSection/SecretSection.tsx
@@ -10,7 +10,12 @@ import { useSecrets } from '../../../hooks/useSecrets';
 import { SecretModel } from '../../../models';
 import TextColumnField from '../../../shared/components/formik-fields/text-column-field/TextColumnField';
 import { useNamespace } from '../../../shared/providers/Namespace';
-import { BuildTimeSecret, SecretType, SecretTypeDropdownLabel } from '../../../types';
+import {
+  BuildTimeSecret,
+  CurrentComponentRef,
+  SecretType,
+  SecretTypeDropdownLabel,
+} from '../../../types';
 import { AccessReviewResources } from '../../../types/rbac';
 import { useAccessReviewForModels } from '../../../utils/rbac';
 import { ButtonWithAccessTooltip } from '../../ButtonWithAccessTooltip';
@@ -20,7 +25,11 @@ import { ImportFormValues } from '../type';
 
 const accessReviewResources: AccessReviewResources = [{ model: SecretModel, verb: 'create' }];
 
-const SecretSection = () => {
+type SecretSectionProps = {
+  currentComponent?: null | CurrentComponentRef;
+};
+
+const SecretSection: React.FC<SecretSectionProps> = ({ currentComponent }) => {
   const isBuildServiceAccountFeatureOn = useIsOnFeatureFlag(FLAGS.buildServiceAccount.key);
   const [canCreateSecret] = useAccessReviewForModels(accessReviewResources);
   const showModal = useModalLauncher();
@@ -103,7 +112,14 @@ const SecretSection = () => {
         data-test="add-secret-button"
         icon={<PlusCircleIcon />}
         onClick={() =>
-          showModal(SecretModalLauncher([...partnerTaskSecrets, ...values.newSecrets], onSubmit))
+          showModal(
+            SecretModalLauncher(
+              [...partnerTaskSecrets, ...values.newSecrets], // existingSecrets
+              onSubmit,
+              undefined, // onClose
+              currentComponent, // currentComponent
+            ),
+          )
         }
         isDisabled={!canCreateSecret}
         tooltip="You don't have access to add a secret"

--- a/src/components/Secrets/SecretForm.tsx
+++ b/src/components/Secrets/SecretForm.tsx
@@ -14,6 +14,7 @@ import {
   K8sSecretType,
   BuildTimeSecret,
   SourceSecretType,
+  CurrentComponentRef,
 } from '../../types';
 import { RawComponentProps } from '../modal/createModalLauncher';
 import { SecretLinkOptions } from './SecretsForm/SecretLinkOption';
@@ -28,9 +29,13 @@ import {
 
 type SecretFormProps = RawComponentProps & {
   existingSecrets: BuildTimeSecret[];
+  currentComponent?: null | CurrentComponentRef;
 };
 
-const SecretForm: React.FC<React.PropsWithChildren<SecretFormProps>> = ({ existingSecrets }) => {
+const SecretForm: React.FC<React.PropsWithChildren<SecretFormProps>> = ({
+  existingSecrets,
+  currentComponent,
+}) => {
   const isBuildServiceAccountFeatureOn = useIsOnFeatureFlag(FLAGS.buildServiceAccount.key);
   const { values, setFieldValue } = useFormikContext<SecretFormValues>();
   const [currentType, setCurrentType] = useState(values.type);
@@ -148,6 +153,7 @@ const SecretForm: React.FC<React.PropsWithChildren<SecretFormProps>> = ({ existi
       />
       {isBuildServiceAccountFeatureOn && shouldShowSecretLinkOptions && (
         <SecretLinkOptions
+          currentComponent={currentComponent}
           secretForComponentOption={secretForComponentOption}
           onOptionChange={(option) => setValue(option)}
           radioLabels={SecretLinkOptionLabels.forImportSecret}

--- a/src/components/Secrets/SecretForm.tsx
+++ b/src/components/Secrets/SecretForm.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { Form } from '@patternfly/react-core';
 import { SelectVariant } from '@patternfly/react-core/deprecated';
 import { useField, useFormikContext } from 'formik';
-import { FIELD_SECRET_FOR_COMPONENT_OPTION } from '~/consts/secrets';
+import { FIELD_SECRET_FOR_COMPONENT_OPTION, SecretLinkOptionLabels } from '~/consts/secrets';
 import { FLAGS } from '~/feature-flags/flags';
 import { useIsOnFeatureFlag } from '~/feature-flags/hooks';
 import { DropdownItemObject } from '../../shared/components/dropdown';
@@ -150,6 +150,7 @@ const SecretForm: React.FC<React.PropsWithChildren<SecretFormProps>> = ({ existi
         <SecretLinkOptions
           secretForComponentOption={secretForComponentOption}
           onOptionChange={(option) => setValue(option)}
+          radioLabels={SecretLinkOptionLabels.forImportSecret}
         />
       )}
       {currentType === SecretTypeDropdownLabel.source && <SourceSecretForm />}

--- a/src/components/Secrets/SecretModal.tsx
+++ b/src/components/Secrets/SecretModal.tsx
@@ -7,6 +7,7 @@ import {
   SecretTypeDropdownLabel,
   SourceSecretType,
   BuildTimeSecret,
+  CurrentComponentRef,
 } from '../../types';
 import { SecretFromSchema } from '../../utils/validation-utils';
 import { RawComponentProps } from '../modal/createModalLauncher';
@@ -30,12 +31,14 @@ export type SecretModalValues = ImportSecret & {
 type SecretModalProps = RawComponentProps & {
   existingSecrets: BuildTimeSecret[];
   onSubmit: (value: SecretModalValues) => void;
+  currentComponent?: null | CurrentComponentRef;
 };
 
 const SecretModal: React.FC<React.PropsWithChildren<SecretModalProps>> = ({
   modalProps,
   onSubmit,
   existingSecrets,
+  currentComponent,
 }) => {
   const defaultKeyValues = [{ key: '', value: '', readOnlyKey: false }];
   const initialValues: SecretModalValues = {
@@ -51,6 +54,7 @@ const SecretModal: React.FC<React.PropsWithChildren<SecretModalProps>> = ({
       authType: SourceSecretType.basic,
     },
     existingSecrets,
+    currentComponent,
     relatedComponents: [],
     secretForComponentOption: null,
   };
@@ -87,7 +91,7 @@ const SecretModal: React.FC<React.PropsWithChildren<SecretModalProps>> = ({
           ]}
         >
           <ModalBoxBody>
-            <SecretForm existingSecrets={existingSecrets} />
+            <SecretForm existingSecrets={existingSecrets} currentComponent={currentComponent} />
           </ModalBoxBody>
         </Modal>
       )}

--- a/src/components/Secrets/SecretModalLauncher.tsx
+++ b/src/components/Secrets/SecretModalLauncher.tsx
@@ -1,5 +1,5 @@
 import { ModalVariant } from '@patternfly/react-core';
-import { SecretFormValues, BuildTimeSecret } from '../../types';
+import { SecretFormValues, BuildTimeSecret, CurrentComponentRef } from '../../types';
 import { createRawModalLauncher } from '../modal/createModalLauncher';
 import SecretForm from './SecretModal';
 
@@ -7,10 +7,11 @@ export const SecretModalLauncher = (
   existingSecrets?: BuildTimeSecret[],
   onSubmit?: (values: SecretFormValues) => void,
   onClose?: () => void,
+  currentComponent?: null | CurrentComponentRef,
 ) =>
   createRawModalLauncher(SecretForm, {
     'data-test': 'create-secret-modal',
     variant: ModalVariant.large,
     hasNoBodyWrapper: true,
     onClose,
-  })({ onSubmit, existingSecrets });
+  })({ onSubmit, existingSecrets, currentComponent });

--- a/src/components/Secrets/SecretsForm/SecretLinkOption.tsx
+++ b/src/components/Secrets/SecretsForm/SecretLinkOption.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { RadioGroupField } from 'formik-pf';
+import { CurrentComponentRef } from '~/types';
 import HelpPopover from '../../HelpPopover';
 import { SecretForComponentOption } from '../utils/secret-utils';
 import { ComponentSelector } from './ComponentSelector';
@@ -13,12 +14,14 @@ type SecretLinkOptionsProps = {
     all: string;
     partial: string;
   };
+  currentComponent?: null | CurrentComponentRef;
 };
 
 export const SecretLinkOptions: React.FC<SecretLinkOptionsProps> = ({
   secretForComponentOption,
   onOptionChange,
   radioLabels,
+  currentComponent,
 }) => {
   return (
     <>
@@ -45,7 +48,9 @@ export const SecretLinkOptions: React.FC<SecretLinkOptionsProps> = ({
       />
 
       {/* Secret Component Dropdown */}
-      {secretForComponentOption === SecretForComponentOption.partial && <ComponentSelector />}
+      {secretForComponentOption === SecretForComponentOption.partial && (
+        <ComponentSelector currentComponent={currentComponent} />
+      )}
     </>
   );
 };

--- a/src/components/Secrets/SecretsForm/SecretLinkOption.tsx
+++ b/src/components/Secrets/SecretsForm/SecretLinkOption.tsx
@@ -4,14 +4,21 @@ import HelpPopover from '../../HelpPopover';
 import { SecretForComponentOption } from '../utils/secret-utils';
 import { ComponentSelector } from './ComponentSelector';
 
+import './SecretLinkOptionForm.scss';
+
 type SecretLinkOptionsProps = {
   secretForComponentOption: SecretForComponentOption;
   onOptionChange: (option: SecretForComponentOption) => void;
+  radioLabels: {
+    all: string;
+    partial: string;
+  };
 };
 
 export const SecretLinkOptions: React.FC<SecretLinkOptionsProps> = ({
   secretForComponentOption,
   onOptionChange,
+  radioLabels,
 }) => {
   return (
     <>
@@ -26,11 +33,11 @@ export const SecretLinkOptions: React.FC<SecretLinkOptionsProps> = ({
         options={[
           {
             value: SecretForComponentOption.all,
-            label: 'All existing and future components in the namespace',
+            label: radioLabels.all,
           },
           {
             value: SecretForComponentOption.partial,
-            label: 'Select components in the namespace',
+            label: radioLabels.partial,
           },
         ]}
         required={false}

--- a/src/components/Secrets/SecretsForm/SecretLinkOptionForm.scss
+++ b/src/components/Secrets/SecretsForm/SecretLinkOptionForm.scss
@@ -1,0 +1,24 @@
+.menugroup {
+  .pf-v5-c-menu__group-title {
+    display: none;
+  }
+}
+
+.labeled-dropdown-field {
+  .title {
+    font-weight: var(--pf-v5-global--FontWeight--bold);
+    font-size: var(--pf-v5-c-form__label--FontSize);
+    line-height: var(--pf-v5-c-form__label--LineHeight);
+    gap: var(--pf-v5-global--spacer--xs);
+    margin-bottom: var(--pf-v5-global--spacer--sm);
+  }
+
+  .component-select-menu {
+    margin-bottom: var(--pf-v5-global--spacer--xs);
+  }
+
+  .help-text {
+    font-size: var(--pf-v5-global--FontSize--sm);
+    font-style: {color: var(--pf-v5-c-helper-text__item-icon--m-indeterminate--Color)};
+  }
+}

--- a/src/components/Secrets/SecretsForm/SecretTypeSubForm.scss
+++ b/src/components/Secrets/SecretsForm/SecretTypeSubForm.scss
@@ -4,28 +4,3 @@
   }
 }
 
-.menugroup {
-  .pf-v5-c-menu__group-title {
-    display: none;
-  }
-}
-
-.labeled-dropdown-field {
-  .title {
-    font-weight: var(--pf-v5-global--FontWeight--bold);
-    font-size: var(--pf-v5-c-form__label--FontSize);
-    line-height: var(--pf-v5-c-form__label--LineHeight);
-    gap: var(--pf-v5-global--spacer--xs);
-    margin-bottom: var(--pf-v5-global--spacer--sm);
-  }
-
-  .component-select-menu {
-    margin-bottom: var(--pf-v5-global--spacer--xs);
-  }
-
-  .help-text {
-    font-size: var(--pf-v5-global--FontSize--sm);
-    font-style: {color: var(--pf-v5-c-helper-text__item-icon--m-indeterminate--Color)};
-  }
-}
-

--- a/src/components/Secrets/SecretsForm/SecretTypeSubForm.tsx
+++ b/src/components/Secrets/SecretsForm/SecretTypeSubForm.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { SelectVariant } from '@patternfly/react-core/deprecated';
 import { useField, useFormikContext } from 'formik';
 import { InputField } from 'formik-pf';
+import { SecretLinkOptionLabels } from '~/consts/secrets';
 import { IfFeature } from '~/feature-flags/hooks';
 import { DropdownItemObject } from '../../../shared/components/dropdown';
 import KeyValueFileInputField from '../../../shared/components/formik-fields/key-value-input-field/KeyValueInputField';
@@ -180,6 +181,7 @@ export const SecretTypeSubForm: React.FC<React.PropsWithChildren<unknown>> = () 
         {shouldShowSecretLinkOptions && (
           <SecretLinkOptions
             secretForComponentOption={secretForComponentOption}
+            radioLabels={SecretLinkOptionLabels.default}
             onOptionChange={(option) => setValue(option)}
           />
         )}

--- a/src/components/Secrets/__tests___/SecretLinkOption.spec.tsx
+++ b/src/components/Secrets/__tests___/SecretLinkOption.spec.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { FormikProvider, useFormik } from 'formik';
+import { SecretLinkOptionLabels } from '~/consts/secrets';
 import { SecretLinkOptions } from '../SecretsForm/SecretLinkOption';
 import { SecretForComponentOption } from '../utils/secret-utils';
 
@@ -26,6 +27,7 @@ describe('SecretLinkOptions', () => {
         <SecretLinkOptions
           secretForComponentOption={SecretForComponentOption.all}
           onOptionChange={mockOnOptionChange}
+          radioLabels={SecretLinkOptionLabels.default}
         />
       </TestWrapper>,
     );
@@ -43,6 +45,7 @@ describe('SecretLinkOptions', () => {
         <SecretLinkOptions
           secretForComponentOption={SecretForComponentOption.all}
           onOptionChange={mockOnOptionChange}
+          radioLabels={SecretLinkOptionLabels.forImportSecret}
         />
       </TestWrapper>,
     );
@@ -58,6 +61,7 @@ describe('SecretLinkOptions', () => {
         <SecretLinkOptions
           secretForComponentOption={SecretForComponentOption.all}
           onOptionChange={mockOnOptionChange}
+          radioLabels={SecretLinkOptionLabels.default}
         />
       </TestWrapper>,
     );
@@ -69,6 +73,7 @@ describe('SecretLinkOptions', () => {
           <SecretLinkOptions
             secretForComponentOption={SecretForComponentOption.partial}
             onOptionChange={mockOnOptionChange}
+            radioLabels={SecretLinkOptionLabels.forImportSecret}
           />
         </QueryClientProvider>
       </TestWrapper>,

--- a/src/consts/secrets.ts
+++ b/src/consts/secrets.ts
@@ -6,3 +6,13 @@ export const IMAGE_PULL_SECRET_TYPES = [
 export const LINKING_ERROR_ANNOTATION = 'konflux-ui/linking-secret-action-error';
 export const MAX_ANNOTATION_LENGTH = 2048;
 export const LINKING_STATUS_ANNOTATION = 'konflux-ui/linking-secret-action-status';
+export const SecretLinkOptionLabels = {
+  default: {
+    all: 'All existing and future components in the namespace',
+    partial: 'Select components in the namespace',
+  },
+  forImportSecret: {
+    all: 'Current component, all existing and future components in the namespace',
+    partial: 'Select components in the namespace',
+  },
+} as const;

--- a/src/shared/components/component-select-menu/ComponentSelectMenu.tsx
+++ b/src/shared/components/component-select-menu/ComponentSelectMenu.tsx
@@ -10,7 +10,9 @@ import {
 } from '@patternfly/react-core';
 import { useField } from 'formik';
 import { flatten, isArray } from 'lodash-es';
+import { CurrentComponentRef } from '~/types/secret';
 import SelectComponentsDropdown from './SelectComponnetsDropdown';
+
 import './ComponentSelectMenu.scss';
 
 type ComponentSelectMenuProps = {
@@ -18,6 +20,7 @@ type ComponentSelectMenuProps = {
   options: string[] | { [application: string]: string[] };
   isMulti?: boolean;
   disableItem?: (item: string) => boolean;
+  defaultSelected?: null | CurrentComponentRef[];
   sourceComponentName?: string;
   includeSelectAll?: boolean;
   defaultToggleText?: string;
@@ -34,6 +37,7 @@ export const ComponentSelectMenu: React.FC<ComponentSelectMenuProps> = ({
   options,
   isMulti = false,
   disableItem,
+  defaultSelected,
   sourceComponentName,
   includeSelectAll = false,
   defaultToggleText = 'Select components',
@@ -110,6 +114,29 @@ export const ComponentSelectMenu: React.FC<ComponentSelectMenuProps> = ({
     }
     return selectedComponents?.length > 0 ? selectedToggleText : defaultToggleText;
   }, [defaultToggleText, value, selectedToggleText]);
+
+  useEffect(() => {
+    if (!defaultSelected || defaultSelected.length === 0) return;
+
+    const filterDefaultSelected = defaultSelected.filter(
+      (c) => c?.componentName && c?.applicationName,
+    );
+
+    if (filterDefaultSelected.length === 0) return;
+
+    const defaultValues = filterDefaultSelected.map((c) => c.componentName);
+
+    if (isMulti) {
+      if (Array.isArray(value) && value.length === 0) {
+        void setValue(defaultValues);
+      }
+    } else {
+      if (!value) {
+        void setValue(defaultValues[0]);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultSelected, setValue, isMulti]);
 
   return (
     <>

--- a/src/shared/components/component-select-menu/__tests__/ComponentSelectMenu.spec.tsx
+++ b/src/shared/components/component-select-menu/__tests__/ComponentSelectMenu.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { useFormik, FormikProvider } from 'formik';
+import { CurrentComponentRef } from '~/types';
 import { ComponentSelectMenu } from '../ComponentSelectMenu';
 
 const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -92,21 +93,45 @@ describe('ComponentSelectMenu', () => {
     });
   });
 
-  it('disables items correctly', async () => {
+  it('renders with defaultSelected items checked', () => {
+    const defaultSelected = [
+      { componentName: 'Item 1', applicationName: 'Group1' },
+    ] as CurrentComponentRef[];
+
+    render(
+      <TestWrapper>
+        <ComponentSelectMenu
+          name="components"
+          options={groupedOptions}
+          isMulti
+          defaultSelected={defaultSelected}
+        />
+      </TestWrapper>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'toggle component menu' }));
+    const checkbox = screen.getByRole('checkbox', { name: /Item 1/i });
+    expect(checkbox).toBeChecked();
+  });
+
+  it('renders with disableItem', () => {
     const disableItem = (item: string) => item === 'Item 2';
 
     render(
       <TestWrapper>
-        <ComponentSelectMenu name="components" options={options} disableItem={disableItem} />
+        <ComponentSelectMenu
+          name="components"
+          options={groupedOptions}
+          disableItem={disableItem}
+          isMulti
+        />
       </TestWrapper>,
     );
 
-    fireEvent.click(screen.getByText('Select components'));
-    const disabledItem = screen.getByText('Item 2');
-    fireEvent.click(disabledItem);
-    await waitFor(() => {
-      expect(screen.getByText('Select components')).toBeInTheDocument();
-    });
+    fireEvent.click(screen.getByRole('button', { name: 'toggle component menu' }));
+
+    const item2 = screen.getByRole('menuitem', { name: 'Item 2' });
+    expect(item2).toHaveClass('pf-m-disabled');
   });
 
   it('renders grouped options correctly', () => {

--- a/src/types/secret.ts
+++ b/src/types/secret.ts
@@ -3,6 +3,11 @@ import { K8sResourceCommon } from './k8s';
 
 export const SecretByUILabel = 'ui.appstudio.redhat.com/secret-for';
 
+export type CurrentComponentRef = {
+  componentName: null | string;
+  applicationName: null | string;
+};
+
 export type ImportSecret = {
   secretName: string;
   type: string;
@@ -21,6 +26,7 @@ export type ImportSecret = {
       readOnlyKey?: boolean;
     }[];
   };
+  currentComponent?: null | CurrentComponentRef;
   relatedComponents?: [];
   secretForComponentOption?: null | SecretForComponentOption;
 };


### PR DESCRIPTION
## Fixes 
[KFLUXUI-530](https://issues.redhat.com/browse/KFLUXUI-530)

## Description
Improve UX & UI of secretlinkoption for  import secrets to ensure it shows more exact info.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
- when we have the component name and application name:

<img width="826" alt="Screenshot 2025-06-10 at 17 05 15" src="https://github.com/user-attachments/assets/d3854bb3-502e-4789-953e-842091fda819" />

- when we do not set the component name or application name:

<img width="795" alt="Screenshot 2025-06-10 at 17 33 31" src="https://github.com/user-attachments/assets/5924edcd-5136-4f2b-841b-a4525d5373fb" />

- to do real linking to ensure there is no regression:

https://github.com/user-attachments/assets/049de62d-0f0b-4fad-b52c-783f5f7ad0a1




## How to test or reproduce?
Try the steps in the recording.:-).

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->