### PR TITLE
KFLUXUI-542 [Snapshots] migrate to useK8sAndKarchResource for k8s-karch fetching

### DIFF
--- a/src/components/Commits/CommitDetails/tabs/__tests__/CommitsPipelineRunTab.spec.tsx
+++ b/src/components/Commits/CommitDetails/tabs/__tests__/CommitsPipelineRunTab.spec.tsx
@@ -4,11 +4,13 @@ import { FilterContextProvider } from '~/components/Filter/generic/FilterContext
 import { useSearchParamBatch } from '~/hooks/useSearchParam';
 import { mockUseSearchParamBatch } from '~/unit-test-utils/mock-useSearchParam';
 import { PipelineRunLabel } from '../../../../../consts/pipelinerun';
+import { useK8sAndKarchResource } from '../../../../../hooks/useK8sAndKarchResources';
 import { usePipelineRunsForCommit } from '../../../../../hooks/usePipelineRuns';
 import { mockUseNamespaceHook } from '../../../../../unit-test-utils/mock-namespace';
 import { createK8sWatchResourceMock } from '../../../../../utils/test-utils';
 import { PipelineRunListRow } from '../../../../PipelineRun/PipelineRunListView/PipelineRunListRow';
 import { pipelineWithCommits } from '../../../__data__/pipeline-with-commits';
+import { MockSnapshots } from '../../visualization/__data__/MockCommitWorkflowData';
 import CommitsPipelineRunTab from '../CommitsPipelineRunTab';
 
 jest.useFakeTimers();
@@ -51,12 +53,17 @@ jest.mock('../../../../../hooks/useSearchParam', () => ({
   useSearchParamBatch: jest.fn(),
 }));
 
+jest.mock('../../../../../hooks/useK8sAndKarchResources', () => ({
+  useK8sAndKarchResource: jest.fn(),
+}));
+
 const appName = 'my-test-app';
 
 const watchResourceMock = createK8sWatchResourceMock();
 const usePipelineRunsForCommitMock = usePipelineRunsForCommit as jest.Mock;
 const useParamsMock = useParams as jest.Mock;
 const useSearchParamBatchMock = useSearchParamBatch as jest.Mock;
+const useSnapshotMock = useK8sAndKarchResource as jest.Mock;
 
 const commitPlrs = [
   pipelineWithCommits[0],
@@ -88,6 +95,7 @@ describe('Commit Pipelinerun List', () => {
     useParamsMock.mockReturnValue({ applicationName: appName, commitName: 'test-sha-1' });
     jest.clearAllMocks();
     useNamespaceMock.mockReturnValue('test-ns');
+    useSnapshotMock.mockReturnValue({ data: MockSnapshots[0], isLoading: false, error: undefined });
   });
   it('should render error state if the API errors out', () => {
     usePipelineRunsForCommitMock.mockReturnValue([

--- a/src/components/SnapshotDetails/SnapshotDetailsView.tsx
+++ b/src/components/SnapshotDetails/SnapshotDetailsView.tsx
@@ -21,11 +21,12 @@ const SnapshotDetailsView: React.FC = () => {
 
   const applicationBreadcrumbs = useApplicationBreadcrumbs();
 
-  const [snapshot, loaded, loadErr] = useSnapshot(namespace, snapshotName);
+  const [snapshot, loaded, snapshotError] = useSnapshot(namespace, snapshotName);
 
   const buildPipelineName = React.useMemo(
-    () => loaded && !loadErr && snapshot?.metadata?.labels?.[SnapshotLabels.BUILD_PIPELINE_LABEL],
-    [snapshot, loaded, loadErr],
+    () =>
+      loaded && !snapshotError && snapshot?.metadata?.labels?.[SnapshotLabels.BUILD_PIPELINE_LABEL],
+    [snapshot, loaded, snapshotError],
   );
 
   const [buildPipelineRun, plrLoaded, plrLoadError] = usePipelineRun(
@@ -38,17 +39,19 @@ const SnapshotDetailsView: React.FC = () => {
     [plrLoaded, plrLoadError, buildPipelineRun],
   );
 
-  if (loadErr || (loaded && !snapshot)) {
+  if (snapshotError || (loaded && !snapshot)) {
     return (
       <ErrorEmptyState
-        httpError={HttpError.fromCode(loadErr ? (loadErr as { code: number }).code : 404)}
+        httpError={HttpError.fromCode(
+          snapshotError ? (snapshotError as { code: number }).code : 404,
+        )}
         title="Snapshot not found"
         body="No such snapshot"
       />
     );
   }
 
-  if (!plrLoadError && !plrLoaded) {
+  if (!plrLoadError && !plrLoaded && !loaded) {
     return (
       <Bullseye>
         <Spinner size="lg" />

--- a/src/components/SnapshotDetails/tabs/SnapshotOverview.tsx
+++ b/src/components/SnapshotDetails/tabs/SnapshotOverview.tsx
@@ -48,14 +48,14 @@ const SnapshotOverviewTab: React.FC = () => {
 
   const componentsTableData: SnapshotComponentTableData[] = React.useMemo(
     () =>
-      snapshot.spec.components.map((component) => {
+      snapshot?.spec?.components?.map((component) => {
         return {
           metadata: { uid: component.name, name: component.name },
-          application: snapshot.spec.application,
+          application: snapshot?.spec?.application,
           ...component,
         };
-      }),
-    [snapshot.spec],
+      }) || [],
+    [snapshot?.spec],
   );
 
   return (
@@ -75,7 +75,7 @@ const SnapshotOverviewTab: React.FC = () => {
               <DescriptionListGroup>
                 <DescriptionListTerm>Created at</DescriptionListTerm>
                 <DescriptionListDescription>
-                  <Timestamp timestamp={snapshot.metadata.creationTimestamp ?? '-'} />
+                  <Timestamp timestamp={snapshot?.metadata?.creationTimestamp ?? '-'} />
                 </DescriptionListDescription>
               </DescriptionListGroup>
               {commit && (
@@ -85,7 +85,7 @@ const SnapshotOverviewTab: React.FC = () => {
                     <Link
                       to={COMMIT_DETAILS_PATH.createPath({
                         workspaceName: namespace,
-                        applicationName: snapshot.spec.application,
+                        applicationName: snapshot?.spec?.application,
                         commitName: commit.sha,
                       })}
                       title={commit.displayName || commit.shaTitle}
@@ -126,7 +126,7 @@ const SnapshotOverviewTab: React.FC = () => {
         <FilterContextProvider filterParams={['name']}>
           <SnapshotComponentsList
             components={componentsTableData}
-            applicationName={snapshot.spec.application}
+            applicationName={snapshot?.spec?.application}
           />
         </FilterContextProvider>
       </div>

--- a/src/hooks/useSnapshots.ts
+++ b/src/hooks/useSnapshots.ts
@@ -1,26 +1,28 @@
+import * as React from 'react';
 import { PipelineRunLabel } from '../consts/pipelinerun';
-import { useK8sWatchResource } from '../k8s';
 import { SnapshotGroupVersionKind, SnapshotModel } from '../models';
 import { Snapshot } from '../types/coreBuildService';
+import { useK8sAndKarchResource, useK8sAndKarchResources } from './useK8sAndKarchResources';
 
 export const useSnapshot = (namespace: string, name: string): [Snapshot, boolean, unknown] => {
-  const {
-    data: snapshot,
-    isLoading,
-    error,
-  } = useK8sWatchResource<Snapshot>(
-    {
-      groupVersionKind: SnapshotGroupVersionKind,
-      namespace,
-      name,
-    },
-    SnapshotModel,
+  const resourceInit = React.useMemo(
+    () => ({
+      model: SnapshotModel,
+      queryOptions: {
+        ns: namespace,
+        name,
+      },
+    }),
+    [namespace, name],
   );
+
+  const { data: snapshot, isLoading, error } = useK8sAndKarchResource<Snapshot>(resourceInit);
+
   return [snapshot, !isLoading, error];
 };
 
 export const useSnapshotsForApplication = (namespace, applicationName) => {
-  return useK8sWatchResource<Snapshot[]>(
+  return useK8sAndKarchResources<Snapshot>(
     {
       groupVersionKind: SnapshotGroupVersionKind,
       namespace,


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

Fixes https://issues.redhat.com/browse/KFLUXUI-542

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR is updating both `useSnapshot` and `useSnapshotsForApplication` hooks to use `useK8sAndKarchResource` / `useK8sAndKarchResources` in order to fetch snapshots from both kubernetes and kubearchive.
The places that were using those hooks were updated in order to handle the refactor correctly.
Also, tests were updated to reflect the new changes :)


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Snapshot Details still works as expected:

https://github.com/user-attachments/assets/a11d7b69-514d-4a7f-bab8-c3ee13c55529

Snapshots Dropdown still works as expected:

https://github.com/user-attachments/assets/470fd5c2-01ed-442e-b1f4-ac21ac63423c

Also showing API calls:

https://github.com/user-attachments/assets/9209b35b-8d9b-446b-87fc-0aee9e296366

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

There are two main pages that were affected by the changes on this PR:

* Snapshot Overview/Details
* Release Plan - Trigger Release (SnapshotDropdown component)
* :coffee:

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->