### PR TITLE
feat(KFLUXUI-548): add do not link option for select link options

### DIFF
--- a/AI_authorized_emails.txt
+++ b/AI_authorized_emails.txt
@@ -10,4 +10,3 @@ marcin.michal02@gmail.com
 rakeshy2797@gmail.com
 sahilbudhwar143@gmail.com
 dehankarjanaki@gmail.com
-wlin@redhat.com

--- a/src/components/Secrets/SecretsForm/SecretLinkOption.tsx
+++ b/src/components/Secrets/SecretsForm/SecretLinkOption.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { RadioGroupField } from 'formik-pf';
+import { SECRET_LINK_OPTION_HELP_TEXT } from '~/consts/secrets';
 import { CurrentComponentRef } from '~/types';
 import HelpPopover from '../../HelpPopover';
 import { SecretForComponentOption } from '../utils/secret-utils';
@@ -11,6 +12,7 @@ type SecretLinkOptionsProps = {
   secretForComponentOption: SecretForComponentOption;
   onOptionChange: (option: SecretForComponentOption) => void;
   radioLabels: {
+    none?: string;
     all: string;
     partial: string;
   };
@@ -29,11 +31,18 @@ export const SecretLinkOptions: React.FC<SecretLinkOptionsProps> = ({
         name="secretForComponentOption"
         label={
           <b>
-            Link secret options{' '}
-            <HelpPopover bodyContent="Select an option that allow you to link your desired components in this namespace while creating the secrets." />
+            Link secret options <HelpPopover bodyContent={SECRET_LINK_OPTION_HELP_TEXT} />
           </b>
         }
         options={[
+          ...(radioLabels.none
+            ? [
+                {
+                  value: SecretForComponentOption.none,
+                  label: radioLabels.none,
+                },
+              ]
+            : []),
           {
             value: SecretForComponentOption.all,
             label: radioLabels.all,

--- a/src/components/Secrets/SecretsForm/SecretTypeSubForm.tsx
+++ b/src/components/Secrets/SecretsForm/SecretTypeSubForm.tsx
@@ -72,9 +72,10 @@ export const SecretTypeSubForm: React.FC<React.PropsWithChildren<unknown>> = () 
   const [currentType, setCurrentType] = useState(secretType);
   const [currentAuthType, setCurrentAuthType] = useState<string | null>(null);
 
-  const [{ value: secretForComponentOption }, , { setValue }] = useField<SecretForComponentOption>(
+  const [{ value: rawOptionValue }, , { setValue }] = useField<SecretForComponentOption>(
     'secretForComponentOption',
   );
+  const currentSecretForComponentOption = rawOptionValue ?? SecretForComponentOption.none;
 
   const selectedForm = React.useMemo(() => {
     const form = secretTypes.find((t) => t.label === currentType);
@@ -124,7 +125,12 @@ export const SecretTypeSubForm: React.FC<React.PropsWithChildren<unknown>> = () 
           setTimeout(() => validateForm());
           setCurrentType(type);
           setCurrentAuthType(null);
-          void setValue(null);
+          // Ensure the default value always works when loading the page or refreshing
+          // the secret type.
+          // If we would like to keep the option when we switch the secret type,
+          // we can get the secretForComponentOption from initial values and
+          // setValue(secretForComponentOption);
+          void setValue(SecretForComponentOption.none as SecretForComponentOption);
           if (type !== SecretTypeDropdownLabel.opaque) {
             resetKeyValues();
             name && isPartnerTask(name) && void setFieldValue('name', '');
@@ -179,7 +185,7 @@ export const SecretTypeSubForm: React.FC<React.PropsWithChildren<unknown>> = () 
       {/* Just for image pull secret and basic auth */}
       {shouldShowSecretLinkOptions && (
         <SecretLinkOptions
-          secretForComponentOption={secretForComponentOption}
+          secretForComponentOption={currentSecretForComponentOption}
           radioLabels={SecretLinkOptionLabels.default}
           onOptionChange={(option) => setValue(option)}
         />

--- a/src/components/Secrets/__tests___/SecretLinkOption.spec.tsx
+++ b/src/components/Secrets/__tests___/SecretLinkOption.spec.tsx
@@ -21,7 +21,7 @@ describe('SecretLinkOptions', () => {
     jest.clearAllMocks();
   });
 
-  it('renders the radio group with correct options', () => {
+  it('renders the radio group with correct options for adding secret page', () => {
     render(
       <TestWrapper>
         <SecretLinkOptions
@@ -33,10 +33,26 @@ describe('SecretLinkOptions', () => {
     );
 
     expect(screen.getByText('Link secret options')).toBeInTheDocument();
-    expect(
-      screen.getByLabelText('All existing and future components in the namespace'),
-    ).toBeInTheDocument();
-    expect(screen.getByLabelText('Select components in the namespace')).toBeInTheDocument();
+    expect(screen.getByLabelText(SecretLinkOptionLabels.default.none)).toBeInTheDocument();
+    expect(screen.getByLabelText(SecretLinkOptionLabels.default.all)).toBeInTheDocument();
+    expect(screen.getByLabelText(SecretLinkOptionLabels.default.partial)).toBeInTheDocument();
+  });
+
+  it('renders the radio group with correct options for importing secret page', () => {
+    render(
+      <TestWrapper>
+        <SecretLinkOptions
+          secretForComponentOption={SecretForComponentOption.all}
+          onOptionChange={mockOnOptionChange}
+          radioLabels={SecretLinkOptionLabels.forImportSecret}
+        />
+      </TestWrapper>,
+    );
+
+    expect(screen.getByText('Link secret options')).toBeInTheDocument();
+    expect(screen.queryByText(SecretLinkOptionLabels.default.none)).toBeNull();
+    expect(screen.getByLabelText(SecretLinkOptionLabels.forImportSecret.all)).toBeInTheDocument();
+    expect(screen.getByLabelText(SecretLinkOptionLabels.forImportSecret.all)).toBeInTheDocument();
   });
 
   it('calls onOptionChange when a radio button is selected', () => {
@@ -52,6 +68,21 @@ describe('SecretLinkOptions', () => {
 
     fireEvent.click(screen.getByLabelText('Select components in the namespace'));
     expect(mockOnOptionChange).toHaveBeenCalledWith(SecretForComponentOption.partial);
+  });
+
+  it('calls onOptionChange with when option is selected', () => {
+    render(
+      <TestWrapper>
+        <SecretLinkOptions
+          secretForComponentOption={SecretForComponentOption.all}
+          onOptionChange={mockOnOptionChange}
+          radioLabels={SecretLinkOptionLabels.default}
+        />
+      </TestWrapper>,
+    );
+
+    fireEvent.click(screen.getByLabelText(SecretLinkOptionLabels.default.all));
+    expect(mockOnOptionChange).toHaveBeenCalledWith(SecretForComponentOption.all);
   });
 
   it('conditionally renders the ComponentSelector when "partial" option is selected', () => {

--- a/src/components/Secrets/utils/secret-utils.ts
+++ b/src/components/Secrets/utils/secret-utils.ts
@@ -26,6 +26,7 @@ export const isImagePullSecret = (secret: SecretKind): boolean => {
 };
 
 export enum SecretForComponentOption {
+  none = 'none',
   all = 'all',
   partial = 'partial',
 }

--- a/src/consts/secrets.ts
+++ b/src/consts/secrets.ts
@@ -8,6 +8,7 @@ export const MAX_ANNOTATION_LENGTH = 2048;
 export const LINKING_STATUS_ANNOTATION = 'konflux-ui/linking-secret-action-status';
 export const SecretLinkOptionLabels = {
   default: {
+    none: 'Do not link',
     all: 'All existing and future components in the namespace',
     partial: 'Select components in the namespace',
   },
@@ -18,3 +19,5 @@ export const SecretLinkOptionLabels = {
 } as const;
 export const IMPORT_SECRET_HELP_TEXT =
   'Keep your data secure by defining a build time secret. Secrets are stored at a namespace level so applications within namespace will have access to these secrets.';
+export const SECRET_LINK_OPTION_HELP_TEXT =
+  'Select an option to link this secret with your desired components in the namespace.';

--- a/src/utils/create-utils.ts
+++ b/src/utils/create-utils.ts
@@ -462,7 +462,10 @@ export const createSecretResourceWithLinkingComponents = async (
 
   if (!createdSecret || dryRun) return createdSecret;
 
-  if (values.secretForComponentOption) {
+  if (
+    values.secretForComponentOption &&
+    values.secretForComponentOption !== SecretForComponentOption.none
+  ) {
     void enqueueLinkingTask(
       secretResource,
       values.relatedComponents,


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/KFLUXUI-548

## Description
We need provide 'Do not link' to add secret page for secret link options. There is no change in import secret page.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
- Recording for the option:
[Kooha-2025-06-24-22-34-19.webm](https://github.com/user-attachments/assets/f04fe6df-3577-4492-85ff-06af3fbe46b3)

- Recording for adding & importing secrets to ensure there is no regression
[Kooha-2025-06-24-22-34-19.webm](https://github.com/user-attachments/assets/c2a76599-8fee-458f-abbd-7b35b315be5a)



## How to test or reproduce?
Just visit the add  & import secret page.


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->