### PR TITLE
perf: stop watch for banner-config-map to avoid refetching of resource on websocket failure

### DIFF
--- a/src/components/KonfluxBanner/useBanner.ts
+++ b/src/components/KonfluxBanner/useBanner.ts
@@ -147,7 +147,6 @@ export const useBanner = () => {
       groupVersionKind: ConfigMapGroupVersionKind,
       namespace: KONFLUX_INFO_NAMESPACE,
       name: BANNER_CONTENT_FILE,
-      watch: true,
     },
     ConfigMapModel,
   );


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
There are a lot of fetch calls for banner config map in case websocket fails. Watch is not necessary for this config map as stale resource are refreshed at an interval by tanstack query.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Konflux banner to use standard data fetch instead of real-time watching. Banner content continues to be parsed and validated as before.
  * Observable impact: banner updates may not appear instantly; reload the page (or wait for default refresh behavior) to see new content.
  * Reduces continuous background updates while preserving existing banner display and activation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->