### PR TITLE
KONFLUX-8605: [Filter] safely parse filter values

### DIFF
--- a/src/components/Filter/generic/__tests__/FilterContext.spec.tsx
+++ b/src/components/Filter/generic/__tests__/FilterContext.spec.tsx
@@ -1,6 +1,12 @@
 import { useContext } from 'react';
-import { renderHook } from '@testing-library/react';
-import { FilterContext } from '../FilterContext';
+import { createSearchParams, useSearchParams } from 'react-router-dom';
+import { renderHook, act } from '@testing-library/react';
+import { FilterContext, FilterContextProvider } from '../FilterContext';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useSearchParams: jest.fn(),
+}));
 
 describe('FilterContext', () => {
   it('should create a context with default values', () => {
@@ -31,5 +37,86 @@ describe('FilterContext', () => {
     expect(result.current.filters).toEqual({ name: 'test' });
     expect(result.current.setFilters).toBe(mockSetFilters);
     expect(result.current.onClearFilters).toBe(mockOnClearFilters);
+  });
+});
+
+describe('FilterContextProvider parsing behavior', () => {
+  const mockSetSearchParams = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useSearchParams as jest.Mock).mockImplementation(() => [
+      createSearchParams({}),
+      mockSetSearchParams,
+    ]);
+  });
+
+  it('should preserve plain string values when getting and setting filters', () => {
+    // setup initial URL param
+    (useSearchParams as jest.Mock).mockImplementation(() => [
+      createSearchParams({ name: 'testrepo-b5746' }),
+      mockSetSearchParams,
+    ]);
+
+    const { result } = renderHook(() => useContext(FilterContext), {
+      wrapper: ({ children }) => (
+        <FilterContextProvider filterParams={['name']}>{children}</FilterContextProvider>
+      ),
+    });
+
+    // check that we get the plain string value correctly
+    expect(result.current.filters).toEqual({ name: 'testrepo-b5746' });
+
+    // set a new plain string value
+    act(() => {
+      result.current.setFilters({ name: 'new-repo-name' });
+    });
+
+    // verify the string was set without modification
+    expect(mockSetSearchParams).toHaveBeenCalled();
+    const params = mockSetSearchParams.mock.calls[0][0];
+    expect(params.get('name')).toBe('new-repo-name');
+  });
+
+  it('should handle JSON values correctly', () => {
+    // setup initial URL param with a JSON string
+    (useSearchParams as jest.Mock).mockImplementation(() => [
+      createSearchParams({ data: '{"key":"value"}' }),
+      mockSetSearchParams,
+    ]);
+
+    const { result } = renderHook(() => useContext(FilterContext), {
+      wrapper: ({ children }) => (
+        <FilterContextProvider filterParams={['data']}>{children}</FilterContextProvider>
+      ),
+    });
+
+    // check that JSON is parsed correctly
+    expect(result.current.filters).toEqual({ data: { key: 'value' } });
+  });
+
+  it('should handle null values correctly', () => {
+    // setup initial URL param with empty and null values
+    (useSearchParams as jest.Mock).mockImplementation(() => [
+      createSearchParams({
+        empty: '',
+        nullValue: null as unknown as string,
+      }),
+      mockSetSearchParams,
+    ]);
+
+    const { result } = renderHook(() => useContext(FilterContext), {
+      wrapper: ({ children }) => (
+        <FilterContextProvider filterParams={['empty', 'nullValue']}>
+          {children}
+        </FilterContextProvider>
+      ),
+    });
+
+    // check that empty and null values are handled correctly
+    expect(result.current.filters).toEqual({
+      empty: null,
+      nullValue: null,
+    });
   });
 });


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

Fixes https://issues.redhat.com/browse/KONFLUX-8605

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In this PR we're improving the way the filter value is being parsed in the `FilterContextProvider`. It fixes an error when `JSON.parse()` is being used to try to parse a value that's a plain string.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

https://github.com/user-attachments/assets/61275dcc-473e-4ab4-95fc-d19f7227b5de

After:

https://github.com/user-attachments/assets/ecd9b782-966e-4c71-ae90-a63a53d9bfed

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

1. navigate to a "PipelineRuns" tab
2. find a PipelineRun that can be "rerun"
3. try to re-run it
4. it should work just fine, no crashes
5. :coffee:

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->