### PR TITLE
fix KFLUXUI-706: show-sbom step is removed

### DIFF
--- a/e2e-tests/support/pages/tabs/PipelinerunsTabPage.ts
+++ b/e2e-tests/support/pages/tabs/PipelinerunsTabPage.ts
@@ -187,7 +187,7 @@ export class TaskRunsTab {
       { name: `${pipelineName}-init`, task: 'init', status: 'Succeeded' },
       { name: `${pipelineName}-clone-repository`, task: 'clone-repository', status: 'Succeeded' },
       { name: `${pipelineName}-build-container`, task: 'build-container', status: 'Succeeded' },
-      { name: `${pipelineName}-show-sbom`, task: 'show-sbom', status: 'Succeeded' },
+      { name: `${pipelineName}-push-dockerfile`, task: 'push-dockerfile', status: 'Succeeded' },
     ];
   }
 

--- a/e2e-tests/tests/basic-happy-path.spec.ts
+++ b/e2e-tests/tests/basic-happy-path.spec.ts
@@ -24,7 +24,13 @@ describe('Basic Happy Path', () => {
   const repoOwner = 'redhat-hac-qe';
   const publicRepo = `https://github.com/${repoOwner}/${repoName}`;
   const componentName: string = Common.generateAppName('java-quarkus');
-  const piplinerunlogsTasks = ['init', 'clone-repository', 'build-container', 'show-sbom'];
+  const piplinerunlogsTasks = [
+    'init',
+    'clone-repository',
+    'build-container',
+    'apply-tags',
+    'push-dockerfile',
+  ];
   const pipeline = 'docker-build-oci-ta';
 
   before(function () {


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/KFLUXUI-706

## Description
Replace the show-sbom with the push-dockerfile step for the pipelines check.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix - tests
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
E2E tests are passing now.

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pipeline runs now show “apply-tags” and “push-dockerfile” tasks in logs and graph.
  * The basic TaskRuns view replaces “show-sbom” with “push-dockerfile”; “show-sbom” remains available in the advanced view.

* **Tests**
  * End-to-end test scenarios updated to validate the new task sequence and UI expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->