### PR TITLE
feat(KFLUXUI-710): add the help info for usernames

### DIFF
--- a/src/components/UserAccess/RBListHeader.tsx
+++ b/src/components/UserAccess/RBListHeader.tsx
@@ -7,8 +7,14 @@ export const rbTableColumnClasses = {
 
 export const RBListHeader = () => [
   {
-    title: 'Username',
-    props: { className: rbTableColumnClasses.username },
+    title: <>Username </>,
+    props: {
+      className: rbTableColumnClasses.username,
+      info: {
+        popover:
+          'The primary user or service account from the role binding. Shows the first subject after sanitization for Kubernetes compatibility. Displays "-" when no subjects are defined.',
+      },
+    },
   },
   {
     title: 'Role',


### PR DESCRIPTION
Assisted-by: Claude


## Fixes 
https://issues.redhat.com/browse/KFLUXUI-710


## Description
Users are confused by '-' in the user list, we need to add explanation for it.
see the slack channel: 
 https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1755791512778159


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<img width="1083" height="307" alt="image" src="https://github.com/user-attachments/assets/eca1c605-d2a8-4fd7-aeb4-38da2e7cfe47" />



## How to test or reproduce?
Navigate to /ns/your-tenant/access and click the help icon for the 'username'.

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an inline help popover to the “Username” column header in the Role Bindings table.
  * The popover clarifies that the column shows the primary user or service account, displays the first subject after Kubernetes-compatible sanitization, and uses “-” when no subjects are defined.
  * Provides quick guidance via hover without disrupting existing workflows.
  * No changes to sorting, filtering, or other columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->