### PR TITLE
feat(KFLUXUI-708): access list should support subjects list in one ro…

### DIFF
--- a/src/components/UserAccess/RBListRow.tsx
+++ b/src/components/UserAccess/RBListRow.tsx
@@ -7,21 +7,27 @@ import { RoleBinding } from '../../types';
 import { rbTableColumnClasses } from './RBListHeader';
 import { useRBActions } from './user-access-actions';
 
-export const RBListRow: React.FC<React.PropsWithChildren<RowFunctionArgs<RoleBinding>>> = ({
-  obj,
-}) => {
-  const actions = useRBActions(obj);
+export const RBListRow: React.FC<
+  React.PropsWithChildren<
+    RowFunctionArgs<{ roleBinding: RoleBinding; subject: RoleBinding['subjects'][0] | null }>
+  >
+> = ({ obj }) => {
+  const actions = useRBActions(obj.roleBinding);
   const [roleMap, loaded] = useRoleMap();
 
   return (
     <>
-      <TableData className={rbTableColumnClasses.username}>
-        {obj.subjects ? obj.subjects[0]?.name : '-'}
-      </TableData>
+      <TableData className={rbTableColumnClasses.username}>{obj.subject?.name || '-'}</TableData>
       <TableData className={rbTableColumnClasses.role}>
-        {!loaded ? <Skeleton width="200px" height="20px" /> : roleMap?.roleMap[obj.roleRef.name]}
+        {!loaded ? (
+          <Skeleton width="200px" height="20px" />
+        ) : (
+          roleMap?.roleMap[obj.roleBinding.roleRef.name]
+        )}
       </TableData>
-      <TableData className={rbTableColumnClasses.rolebinding}>{obj.metadata.name}</TableData>
+      <TableData className={rbTableColumnClasses.rolebinding}>
+        {obj.roleBinding.metadata.name}
+      </TableData>
       <TableData className={rbTableColumnClasses.kebab}>
         <ActionMenu actions={actions} />
       </TableData>

--- a/src/components/UserAccess/__tests__/RBListRow.spec.tsx
+++ b/src/components/UserAccess/__tests__/RBListRow.spec.tsx
@@ -20,7 +20,11 @@ describe('RBListRow', () => {
     const mockUseRoleMap = useRoleMap as jest.Mock;
     watchMock.mockReturnValueOnce([mockRoleBinding, false]);
     mockUseRoleMap.mockReturnValueOnce([defaultKonfluxRoleMap, true, null]);
-    const wrapper = render(<RBListRow obj={mockRoleBinding} columns={[]} />, {
+    const rowData = {
+      roleBinding: mockRoleBinding,
+      subject: mockRoleBinding.subjects?.[0] || null,
+    };
+    const wrapper = render(<RBListRow obj={rowData} columns={[]} />, {
       container: document.createElement('tr'),
     });
     const cells = wrapper.container.getElementsByTagName('td');
@@ -35,7 +39,11 @@ describe('RBListRow', () => {
     const mockUseRoleMap = useRoleMap as jest.Mock;
     watchMock.mockReturnValueOnce([mockRoleBinding, false]);
     mockUseRoleMap.mockReturnValueOnce([defaultKonfluxRoleMap, true, null]);
-    const wrapper = render(<RBListRow obj={mockRoleBinding} columns={[]} />, {
+    const rowData = {
+      roleBinding: mockRoleBinding,
+      subject: mockRoleBinding.subjects?.[0] || null,
+    };
+    const wrapper = render(<RBListRow obj={rowData} columns={[]} />, {
       container: document.createElement('div'),
     });
     wrapper.container.getElementsByTagName('spinner');


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/KFLUXUI-708


## Description
Currently, UI just show the first subject in one rolebinging. -> When users grant roles by UI, it works well.
But now, more and more team grant roles by API with yamls.
In this case, UI need to support the subjects list well.
 
## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
see the two rows for ocm-ui-tenant-konflux-contributors
<img width="1518" height="608" alt="image" src="https://github.com/user-attachments/assets/48242253-ff13-4990-88cb-f3a7e5d3c139" />


## How to test or reproduce?
1. apply the exmaple yaml to your tenant
```
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: ocm-ui-tenant-konflux-contributors
  namespace: your-tenant
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: konflux-contributor-user-actions
subjects:
- apiGroup: rbac.authorization.k8s.io
  kind: User
  name: dtaylor
- apiGroup: rbac.authorization.k8s.io
  kind: User
  name: remanuel
```
2. view the user access list page and both dtaylor and remanuel should be listed there with the role binding.
## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User Access list now displays per-subject rows, with unique identifiers per subject.
  * Rows clearly show role binding and subject; displays “-” when no subject is present.
  * Actions menu remains available per row.

* **Bug Fixes**
  * Filtering applies per row by username, improving accuracy.
  * Role bindings without subjects are now included in results.

* **Tests**
  * Updated test cases to match the new row structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->