### PR TITLE
fix: breadcrumb link fix

### DIFF
--- a/src/components/SnapshotDetails/SnapshotDetailsView.tsx
+++ b/src/components/SnapshotDetails/SnapshotDetailsView.tsx
@@ -5,7 +5,7 @@ import { SnapshotLabels } from '../../consts/snapshots';
 import { usePipelineRun } from '../../hooks/usePipelineRuns';
 import { useSnapshot } from '../../hooks/useSnapshots';
 import { HttpError } from '../../k8s/error';
-import { SNAPSHOT_DETAILS_PATH } from '../../routes/paths';
+import { SNAPSHOT_DETAILS_PATH, SNAPSHOT_LIST_PATH } from '../../routes/paths';
 import { RouterParams } from '../../routes/utils';
 import ErrorEmptyState from '../../shared/components/empty-state/ErrorEmptyState';
 import { Timestamp } from '../../shared/components/timestamp/Timestamp';
@@ -66,7 +66,10 @@ const SnapshotDetailsView: React.FC = () => {
         breadcrumbs={[
           ...applicationBreadcrumbs,
           {
-            path: `#`,
+            path: SNAPSHOT_LIST_PATH.createPath({
+              workspaceName: namespace,
+              applicationName,
+            }),
             name: 'Snapshots',
           },
           {


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
When in Snapshot details view breadcrumb `Snapshots` redirects to [https://localhost:8080/ns/<tenant>/applications/<applicatiom>/snapshots/<application>-dk6p9](https://localhost:8080/ns/<tenant>/applications/<applicatiom>/snapshots/<application>-dk6p9 ) instead of [https://localhost:8080/ns/<tenant>/applications/<applicatiom>/snapshots](https://localhost:8080/ns/<tenant>/applications/<applicatiom>/snapshots)

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
Before:
![Screenshot 2025-07-30 at 15 38 42](https://github.com/user-attachments/assets/2ca33553-cc8e-4bb8-81ea-b70f96cda582)

After: 
![Screenshot 2025-07-30 at 15 37 54](https://github.com/user-attachments/assets/54935433-ff7c-4569-bd06-7bca603add55)


## How to test or reproduce?
Open the Snapshots detail page of one snapshot and see where breadcrumbs points to.


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [x] Safari
- [ ] Edge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the navigation breadcrumbs in the Snapshot Details view to use dynamic links for improved navigation to the snapshots list page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->