### PR TITLE
fix(KFLUXUI-549): handle errors in SecretsListView

### DIFF
--- a/src/components/Secrets/SecretsListView/SecretsListView.tsx
+++ b/src/components/Secrets/SecretsListView/SecretsListView.tsx
@@ -4,7 +4,9 @@ import { Bullseye, EmptyStateBody, Spinner } from '@patternfly/react-core';
 import { SECRET_CREATE_PATH } from '@routes/paths';
 import { FilterContext } from '~/components/Filter/generic/FilterContext';
 import { BaseTextFilterToolbar } from '~/components/Filter/toolbars/BaseTextFIlterToolbar';
+import { HttpError } from '~/k8s/error';
 import { useDeepCompareMemoize } from '~/shared';
+import ErrorEmptyState from '~/shared/components/empty-state/ErrorEmptyState';
 import secretEmptyStateIcon from '../../../assets/secret.svg';
 import { useSecrets } from '../../../hooks/useSecrets';
 import { SecretModel } from '../../../models';
@@ -18,7 +20,7 @@ import SecretsList from './SecretsList';
 const SecretsListView: React.FC = () => {
   const namespace = useNamespace();
 
-  const [secrets, secretsLoaded] = useSecrets(namespace, true);
+  const [secrets, secretsLoaded, error] = useSecrets(namespace, true);
   const { filters: unparsedFilters, setFilters, onClearFilters } = React.useContext(FilterContext);
   const filters = useDeepCompareMemoize({
     name: unparsedFilters.name ? (unparsedFilters.name as string) : '',
@@ -74,6 +76,18 @@ const SecretsListView: React.FC = () => {
       </Bullseye>
     );
   }
+
+  if (error || secrets === undefined) {
+    const httpError = HttpError.fromCode(error ? (error as { code: number }).code : 404);
+    return (
+      <ErrorEmptyState
+        httpError={httpError}
+        title="Unable to load secrets"
+        body={httpError?.message.length ? httpError?.message : 'Something went wrong'}
+      />
+    );
+  }
+
   if (secrets.length === 0) return emptyState;
 
   return (

--- a/src/components/Secrets/__tests___/SecretsListView.spec.tsx
+++ b/src/components/Secrets/__tests___/SecretsListView.spec.tsx
@@ -106,6 +106,13 @@ describe('Secrets List With Components and Status', () => {
     expect(screen.queryByTestId('secrets-empty-state')).toBeInTheDocument();
   });
 
+  it('should render the error state if there is an error loading the secrets', () => {
+    useSecretsMock.mockReturnValue([[], true, Error()]);
+    render(SecretsList);
+    expect(screen.getByText('Unable to load secrets')).toBeInTheDocument();
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
   it('should render all the remote secrets in the namespace', () => {
     render(SecretsList);
 


### PR DESCRIPTION
Assisted-by: Cursor


## Fixes 
https://issues.redhat.com/browse/KFLUXUI-549

## Description
The SecretsListView page did not handle the error returned by the useSecrets hook, leading to accessing information that was possibly undefined.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [X] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->