### PR TITLE
KONFLUX-9107: [PLR rerun] update logic to handle "tenant", "managed" and "final" run types

### DIFF
--- a/src/consts/pipelinerun.ts
+++ b/src/consts/pipelinerun.ts
@@ -40,6 +40,9 @@ export enum PipelineRunType {
   BUILD = 'build',
   RELEASE = 'release',
   TEST = 'test',
+  TENANT = 'tenant',
+  MANAGED = 'managed',
+  FINAL = 'final',
 }
 
 export enum PipelineRunEventType {


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

Fixes https://issues.redhat.com/browse/KONFLUX-9107

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In this PR we're updating the pipeline run rerun logic to account for all possible `PipelineRunType` values, ensuring correct behavior for new types such as `'tenant'`, `'managed'` and `'final'`.

**P.S. I don't have any examples of a PLR with the "final" type, so there won't be a visual reference here. ☕️**

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

1. Before ("rerun" button was active for "tenant" and "managed" build types, even though it would not work)

1.1. managed:

https://github.com/user-attachments/assets/40270acd-213f-4682-8b2a-d0ddedb9f57b

1.2. tenant:

https://github.com/user-attachments/assets/ad2a12a8-c748-4dd2-a9fa-21dba53a6580

2. After ("rerun" button is inactive and it shows an explanatory message in the tooltip: `"Cannot re-run pipeline run for the type X"`)

2.1. managed:

![plr-rerun-MANAGED-FIX](https://github.com/user-attachments/assets/e348dd16-9505-4409-8b62-29ff186c99f4)

2.2. tenant:

![plr-rerun-TENANT-FIX](https://github.com/user-attachments/assets/20a240ea-6476-4387-b882-765a8d84a67b)

3. regular "push build" continues working as expected:

https://github.com/user-attachments/assets/a08e8f52-c324-4448-824e-cdf7f85d6ce6

4. regular "test build" continues working as expected:

https://github.com/user-attachments/assets/7458156c-9934-4562-9743-2033c9d5703b

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer messaging and disabled state for rerun actions on pipeline runs labeled as "tenant", "managed", "release", and "final" types.
  * Tooltips now indicate when rerun is not supported for specific pipeline run types.

* **Bug Fixes**
  * Improved consistency and clarity of rerun action availability and tooltips across different pipeline run types.

* **Tests**
  * Expanded test coverage to verify rerun action disabling and tooltip messages for additional pipeline run types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->