### PR TITLE
KFLUXUI-653: [ReleasePlanAdmission] replace auto-release with block-releases

### DIFF
--- a/src/components/ReleaseService/ReleasePlanAdmission/ReleasePlanAdmissionListHeader.tsx
+++ b/src/components/ReleaseService/ReleasePlanAdmission/ReleasePlanAdmissionListHeader.tsx
@@ -2,7 +2,7 @@ export const releasesPlanAdmissionTableColumnClasses = {
   name: 'pf-m-width-20 wrap-column',
   application: 'pf-m-width-30',
   source: 'pf-m-width-20',
-  autoRelease: 'pf-m-width-20',
+  blockReleases: 'pf-m-width-20',
   kebab: 'pf-c-table__action',
 };
 
@@ -21,8 +21,8 @@ const ReleasePlanAdmissionListHeader = () => {
       props: { className: releasesPlanAdmissionTableColumnClasses.source },
     },
     {
-      title: 'Auto release',
-      props: { className: releasesPlanAdmissionTableColumnClasses.autoRelease },
+      title: 'Block releases',
+      props: { className: releasesPlanAdmissionTableColumnClasses.blockReleases },
     },
     {
       title: ' ',

--- a/src/components/ReleaseService/ReleasePlanAdmission/ReleasePlanAdmissionListRow.tsx
+++ b/src/components/ReleaseService/ReleasePlanAdmission/ReleasePlanAdmissionListRow.tsx
@@ -26,8 +26,8 @@ const ReleasePlanAdmissionListRow: React.FC<
       <TableData className={releasesPlanAdmissionTableColumnClasses.source}>
         {obj.spec.origin ?? '-'}
       </TableData>
-      <TableData className={releasesPlanAdmissionTableColumnClasses.autoRelease}>
-        {capitalize(obj.metadata.labels?.['release.appstudio.openshift.io/auto-release'] ?? '-')}
+      <TableData className={releasesPlanAdmissionTableColumnClasses.blockReleases}>
+        {capitalize(obj.metadata.labels?.['release.appstudio.openshift.io/block-releases'] ?? '-')}
       </TableData>
       <TableData className={releasesPlanAdmissionTableColumnClasses.kebab}>
         <ActionMenu actions={actions} />

--- a/src/components/ReleaseService/ReleasePlanAdmission/__data__/release-plan-admission.mock.ts
+++ b/src/components/ReleaseService/ReleasePlanAdmission/__data__/release-plan-admission.mock.ts
@@ -6,7 +6,7 @@ export const mockReleasePlanAdmissions = [
       creationTimestamp: '2023-08-03T15:08:32Z',
       generation: 1,
       labels: {
-        'release.appstudio.openshift.io/auto-release': 'true',
+        'release.appstudio.openshift.io/block-releases': 'true',
       },
       name: 'test-rpa',
       namespace: 'rorai-tenant',
@@ -27,7 +27,7 @@ export const mockReleasePlanAdmissions = [
       creationTimestamp: '2023-08-03T15:08:33Z',
       generation: 1,
       labels: {
-        'release.appstudio.openshift.io/auto-release': 'true',
+        'release.appstudio.openshift.io/block-releases': 'false',
       },
       name: 'test-rpa-2',
       namespace: 'rorai-tenant',

--- a/src/components/ReleaseService/ReleasePlanAdmission/__tests__/ReleasePlanAdmissionListRow.spec.tsx
+++ b/src/components/ReleaseService/ReleasePlanAdmission/__tests__/ReleasePlanAdmissionListRow.spec.tsx
@@ -42,4 +42,105 @@ describe('ReleasePlanAdmissionListRow', () => {
     expect(cells[2].innerHTML).toBe('sbudhwar-1-tenant');
     expect(cells[3].innerHTML).toBe('True');
   });
+
+  it('should display "True" when block-releases label is set to true', () => {
+    const wrapper = render(
+      <ReleasePlanAdmissionListRow obj={mockReleasePlanAdmission} columns={[]} />,
+      {
+        container: document.createElement('tr'),
+      },
+    );
+    const cells = wrapper.container.getElementsByTagName('td');
+
+    expect(cells[3].innerHTML).toBe('True');
+  });
+
+  it('should display "False" when block-releases label is set to false', () => {
+    const mockRPAWithBlockReleasesFalse = {
+      ...mockReleasePlanAdmission,
+      metadata: {
+        ...mockReleasePlanAdmission.metadata,
+        labels: {
+          'release.appstudio.openshift.io/block-releases': 'false',
+        },
+      },
+      application: mockApplicationWithDisplayName,
+    };
+
+    const wrapper = render(
+      <ReleasePlanAdmissionListRow obj={mockRPAWithBlockReleasesFalse} columns={[]} />,
+      {
+        container: document.createElement('tr'),
+      },
+    );
+    const cells = wrapper.container.getElementsByTagName('td');
+
+    expect(cells[3].innerHTML).toBe('False');
+  });
+
+  it('should display "-" when block-releases label is missing', () => {
+    const mockRPAWithoutBlockReleasesLabel = {
+      ...mockReleasePlanAdmission,
+      metadata: {
+        ...mockReleasePlanAdmission.metadata,
+        labels: {},
+      },
+      application: mockApplicationWithDisplayName,
+    };
+
+    const wrapper = render(
+      <ReleasePlanAdmissionListRow obj={mockRPAWithoutBlockReleasesLabel} columns={[]} />,
+      {
+        container: document.createElement('tr'),
+      },
+    );
+    const cells = wrapper.container.getElementsByTagName('td');
+
+    expect(cells[3].innerHTML).toBe('-');
+  });
+
+  it('should display "-" when labels object is undefined', () => {
+    const mockRPAWithoutLabels = {
+      ...mockReleasePlanAdmission,
+      metadata: {
+        ...mockReleasePlanAdmission.metadata,
+        labels: undefined,
+      },
+      application: mockApplicationWithDisplayName,
+    };
+
+    const wrapper = render(
+      <ReleasePlanAdmissionListRow obj={mockRPAWithoutLabels} columns={[]} />,
+      {
+        container: document.createElement('tr'),
+      },
+    );
+    const cells = wrapper.container.getElementsByTagName('td');
+
+    expect(cells[3].innerHTML).toBe('-');
+  });
+
+  it('should display "-" when labels exist but block-releases label is missing', () => {
+    const mockRPAWithOtherLabels = {
+      ...mockReleasePlanAdmission,
+      metadata: {
+        ...mockReleasePlanAdmission.metadata,
+        labels: {
+          'some.other.label': 'value',
+          'another.label': 'another-value',
+        },
+      },
+      application: mockApplicationWithDisplayName,
+    };
+
+    const wrapper = render(
+      <ReleasePlanAdmissionListRow obj={mockRPAWithOtherLabels} columns={[]} />,
+      {
+        container: document.createElement('tr'),
+      },
+    );
+    const cells = wrapper.container.getElementsByTagName('td');
+
+    expect(cells[3].innerHTML).toBe('-');
+  });
 });


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

Fixes https://issues.redhat.com/browse/KFLUXUI-653

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In this PR we're replacing RPA's `auto-release` label with `block-releases`.

The main changes are:

- updated `ReleasePlanAdmissionListRow` to display "Block releases" column
- added tests for the new block-releases label functionality
- updated mock data to include block-releases label examples

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

![RPA-auto-release](https://github.com/user-attachments/assets/37f81838-f6d9-4e9d-a8eb-c61e63d42b20)

After:

![RPA-block-releases](https://github.com/user-attachments/assets/81699191-7899-45b6-a3ad-1ac2e56916da)

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

* you can follow the docs to create a new RPA that contains the `block-releases` label: https://konflux-ci.dev/docs/releasing/create-release-plan-admission/#creating-a-releaseplanadmission-object
* go to Releases dashboard
* navigate to "Release Plan Admission" tab
* notice that the "Auto release" column was replaced with "Block releases"
* :coffee:

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the column header and label from "Auto release" to "Block releases" in the release plan admission list for improved clarity.

* **Tests**
  * Added new test cases to verify correct display of "block-releases" label values under various scenarios.

* **Chores**
  * Updated mock data to use the new "block-releases" label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->