### PR TITLE
fix(KFLUXUI-578): don't allow incomplete component relationships

### DIFF
--- a/src/components/ComponentRelation/__tests__/utils.spec.ts
+++ b/src/components/ComponentRelation/__tests__/utils.spec.ts
@@ -3,6 +3,7 @@ import {
   componentRelationValidationSchema,
   computeNudgeDataChanges,
   transformNudgeData,
+  toCustomBoolean,
 } from '../utils';
 
 describe('computeNudgeDataChanges', () => {
@@ -71,7 +72,7 @@ describe('componentRelationValidationSchema', () => {
   it('should validate yup schema', async () => {
     const values = {
       relations: [
-        { source: 'adf', nudgeType: ComponentRelationNudgeType.NUDGES, target: [] },
+        { source: 'adf', nudgeType: ComponentRelationNudgeType.NUDGES, target: ['a'] },
         { source: 'adf', nudgeType: ComponentRelationNudgeType.NUDGED_BY, target: ['b', 'c'] },
       ],
     };
@@ -94,5 +95,15 @@ describe('componentRelationValidationSchema', () => {
         relations: [{ source: 'adf', target: ['a'] }],
       }),
     ).rejects.toThrowError();
+  });
+});
+
+describe('toCustomBoolean', () => {
+  it('should use custom logic to convert value to boolean', () => {
+    expect(toCustomBoolean([])).toBe(false);
+    expect(toCustomBoolean(['a'])).toBe(true);
+    expect(toCustomBoolean('a')).toBe(true);
+    expect(toCustomBoolean(null)).toBe(false);
+    expect(toCustomBoolean(undefined)).toBe(false);
   });
 });

--- a/src/components/ComponentRelation/utils.ts
+++ b/src/components/ComponentRelation/utils.ts
@@ -11,6 +11,15 @@ import {
 
 export const DUPLICATE_RELATONSHIP = 'duplicate-component-relationship';
 
+export const toCustomBoolean = (value: unknown) => {
+  // Treat empty array as false
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+
+  return !!value;
+};
+
 export const componentRelationValidationSchema = yup.mixed().test(
   (values: ComponentRelationFormikValue) =>
     yup
@@ -25,13 +34,16 @@ export const componentRelationValidationSchema = yup.mixed().test(
                 source: yup.string(),
 
                 nudgeType: yup.string().required(),
-                target: yup.array().of(yup.string()).required().min(0),
+                target: yup.array().of(yup.string()),
               })
               .test('duplicate-relation-test', DUPLICATE_RELATONSHIP, (value) => {
                 const filteredValue = values.relations.filter(
                   (val) => val.source === value.source && val.nudgeType === value.nudgeType,
                 );
                 return filteredValue.length < 2;
+              })
+              .test('incomplete-relation-test', (value) => {
+                return toCustomBoolean(value.source) === toCustomBoolean(value.target);
               }),
           )
           .required()


### PR DESCRIPTION
Assisted-by: Cursor


## Fixes 
https://issues.redhat.com/browse/KFLUXUI-578


## Description
It was possible for a user to create an incomplete component relationship, only specifying the source and not the target or wise versa. Due to how the form for adding a new relationship works (there is always at least one, empty relationship), the schema is valid only if the relationships is fully empty or fully defined.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [X] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
Before:

https://github.com/user-attachments/assets/1947f320-6bfb-4057-b4df-7f289cb01d69


After:

https://github.com/user-attachments/assets/9d1acc46-296d-481f-ae06-90db95a093c2




## How to test or reproduce?
Go to the application page, click the `Actions` button and click `Define component relationships`. Select only the source and leave the target blank.

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

