### PR TITLE
fix(release): omit empty releaseNotes fields and add tests to prevent…

### DIFF
--- a/src/components/ReleaseService/ReleasePlan/TriggerRelease/__tests__/form-utils.spec.ts
+++ b/src/components/ReleaseService/ReleasePlan/TriggerRelease/__tests__/form-utils.spec.ts
@@ -116,4 +116,46 @@ describe('triggerReleasePlan', () => {
       }),
     );
   });
+
+  it('should omit empty fields from releaseNotes', async () => {
+    const result = await createRelease(
+      {
+        snapshot: 'test-snapshot',
+        releasePlan: 'test-releasePlan',
+        synopsis: '', // empty string
+        topic: '',
+        description: undefined, // undefined
+        solution: null, // null
+        references: [], // empty array
+        issues: [], // empty array
+        cves: [], // empty array
+        labels: [],
+      },
+      'test-ns',
+    );
+    // data should be omitted entirely
+    expect(result.spec.data).toBeUndefined();
+  });
+
+  it('should only include non-empty fields in releaseNotes', async () => {
+    const result = await createRelease(
+      {
+        snapshot: 'test-snapshot',
+        releasePlan: 'test-releasePlan',
+        synopsis: 'A summary',
+        topic: '',
+        description: '',
+        solution: undefined,
+        references: [],
+        issues: [{ id: 'ISSUE-1', source: 'src' }],
+        cves: [],
+        labels: [],
+      },
+      'test-ns',
+    );
+    expect(result.spec.data.releaseNotes).toEqual({
+      synopsis: 'A summary',
+      fixed: [{ id: 'ISSUE-1', source: 'src' }],
+    });
+  });
 });

--- a/src/components/ReleaseService/ReleasePlan/TriggerRelease/form-utils.ts
+++ b/src/components/ReleaseService/ReleasePlan/TriggerRelease/form-utils.ts
@@ -9,14 +9,14 @@ export enum ReleasePipelineLocation {
   target,
 }
 
-const getIssues = (issues): { id: string; source: string }[] => {
+export const getIssues = (issues): { id: string; source: string }[] => {
   return issues?.map((issue) => {
     return { id: issue.id, source: issue.source };
   });
 };
 
 // Create release notes object, filtering out empty values and ensuring required fields are present
-const createReleaseNotes = (values: {
+export const createReleaseNotes = (values: {
   issues?: object[];
   cves?: CVE[];
   references?: string[];

--- a/src/components/ReleaseService/ReleasePlan/TriggerRelease/form-utils.ts
+++ b/src/components/ReleaseService/ReleasePlan/TriggerRelease/form-utils.ts
@@ -1,7 +1,7 @@
 import * as yup from 'yup';
 import { K8sQueryCreateResource } from '../../../../k8s';
 import { ReleaseGroupVersionKind, ReleaseModel } from '../../../../models';
-import { CVE, ReleaseKind } from '../../../../types/coreBuildService';
+import { CVE, ReleaseKind, ReleaseSpec } from '../../../../types/coreBuildService';
 import { resourceNameYupValidation } from '../../../../utils/validation-utils';
 
 export enum ReleasePipelineLocation {
@@ -13,6 +13,66 @@ const getIssues = (issues): { id: string; source: string }[] => {
   return issues?.map((issue) => {
     return { id: issue.id, source: issue.source };
   });
+};
+
+// Create release notes object, filtering out empty values and ensuring required fields are present
+const createReleaseNotes = (values: {
+  issues?: object[];
+  cves?: CVE[];
+  references?: string[];
+  synopsis: string;
+  topic: string;
+  description?: string;
+  solution?: string;
+}) => {
+  const { issues, cves, references, synopsis, topic, description, solution } = values;
+
+  // Check if we have any required fields with values
+  const hasRequiredFields =
+    (synopsis && synopsis.trim()) ||
+    (description && description.trim()) ||
+    (issues && issues.length > 0) ||
+    (cves && cves.length > 0);
+
+  // If no required fields, return undefined
+  if (!hasRequiredFields) {
+    return undefined;
+  }
+
+  const releaseNotes: {
+    topic?: string;
+    description?: string;
+    synopsis?: string;
+    fixed?: { id: string; source: string }[];
+    cves?: CVE[];
+    solution?: string;
+    references?: string[];
+  } = {};
+
+  // Only add fields if they have values
+  if (synopsis && synopsis.trim()) {
+    releaseNotes.synopsis = synopsis;
+  }
+  if (description && description.trim()) {
+    releaseNotes.description = description;
+  }
+  if (topic && topic.trim()) {
+    releaseNotes.topic = topic;
+  }
+  if (solution && solution.trim()) {
+    releaseNotes.solution = solution;
+  }
+  if (references && references.length > 0) {
+    releaseNotes.references = references;
+  }
+  if (issues && issues.length > 0) {
+    releaseNotes.fixed = getIssues(issues);
+  }
+  if (cves && cves.length > 0) {
+    releaseNotes.cves = cves;
+  }
+
+  return releaseNotes;
 };
 
 export type TriggerReleaseFormValues = {
@@ -51,6 +111,20 @@ export const createRelease = async (values: TriggerReleaseFormValues, namespace:
     .filter((l) => !!l.key)
     .reduce((acc, o) => ({ ...acc, [o.key]: o.value }), {} as Record<string, string>);
 
+  // Create release notes object and filter out empty values
+  const releaseNotes = createReleaseNotes({
+    issues,
+    cves,
+    references,
+    synopsis,
+    topic,
+    description,
+    solution,
+  });
+
+  // Only include data if releaseNotes has any non-empty fields
+  const data = releaseNotes ? { releaseNotes } : undefined;
+
   const resource: ReleaseKind = {
     apiVersion: `${ReleaseGroupVersionKind.group}/${ReleaseGroupVersionKind.version}`,
     kind: ReleaseGroupVersionKind.kind,
@@ -64,17 +138,7 @@ export const createRelease = async (values: TriggerReleaseFormValues, namespace:
     spec: {
       releasePlan: rp,
       snapshot,
-      data: {
-        releaseNotes: {
-          fixed: getIssues(issues),
-          cves,
-          references,
-          synopsis,
-          topic,
-          description,
-          solution,
-        },
-      },
+      ...(data && { data: data as ReleaseSpec['data'] }),
     },
   };
   return await K8sQueryCreateResource({

--- a/src/components/ReleaseService/ReleasePlan/TriggerRelease/form-utils.ts
+++ b/src/components/ReleaseService/ReleasePlan/TriggerRelease/form-utils.ts
@@ -15,71 +15,52 @@ export const getIssues = (issues): { id: string; source: string }[] => {
   });
 };
 
-// Create release notes object, filtering out empty values and ensuring required fields are present
+// Create release notes object, filtering out empty values
 export const createReleaseNotes = (values: {
   issues?: object[];
   cves?: CVE[];
   references?: string[];
-  synopsis: string;
-  topic: string;
+  synopsis?: string;
+  topic?: string;
   description?: string;
   solution?: string;
 }) => {
   const { issues, cves, references, synopsis, topic, description, solution } = values;
 
-  // Check if we have any required fields with values
-  const hasRequiredFields =
-    (synopsis && synopsis.trim()) ||
-    (description && description.trim()) ||
-    (issues && issues.length > 0) ||
-    (cves && cves.length > 0);
-
-  // If no required fields, return undefined
-  if (!hasRequiredFields) {
-    return undefined;
-  }
-
-  const releaseNotes: {
-    topic?: string;
-    description?: string;
-    synopsis?: string;
-    fixed?: { id: string; source: string }[];
-    cves?: CVE[];
-    solution?: string;
-    references?: string[];
-  } = {};
+  const releaseNotes: NonNullable<ReleaseSpec['data']>['releaseNotes'] = {};
 
   // Only add fields if they have values
-  if (synopsis && synopsis.trim()) {
+  if (synopsis?.trim()) {
     releaseNotes.synopsis = synopsis;
   }
-  if (description && description.trim()) {
+  if (description?.trim()) {
     releaseNotes.description = description;
   }
-  if (topic && topic.trim()) {
+  if (topic?.trim()) {
     releaseNotes.topic = topic;
   }
-  if (solution && solution.trim()) {
+  if (solution?.trim()) {
     releaseNotes.solution = solution;
   }
-  if (references && references.length > 0) {
+  if (references?.length > 0) {
     releaseNotes.references = references;
   }
-  if (issues && issues.length > 0) {
+  if (issues?.length > 0) {
     releaseNotes.fixed = getIssues(issues);
   }
-  if (cves && cves.length > 0) {
+  if (cves?.length > 0) {
     releaseNotes.cves = cves;
   }
 
-  return releaseNotes;
+  // Return undefined if no fields were added
+  return Object.keys(releaseNotes).length > 0 ? releaseNotes : undefined;
 };
 
 export type TriggerReleaseFormValues = {
   releasePlan: string;
   snapshot: string;
-  synopsis: string;
-  topic: string;
+  synopsis?: string;
+  topic?: string;
   description?: string;
   solution?: string;
   references?: string[];

--- a/src/types/coreBuildService.ts
+++ b/src/types/coreBuildService.ts
@@ -98,10 +98,10 @@ export type ReleaseSpec = {
   data?: {
     releaseNotes?: {
       topic?: string;
-      description: string;
-      synopsis: string;
-      fixed: { id: string; source: string }[];
-      cves: CVE[];
+      description?: string;
+      synopsis?: string;
+      fixed?: { id: string; source: string }[];
+      cves?: CVE[];
       solution?: string;
       references?: string[];
     };


### PR DESCRIPTION
… regression (CI validation)


## Fixes 

When triggering a release and leaving empty fields on the releasePlan form, the release fails. Unfortunately it fails not at CR creation, but later in the pipeline. The CR create returns a 201 success, but empty keys and keys with empty strings break the release tasks.

This PR removes keys set to empty string and also empty keys from the release CR

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->