### PR TITLE
KFLUXUI-642 [IntegrationTestScenario] preserve resolverRef properties when editing integration tests

### DIFF
--- a/src/components/IntegrationTests/IntegrationTestForm/utils/__tests__/create-utils.spec.ts
+++ b/src/components/IntegrationTests/IntegrationTestForm/utils/__tests__/create-utils.spec.ts
@@ -1,4 +1,5 @@
 import { IntegrationTestScenarioModel } from '../../../../../models';
+import { ResolverType } from '../../../../../types/coreBuildService';
 import { createK8sUtilMock } from '../../../../../utils/test-utils';
 import { MockIntegrationTestsWithGit } from '../../../IntegrationTestsListView/__data__/mock-integration-tests';
 import {
@@ -11,6 +12,7 @@ import { IntegrationTestAnnotations, IntegrationTestLabels } from '../../types';
 import {
   ResolverRefParams,
   createIntegrationTest,
+  editIntegrationTest,
   getLabelForParam,
   getURLForParam,
   formatParams,
@@ -18,6 +20,7 @@ import {
 } from '../create-utils';
 
 const createResourceMock = createK8sUtilMock('K8sQueryCreateResource');
+const updateResourceMock = createK8sUtilMock('K8sQueryUpdateResource');
 
 const integrationTestData = {
   apiVersion: `${IntegrationTestScenarioModel.apiGroup}/${IntegrationTestScenarioModel.apiVersion}`,
@@ -263,5 +266,74 @@ describe('Create Utils formatContexts', () => {
       { name: 'orange', description: 'an orange' },
     ]);
     expect(formattedContexts.length).toBe(3);
+  });
+});
+
+describe('Edit Integration Test Utils', () => {
+  const mockIntegrationTest = {
+    apiVersion: 'appstudio.redhat.com/v1beta1',
+    kind: 'IntegrationTestScenario',
+    metadata: {
+      name: 'existing-test',
+      namespace: 'test-ns',
+      resourceVersion: '12345',
+      uid: 'abc-123',
+    },
+    spec: {
+      application: 'Test Application',
+      resolverRef: {
+        resolver: ResolverType.GIT,
+        params: [
+          { name: 'url', value: 'old-url' },
+          { name: 'revision', value: 'old-revision' },
+          { name: 'pathInRepo', value: 'old-path' },
+        ],
+        resourceKind: 'pipelinerun',
+      },
+      params: null,
+      contexts: null,
+    },
+  };
+
+  it('Should preserve existing resolverRef properties when editing', async () => {
+    updateResourceMock.mockImplementation(({ resource }) => resource);
+    const resource = await editIntegrationTest(mockIntegrationTest, {
+      name: 'existing-test',
+      revision: 'new-revision',
+      url: 'new-url',
+      path: 'new-path',
+      optional: true,
+      environmentName: 'development',
+      environmentType: 'POC',
+    });
+
+    expect(resource.spec.resolverRef.resolver).toBe('git');
+    expect(resource.spec.resolverRef.params).toEqual([
+      { name: 'url', value: 'new-url' },
+      { name: 'revision', value: 'new-revision' },
+      { name: 'pathInRepo', value: 'new-path' },
+    ]);
+    expect(resource.spec.resolverRef.resourceKind).toEqual('pipelinerun');
+  });
+
+  it('Should update integration test with new values while preserving metadata', async () => {
+    updateResourceMock.mockImplementation(({ resource }) => resource);
+    const resource = await editIntegrationTest(mockIntegrationTest, {
+      name: 'existing-test',
+      revision: 'updated-revision',
+      url: 'updated-url',
+      path: 'updated-path',
+      optional: false,
+    });
+
+    expect(resource.metadata.name).toBe('existing-test');
+    expect(resource.metadata.namespace).toBe('test-ns');
+    expect(resource.metadata.resourceVersion).toBe('12345');
+    expect(resource.metadata.uid).toBe('abc-123');
+    expect(resource.spec.resolverRef.params).toEqual([
+      { name: 'url', value: 'updated-url' },
+      { name: 'revision', value: 'updated-revision' },
+      { name: 'pathInRepo', value: 'updated-path' },
+    ]);
   });
 });

--- a/src/components/IntegrationTests/IntegrationTestForm/utils/create-utils.ts
+++ b/src/components/IntegrationTests/IntegrationTestForm/utils/create-utils.ts
@@ -79,6 +79,7 @@ export const editIntegrationTest = (
             }
           : null,
       resolverRef: {
+        ...integrationTest.spec.resolverRef,
         resolver: ResolverType.GIT,
         params: [
           { name: ResolverRefParams.URL, value: url },

--- a/src/components/IntegrationTests/__tests__/EditContextsModal.spec.tsx
+++ b/src/components/IntegrationTests/__tests__/EditContextsModal.spec.tsx
@@ -108,7 +108,7 @@ describe('EditContextsModal', () => {
       expect.objectContaining({
         model: {
           apiGroup: 'appstudio.redhat.com',
-          apiVersion: 'v1beta1',
+          apiVersion: 'v1beta2',
           kind: 'IntegrationTestScenario',
           namespaced: true,
           plural: 'integrationtestscenarios',

--- a/src/models/integration-test-scenario.ts
+++ b/src/models/integration-test-scenario.ts
@@ -2,7 +2,7 @@ import { K8sModelCommon, K8sGroupVersionKind } from '../types/k8s';
 
 export const IntegrationTestScenarioModel: K8sModelCommon = {
   apiGroup: 'appstudio.redhat.com',
-  apiVersion: 'v1beta1',
+  apiVersion: 'v1beta2',
   kind: 'IntegrationTestScenario',
   plural: 'integrationtestscenarios',
   namespaced: true,

--- a/src/types/coreBuildService.ts
+++ b/src/types/coreBuildService.ts
@@ -22,6 +22,7 @@ export type IntegrationTestScenarioSpec = {
   resolverRef?: {
     resolver: ResolverType;
     params: ResolverParam[];
+    resourceKind?: string;
   };
   pipeline?: string;
   bundle?: string;


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

Fixes https://issues.redhat.com/browse/KFLUXUI-642

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When editing an `IntegrationTestScenario`, the existing `spec.resolverRef` properties were being overwritten, causing loss of data like `resourceKind`.

This fix preserves existing resolverRef properties by spreading the original object before applying updates.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

https://github.com/user-attachments/assets/c2c27c31-d02e-4fc2-8b5a-2b6771330d0b

After:

https://github.com/user-attachments/assets/5882cdb5-f54e-4c32-9b94-2d9a2d225ee2

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

You might be able to test it in different ways, I did it by checking `IntegrationTestScenario` yaml details in the OpenShift console.

* [OpenShift Console] in the details page of your integration test scenario in the OpenShift console, update the `resourceKind` field to be `pipelinerun`
[Konflux UI]
* go to "Integration tests" tab
* open one of the listed integration tests; click on the "three dots"; click on "Edit"
* in the "Edit" page, edit any field and save changes
[OpenShift Console]
* reload the integration test scenario yaml
* notice that the `resourceKind` field should remain unchanged (`pipelinerun`)
* :coffee:

If it was confusing, I apologize. Maybe the screen-records added above might be more clarifying :)

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an optional resource kind field in integration test configurations.

* **Bug Fixes**
  * Improved editing of integration tests to ensure all existing resolver reference properties are preserved and updated correctly.

* **Tests**
  * Expanded test coverage for integration test editing, verifying proper handling of resolver references and metadata.
  * Updated tests to reflect the API version change to v1beta2 for integration test scenarios.

* **Chores**
  * Updated the API version for integration test scenarios to v1beta2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->