### PR TITLE
fix(KONFLUX-8863): fix the component link of the pipelinerun security tab

### DIFF
--- a/AI_authorized_emails.txt
+++ b/AI_authorized_emails.txt
@@ -10,4 +10,3 @@ marcin.michal02@gmail.com
 rakeshy2797@gmail.com
 sahilbudhwar143@gmail.com
 dehankarjanaki@gmail.com
-wlin@redhat.com

--- a/src/components/EnterpriseContract/EnterpriseContractTable/EnterpriseContractRow.tsx
+++ b/src/components/EnterpriseContract/EnterpriseContractTable/EnterpriseContractRow.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { Truncate } from '@patternfly/react-core';
-import { COMPONENT_LIST_PATH } from '@routes/paths';
+import { COMPONENT_DETAILS_PATH } from '@routes/paths';
 import { TableData } from '~/shared';
 import { useNamespace } from '~/shared/providers/Namespace';
 import { UIEnterpriseContractData } from '../types';
 import { getRuleStatus } from '../utils';
 import { EnterpriseContractTableColumnClasses } from './EnterpriseContractHeader';
-
 import './EnterpriceContractTable.scss';
 
 type EnterpriseContractRowType = {
@@ -16,7 +15,7 @@ type EnterpriseContractRowType = {
 
 const EnterpriseContractRow: React.FC<EnterpriseContractRowType> = ({ data }) => {
   const namespace = useNamespace();
-  const { appName } = useParams();
+  const { applicationName } = useParams();
   return (
     <>
       <TableData className={`${EnterpriseContractTableColumnClasses.rules} vertical-center-cell`}>
@@ -35,9 +34,10 @@ const EnterpriseContractRow: React.FC<EnterpriseContractRowType> = ({ data }) =>
         className={`${EnterpriseContractTableColumnClasses.component} vertical-center-cell`}
       >
         <Link
-          to={COMPONENT_LIST_PATH.createPath({
+          to={COMPONENT_DETAILS_PATH.createPath({
             workspaceName: namespace,
-            applicationName: appName,
+            applicationName: applicationName || '',
+            componentName: data.component,
           })}
         >
           {data.component}

--- a/src/components/EnterpriseContract/__tests__/SecurityEnterpriseContractTab.spec.tsx
+++ b/src/components/EnterpriseContract/__tests__/SecurityEnterpriseContractTab.spec.tsx
@@ -20,6 +20,15 @@ jest.mock('~/hooks/useSearchParam', () => ({
   useSearchParamBatch: () => mockUseSearchParamBatch(),
 }));
 
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({
+    namespace: 'my-ns',
+    applicationName: 'my-app',
+    pipelineRunName: 'dummy-1',
+  }),
+}));
+
 jest.mock('../../../shared/components/table/TableComponent', () => {
   return (props) => {
     const { data, filters, selected, match, kindObj } = props;
@@ -156,5 +165,28 @@ describe('SecurityEnterpriseContractTab', () => {
     expect(value[0].textContent).toBe('1');
     expect(value[1].textContent).toBe('0');
     expect(value[2].textContent).toBe('1');
+  });
+
+  it('should render links with correct appName and component Name', () => {
+    routerRenderer(securityEnterpriseContracts('dummy-1'));
+
+    const links = screen.getAllByRole('link');
+
+    // Ensure there is at least one link rendered
+    expect(links.length).toBeGreaterThan(0);
+
+    // Check that all relevant hrefs include expected params
+    // Only check the last two component links
+    const lastTwoLinks = links.slice(-2);
+    lastTwoLinks.forEach((link) => {
+      const href = link.getAttribute('href');
+      expect(href).toContain('my-app');
+      // Get the related component name
+      const expectedComponent = mockEnterpriseContractUIData[lastTwoLinks.indexOf(link)].component;
+      // Get the href component name
+      const hrefParts = href?.split('/');
+      const lastField = hrefParts?.[hrefParts.length - 1];
+      expect(lastField).toBe(expectedComponent);
+    });
   });
 });


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/KONFLUX-8863

## Description
The link of the pipelinerun security tab should be pointed to exact component


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

Without the patch:
![Screenshot From 2025-06-24 18-44-52](https://github.com/user-attachments/assets/1403f02e-dbd6-4dd5-9d87-3e19326005a0)

With the patch:
![Screenshot From 2025-06-24 18-44-37](https://github.com/user-attachments/assets/3b4035c2-9b12-4475-9dfd-c278da92429e)



## How to test or reproduce?
Find one integration pipelinerun and open the security tab, check the component links work well.


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->