### PR TITLE
KFLUXUI-594 [PLR actions] keep users on integration tests / snapshots page after test rerun

### DIFF
--- a/src/components/Commits/CommitDetails/tabs/__tests__/CommitsPipelineRunTab.spec.tsx
+++ b/src/components/Commits/CommitDetails/tabs/__tests__/CommitsPipelineRunTab.spec.tsx
@@ -34,6 +34,7 @@ jest.mock('react-router-dom', () => ({
   Link: (props) => <a href={props.to}>{props.children}</a>,
   useNavigate: jest.fn(),
   useParams: jest.fn(),
+  useLocation: jest.fn(() => ({ pathname: '/ns/test-ns' })),
 }));
 jest.mock('../../../../../hooks/useTektonResults');
 jest.mock('../../../../../hooks/usePipelineRuns', () => ({

--- a/src/components/PipelineRun/PipelineRunListView/__tests__/PipelineRunListRow.spec.tsx
+++ b/src/components/PipelineRun/PipelineRunListView/__tests__/PipelineRunListRow.spec.tsx
@@ -12,6 +12,7 @@ jest.mock('react-router-dom', () => {
     useNavigate: () => jest.fn(),
     Link: (props) => <a href={props.to}>{props.children}</a>,
     useSearchParams: jest.fn(),
+    useLocation: jest.fn(() => ({ pathname: '/ns/test-ns' })),
   };
 });
 

--- a/src/components/PipelineRun/PipelineRunListView/__tests__/PipelineRunListView.spec.tsx
+++ b/src/components/PipelineRun/PipelineRunListView/__tests__/PipelineRunListView.spec.tsx
@@ -46,6 +46,7 @@ jest.mock('react-router-dom', () => {
     ...actual,
     Link: (props) => <a href={props.to}>{props.children}</a>,
     useNavigate: jest.fn(),
+    useLocation: jest.fn(() => ({ pathname: '/ns/test-ns' })),
   };
 });
 

--- a/src/components/PipelineRun/PipelineRunListView/pipelinerun-actions.tsx
+++ b/src/components/PipelineRun/PipelineRunListView/pipelinerun-actions.tsx
@@ -61,6 +61,7 @@ export const usePipelinererunAction = (pipelineRun: PipelineRunKind): RerunActio
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const isIntegrationTestsPage = pathname?.includes('integrationtests') ?? false;
+  const isSnapshotsPage = pathname?.includes('snapshots') ?? false;
   const namespace = useNamespace();
   const [canPatchComponent] = useAccessReviewForModel(ComponentModel, 'patch');
   const [canPatchSnapshot] = useAccessReviewForModel(SnapshotModel, 'patch');
@@ -104,6 +105,7 @@ export const usePipelinererunAction = (pipelineRun: PipelineRunKind): RerunActio
           ...defaultEmptyAction,
           cta: () =>
             startNewBuild(component).then(() => {
+              if (isSnapshotsPage) return;
               navigate(
                 `${PIPELINE_RUNS_LIST_PATH.createPath({
                   workspaceName: namespace,
@@ -128,7 +130,7 @@ export const usePipelinererunAction = (pipelineRun: PipelineRunKind): RerunActio
           ...defaultEmptyAction,
           cta: () =>
             rerunTestPipeline(snapshot, scenario).then(() => {
-              if (isIntegrationTestsPage) return;
+              if (isIntegrationTestsPage || isSnapshotsPage) return;
               const componentName = snapshot.metadata.labels?.[SnapshotLabels.COMPONENT];
               navigate(
                 `${PIPELINE_RUNS_LIST_PATH.createPath({
@@ -159,17 +161,18 @@ export const usePipelinererunAction = (pipelineRun: PipelineRunKind): RerunActio
   }, [
     canPatchComponent,
     canPatchSnapshot,
-    component,
-    componentError,
-    componentLoaded,
-    isPushBuildType,
-    namespace,
-    navigate,
     runType,
-    scenario,
-    isIntegrationTestsPage,
+    isPushBuildType,
+    componentLoaded,
+    componentError,
+    component,
+    navigate,
+    namespace,
     snapshot,
+    scenario,
     snapshotError,
+    isIntegrationTestsPage,
+    isSnapshotsPage,
   ]);
 };
 

--- a/src/components/PipelineRun/PipelineRunListView/pipelinerun-actions.tsx
+++ b/src/components/PipelineRun/PipelineRunListView/pipelinerun-actions.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useSnapshot } from '~/hooks/useSnapshots';
 import { PIPELINE_RUNS_LIST_PATH } from '~/routes/paths';
 import { useNamespace } from '~/shared/providers/Namespace';
@@ -59,6 +59,8 @@ const defaultEmptyAction: RerunActionReturnType = {
 
 export const usePipelinererunAction = (pipelineRun: PipelineRunKind): RerunActionReturnType => {
   const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const isIntegrationTestsPage = pathname?.includes('integrationtests') ?? false;
   const namespace = useNamespace();
   const [canPatchComponent] = useAccessReviewForModel(ComponentModel, 'patch');
   const [canPatchSnapshot] = useAccessReviewForModel(SnapshotModel, 'patch');
@@ -126,6 +128,7 @@ export const usePipelinererunAction = (pipelineRun: PipelineRunKind): RerunActio
           ...defaultEmptyAction,
           cta: () =>
             rerunTestPipeline(snapshot, scenario).then(() => {
+              if (isIntegrationTestsPage) return;
               const componentName = snapshot.metadata.labels?.[SnapshotLabels.COMPONENT];
               navigate(
                 `${PIPELINE_RUNS_LIST_PATH.createPath({
@@ -164,6 +167,7 @@ export const usePipelinererunAction = (pipelineRun: PipelineRunKind): RerunActio
     navigate,
     runType,
     scenario,
+    isIntegrationTestsPage,
     snapshot,
     snapshotError,
   ]);

--- a/src/components/SnapshotDetails/tabs/__tests__/SnapshotPipelineRunsList.spec.tsx
+++ b/src/components/SnapshotDetails/tabs/__tests__/SnapshotPipelineRunsList.spec.tsx
@@ -34,6 +34,7 @@ jest.mock('../../../../hooks/useScanResults', () => ({
 jest.mock('react-router-dom', () => ({
   Link: (props) => <a href={props.to}>{props.children}</a>,
   useNavigate: jest.fn(),
+  useLocation: jest.fn(() => ({ pathname: '/ns/test-ns' })),
 }));
 
 jest.mock('../../../../hooks/useSearchParam', () => ({

--- a/src/components/SnapshotDetails/tabs/__tests__/SnapshotPipelineRunsTab.spec.tsx
+++ b/src/components/SnapshotDetails/tabs/__tests__/SnapshotPipelineRunsTab.spec.tsx
@@ -46,6 +46,7 @@ jest.mock('react-router-dom', () => {
     Link: (props) => <a href={props.to}>{props.children}</a>,
     useNavigate: jest.fn(),
     useParams: jest.fn(),
+    useLocation: jest.fn(() => ({ pathname: '/ns/test-ns' })),
   };
 });
 


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

Fixes https://issues.redhat.com/browse/KFLUXUI-594

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In this PR we're updating the `usePipelinererunAction` hook to skip automatic navigation to pipeline runs page when rerunning integration tests from the integration tests tab OR re-running PLRs from the snapshots tab, allowing users to stay in context and see results on the same page.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before (Integration tests tab):

https://github.com/user-attachments/assets/f139785e-0dde-449a-8c3a-23242e31c4b7

After (Integration tests tab):

https://github.com/user-attachments/assets/04c8c193-73ba-4392-adfb-941854c1c80a

Before (Snapshots tab):

https://github.com/user-attachments/assets/54b429f5-db71-4494-b9cb-cfae40579acc

After (Snapshots tab):

https://github.com/user-attachments/assets/8d80b900-3fc7-4ff7-8053-e528fa81a46f

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

1. Integration tests tab

* go to Integration Tests tab
* open some of the integration tests
* go to "Pipeline runs" tab
* re-run some of the tests
* you should stay in the same page and the new test PLR should show up as the top row in the table
* ☕ 

2. Snapshots tab

* go to Snapshots tab
* open some of the snapshots
* go to "Pipeline runs" tab
* re-run some of the PLRs (either Build or Test)
* you should stay in the same page and the new test PLR should show up as the top row in the table
* 🍫 

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of navigation behavior after rerunning test pipelines, ensuring correct handling when on integration tests and snapshots pages.

* **Tests**
  * Updated multiple test suites to mock the current location, providing consistent pathname values for more stable and predictable test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->