### PR TITLE
KFLUXUI-683: [Add Component Page] Fix crash when 'integrations' object is 'undefined'

### DIFF
--- a/src/hooks/__tests__/useUIInstance.spec.ts
+++ b/src/hooks/__tests__/useUIInstance.spec.ts
@@ -10,6 +10,8 @@ import {
   useBombinoUrl,
   useUIInstance,
   useInstanceVisibility,
+  useApplicationUrl,
+  useNotifications,
 } from '../useUIInstance';
 
 jest.mock('../useKonfluxPublicInfo');
@@ -232,6 +234,236 @@ describe('useBombinoUrl', () => {
 
     const { result } = renderHook(() => useBombinoUrl());
     expect(result.current).toBe('https://custom-bombino-url.com');
+  });
+
+  it('should handle undefined integrations gracefully in useBombinoUrl', () => {
+    (useKonfluxPublicInfo as jest.Mock).mockReturnValue([
+      {
+        integrations: undefined,
+      },
+      true,
+      null,
+    ]);
+
+    const { result } = renderHook(() => useBombinoUrl());
+    expect(result.current).toBe(undefined);
+  });
+
+  it('should handle undefined image_controller gracefully in useBombinoUrl', () => {
+    (useKonfluxPublicInfo as jest.Mock).mockReturnValue([
+      {
+        integrations: {
+          image_controller: undefined,
+        },
+      },
+      true,
+      null,
+    ]);
+
+    const { result } = renderHook(() => useBombinoUrl());
+    expect(result.current).toBe(undefined);
+  });
+
+  it('should return empty string when no matching notification is found', () => {
+    (useKonfluxPublicInfo as jest.Mock).mockReturnValue([
+      {
+        integrations: {
+          image_controller: {
+            notifications: [
+              {
+                title: 'Different-Title',
+                event: 'repo_push',
+                config: { url: 'https://different-url.com' },
+              },
+            ],
+          },
+        },
+      },
+      true,
+      null,
+    ]);
+
+    const { result } = renderHook(() => useBombinoUrl());
+    expect(result.current).toBe('');
+  });
+
+  it('should return undefined when data is loading in useBombinoUrl', () => {
+    (useKonfluxPublicInfo as jest.Mock).mockReturnValue([{}, false, null]);
+
+    const { result } = renderHook(() => useBombinoUrl());
+    expect(result.current).toBe(undefined);
+  });
+
+  it('should return undefined when there is an error in useBombinoUrl', () => {
+    (useKonfluxPublicInfo as jest.Mock).mockReturnValue([{}, true, new Error('Failed to load')]);
+
+    const { result } = renderHook(() => useBombinoUrl());
+    expect(result.current).toBe(undefined);
+  });
+});
+
+describe('useApplicationUrl', () => {
+  it('should return the correct application URL from KonfluxPublicInfo', () => {
+    (useKonfluxPublicInfo as jest.Mock).mockReturnValue([
+      {
+        integrations: {
+          github: {
+            application_url: 'https://github.com/apps/konflux-staging',
+          },
+        },
+      },
+      true,
+      null,
+    ]);
+
+    const { result } = renderHook(() => useApplicationUrl());
+    expect(result.current).toBe('https://github.com/apps/konflux-staging');
+  });
+
+  it('should handle undefined integrations gracefully in useApplicationUrl', () => {
+    (useKonfluxPublicInfo as jest.Mock).mockReturnValue([
+      {
+        integrations: undefined,
+      },
+      true,
+      null,
+    ]);
+
+    const { result } = renderHook(() => useApplicationUrl());
+    expect(result.current).toBe(undefined);
+  });
+
+  it('should handle undefined github gracefully in useApplicationUrl', () => {
+    (useKonfluxPublicInfo as jest.Mock).mockReturnValue([
+      {
+        integrations: {
+          github: undefined,
+        },
+      },
+      true,
+      null,
+    ]);
+
+    const { result } = renderHook(() => useApplicationUrl());
+    expect(result.current).toBe(undefined);
+  });
+
+  it('should return undefined when data is loading in useApplicationUrl', () => {
+    (useKonfluxPublicInfo as jest.Mock).mockReturnValue([{}, false, null]);
+
+    const { result } = renderHook(() => useApplicationUrl());
+    expect(result.current).toBe(undefined);
+  });
+
+  it('should return undefined when there is an error in useApplicationUrl', () => {
+    (useKonfluxPublicInfo as jest.Mock).mockReturnValue([{}, true, new Error('Failed to load')]);
+
+    const { result } = renderHook(() => useApplicationUrl());
+    expect(result.current).toBe(undefined);
+  });
+
+  it('should handle undefined application_url gracefully in useApplicationUrl', () => {
+    (useKonfluxPublicInfo as jest.Mock).mockReturnValue([
+      {
+        integrations: {
+          github: {
+            application_url: undefined,
+          },
+        },
+      },
+      true,
+      null,
+    ]);
+
+    const { result } = renderHook(() => useApplicationUrl());
+    expect(result.current).toBe(undefined);
+  });
+});
+
+describe('useNotifications', () => {
+  it('should return notifications from KonfluxPublicInfo', () => {
+    const mockNotifications = [
+      {
+        title: 'SBOM-event-to-Bombino',
+        event: 'repo_push',
+        method: 'webhook',
+        config: { url: 'https://bombino.com' },
+      },
+    ];
+
+    (useKonfluxPublicInfo as jest.Mock).mockReturnValue([
+      {
+        integrations: {
+          image_controller: {
+            notifications: mockNotifications,
+          },
+        },
+      },
+      true,
+      null,
+    ]);
+
+    const { result } = renderHook(() => useNotifications());
+    expect(result.current).toEqual(mockNotifications);
+  });
+
+  it('should handle undefined integrations gracefully in useNotifications', () => {
+    (useKonfluxPublicInfo as jest.Mock).mockReturnValue([
+      {
+        integrations: undefined,
+      },
+      true,
+      null,
+    ]);
+
+    const { result } = renderHook(() => useNotifications());
+    expect(result.current).toEqual([]);
+  });
+
+  it('should handle undefined image_controller gracefully in useNotifications', () => {
+    (useKonfluxPublicInfo as jest.Mock).mockReturnValue([
+      {
+        integrations: {
+          image_controller: undefined,
+        },
+      },
+      true,
+      null,
+    ]);
+
+    const { result } = renderHook(() => useNotifications());
+    expect(result.current).toEqual([]);
+  });
+
+  it('should handle undefined notifications gracefully in useNotifications', () => {
+    (useKonfluxPublicInfo as jest.Mock).mockReturnValue([
+      {
+        integrations: {
+          image_controller: {
+            notifications: undefined,
+          },
+        },
+      },
+      true,
+      null,
+    ]);
+
+    const { result } = renderHook(() => useNotifications());
+    expect(result.current).toEqual([]);
+  });
+
+  it('should return empty array when data is loading in useNotifications', () => {
+    (useKonfluxPublicInfo as jest.Mock).mockReturnValue([{}, false, null]);
+
+    const { result } = renderHook(() => useNotifications());
+    expect(result.current).toEqual([]);
+  });
+
+  it('should return empty array when there is an error in useNotifications', () => {
+    (useKonfluxPublicInfo as jest.Mock).mockReturnValue([{}, true, new Error('Failed to load')]);
+
+    const { result } = renderHook(() => useNotifications());
+    expect(result.current).toEqual([]);
   });
 
   describe('useInstanceVisibility', () => {

--- a/src/hooks/useUIInstance.ts
+++ b/src/hooks/useUIInstance.ts
@@ -77,7 +77,7 @@ export const useSbomUrl = (): ((imageHash: string, sbomSha?: string) => string |
 export const useBombinoUrl = (): string | undefined => {
   const [konfluxPublicInfo, loaded, error] = useKonfluxPublicInfo();
 
-  if (loaded && !error && konfluxPublicInfo) {
+  if (loaded && !error && konfluxPublicInfo?.integrations?.image_controller?.notifications) {
     const notifications = konfluxPublicInfo.integrations.image_controller.notifications || [];
     return getBombinoUrl(notifications);
   }
@@ -86,7 +86,7 @@ export const useBombinoUrl = (): string | undefined => {
 
 export const useApplicationUrl = (): string | undefined => {
   const [konfluxPublicInfo, loaded, error] = useKonfluxPublicInfo();
-  if (loaded && !error && konfluxPublicInfo) {
+  if (loaded && !error && konfluxPublicInfo?.integrations?.github?.application_url) {
     return konfluxPublicInfo.integrations.github.application_url;
   }
   return undefined;
@@ -94,8 +94,8 @@ export const useApplicationUrl = (): string | undefined => {
 
 export const useNotifications = (): SBOMEventNotification[] => {
   const [konfluxPublicInfo, loaded, error] = useKonfluxPublicInfo();
-  if (loaded && !error && konfluxPublicInfo) {
-    return konfluxPublicInfo.integrations.image_controller.notifications || [];
+  if (loaded && !error && konfluxPublicInfo?.integrations?.image_controller?.notifications) {
+    return konfluxPublicInfo.integrations.image_controller.notifications;
   }
   return [];
 };


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

Fixes https://issues.redhat.com/browse/KFLUXUI-683
Fixes #366

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In this PR we're updating the logic in the `useBombinoUrl()`, `useNotifications()`, and `useApplicationUrl()` hooks to not try to access data from a possible undefined `integrations` object when trying to get data from it using optional chaining.

The issue reported in the GH issue was directly related to the `useNotifications()` hook, but I took the chance to update the other hooks around that had a similar logic and could potentially cause a crash too :)


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

https://github.com/user-attachments/assets/ae0dd5f9-ee81-443c-87d8-4b1e4256e094

After:

https://github.com/user-attachments/assets/d90b03f4-d942-4ee3-963a-3c988316bff5

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

The easiest way to reproduce this issue is by forcing the `useKonfluxPublicInfo` to return `undefined` data for the `integrations` object. You can apply the following diff :coffee:

```diff
diff --git a/src/hooks/useKonfluxPublicInfo.ts b/src/hooks/useKonfluxPublicInfo.ts
index e71f874a..c8cdb87e 100644
--- a/src/hooks/useKonfluxPublicInfo.ts
+++ b/src/hooks/useKonfluxPublicInfo.ts
@@ -22,5 +22,5 @@ export const useKonfluxPublicInfo = (): [KonfluxPublicInfo, boolean, unknown] =>
     return !isLoading && !error && configMap?.data ? JSON.parse(configMap.data['info.json']) : {};
   }, [configMap, isLoading, error]);

-  return [parsedData, !isLoading, error];
+  return [{ ...parsedData, integrations: undefined }, !isLoading, error];
```


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->