### PR TITLE
style(KFLUXUI-529): Link Secret modal updated to small variant

### DIFF
--- a/src/components/Components/LinkSecret/LinkSecret.tsx
+++ b/src/components/Components/LinkSecret/LinkSecret.tsx
@@ -31,6 +31,6 @@ export const LinkSecret: React.FC<React.PropsWithChildren<LinkSecretModalProps>>
 export const createLinkSecretModalLauncher = () =>
   createModalLauncher(LinkSecret, {
     'data-test': `link-secret-modal`,
-    variant: ModalVariant.medium,
+    variant: ModalVariant.small,
     title: `Link Secrets?`,
   });

--- a/src/components/Components/LinkSecret/SecretSelector.tsx
+++ b/src/components/Components/LinkSecret/SecretSelector.tsx
@@ -58,7 +58,7 @@ export const SecretSelector: React.FC<React.PropsWithChildren<SecretSelectorProp
           defaultAriaLabel="Search secrets"
         />
       </div>
-      <div style={{ marginTop: '2rem' }}>
+      <div>
         <Button onClick={handleSubmit} isDisabled={linkedSecretsList.length === 0}>
           Link Secrets
         </Button>


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
<a href="https://issues.redhat.com/browse/KFLUXUI-529">KFLUXUI-529</a>


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Adjusted the Link Secret modal size to be similar with Unlink secret modal within same page.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [x] Design Change
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


<img width="1436" alt="image" src="https://github.com/user-attachments/assets/8f39a5b4-7663-489c-a3df-23c9dfefad2a" />


<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->