### PR TITLE
feat(KFLUXUI-713): add watch support to useK8sAndKarchResource hook

### DIFF
--- a/src/components/Commits/CommitDetails/tabs/__tests__/CommitsPipelineRunTab.spec.tsx
+++ b/src/components/Commits/CommitDetails/tabs/__tests__/CommitsPipelineRunTab.spec.tsx
@@ -96,7 +96,13 @@ describe('Commit Pipelinerun List', () => {
     useParamsMock.mockReturnValue({ applicationName: appName, commitName: 'test-sha-1' });
     jest.clearAllMocks();
     useNamespaceMock.mockReturnValue('test-ns');
-    useSnapshotMock.mockReturnValue({ data: MockSnapshots[0], isLoading: false, error: undefined });
+    useSnapshotMock.mockReturnValue({
+      data: MockSnapshots[0],
+      isLoading: false,
+      fetchError: undefined,
+      wsError: undefined,
+      isError: false,
+    });
   });
   it('should render error state if the API errors out', () => {
     usePipelineRunsForCommitMock.mockReturnValue([

--- a/src/components/Releases/ReleaseArtifactsTab/__tests__/ReleaseArtifactsTab.spec.tsx
+++ b/src/components/Releases/ReleaseArtifactsTab/__tests__/ReleaseArtifactsTab.spec.tsx
@@ -60,13 +60,16 @@ describe('ReleaseArtifactsTab', () => {
         status: { artifacts: { images: mockImages } },
       },
       true,
+      undefined,
+      undefined,
+      false,
     ]);
     (useSortedResources as jest.Mock).mockReturnValue(mockImages);
     (useSearchParam as jest.Mock).mockReturnValue(['', jest.fn()]);
   });
 
   it('renders spinner while loading', () => {
-    (useRelease as jest.Mock).mockReturnValue([{}, false]);
+    (useRelease as jest.Mock).mockReturnValue([{}, false, undefined, undefined, false]);
 
     render(
       <MemoryRouter
@@ -91,6 +94,9 @@ describe('ReleaseArtifactsTab', () => {
         status: { artifacts: { images: [] } },
       },
       true,
+      undefined,
+      undefined,
+      false,
     ]);
     (useSortedResources as jest.Mock).mockReturnValue([]);
 

--- a/src/components/Releases/ReleaseOverviewTab.tsx
+++ b/src/components/Releases/ReleaseOverviewTab.tsx
@@ -26,7 +26,7 @@ import { StatusIconWithText } from '../StatusIcon/StatusIcon';
 const ReleaseOverviewTab: React.FC = () => {
   const { releaseName } = useParams<RouterParams>();
   const namespace = useNamespace();
-  const [release, loaded, isError] = useRelease(namespace, releaseName);
+  const [release, loaded, error] = useRelease(namespace, releaseName);
   const status = useReleaseStatus(release);
 
   if (!loaded) {
@@ -36,13 +36,13 @@ const ReleaseOverviewTab: React.FC = () => {
       </Bullseye>
     );
   }
-  if (isError) {
-    const httpError = HttpError.fromCode((isError as { code: number }).code);
+  if (error) {
+    const httpError = HttpError.fromCode((error as { code: number }).code);
     return (
       <ErrorEmptyState
         httpError={httpError}
         title={`Unable to load release ${releaseName}`}
-        body={(isError as { message: string }).message}
+        body={(error as { message: string }).message}
       />
     );
   }

--- a/src/components/Releases/__tests__/ReleaseDetailsView.spec.tsx
+++ b/src/components/Releases/__tests__/ReleaseDetailsView.spec.tsx
@@ -36,13 +36,25 @@ describe('ReleaseDetailsView', () => {
     },
   };
   it('should render spinner if release data is not loaded', () => {
-    useMockRelease.mockReturnValue({ data: mockRelease, isLoading: true, error: false });
+    useMockRelease.mockReturnValue({
+      data: mockRelease,
+      isLoading: true,
+      fetchError: undefined,
+      wsError: undefined,
+      isError: false,
+    });
     renderWithQueryClientAndRouter(<ReleaseDetailsView />);
     expect(screen.getByRole('progressbar')).toBeVisible();
   });
 
   it('should render the error state if the release is not found', () => {
-    useMockRelease.mockReturnValue({ data: {}, isLoading: false, error: { code: 404 } });
+    useMockRelease.mockReturnValue({
+      data: {},
+      isLoading: false,
+      fetchError: { code: 404 },
+      wsError: undefined,
+      isError: true,
+    });
     renderWithQueryClientAndRouter(<ReleaseDetailsView />);
     expect(screen.getByText('404: Page not found')).toBeVisible();
     expect(screen.getByText('Go to applications list')).toBeVisible();

--- a/src/components/Releases/__tests__/ReleaseOverviewTab.spec.tsx
+++ b/src/components/Releases/__tests__/ReleaseOverviewTab.spec.tsx
@@ -22,13 +22,13 @@ describe('ReleaseOverviewTab', () => {
   });
 
   it('should render loading indicator', () => {
-    useMockRelease.mockImplementation(() => [mockReleases[1], false]);
+    useMockRelease.mockImplementation(() => [mockReleases[1], false, undefined, undefined, false]);
     render(<ReleaseOverviewTab />);
     expect(screen.getByRole('progressbar')).toBeVisible();
   });
 
   it('should render correct details', () => {
-    useMockRelease.mockImplementation(() => [mockReleases[0], true]);
+    useMockRelease.mockImplementation(() => [mockReleases[0], true, undefined, undefined, false]);
     render(<ReleaseOverviewTab />);
     expect(screen.getByText('Duration')).toBeVisible();
     expect(screen.getByText('10 seconds')).toBeVisible();

--- a/src/components/Releases/__tests__/ReleasePipelineRunTab.spec.tsx
+++ b/src/components/Releases/__tests__/ReleasePipelineRunTab.spec.tsx
@@ -49,7 +49,7 @@ describe('ReleasePipelineRunTab', () => {
   });
 
   it('renders spinner while data is loading', () => {
-    useMockRelease.mockReturnValue([null, false]);
+    useMockRelease.mockReturnValue([null, false, undefined, undefined, false]);
     useMockReleasePlan.mockReturnValue([null, false]);
     render(wrapper);
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
@@ -64,6 +64,9 @@ describe('ReleasePipelineRunTab', () => {
         },
       },
       true,
+      undefined,
+      undefined,
+      false,
     ]);
     useMockReleasePlan.mockReturnValue([{}, true]);
     render(wrapper);

--- a/src/hooks/useK8sAndKarchResources.ts
+++ b/src/hooks/useK8sAndKarchResources.ts
@@ -1,10 +1,19 @@
 import * as React from 'react';
+import { hashKey } from '@tanstack/query-core';
+import { useK8sQueryWatch } from '~/k8s/hooks/useK8sQueryWatch';
+import { WebSocketOptions } from '~/k8s/web-socket/types';
 import { fetchResourceWithK8sAndKubeArchive } from '~/kubearchive/resource-utils';
-import { useK8sWatchResource } from '../k8s';
+import { createQueryKeys, useK8sWatchResource } from '../k8s';
 import { K8sResourceReadOptions } from '../k8s/k8s-fetch';
 import { TQueryOptions } from '../k8s/query/type';
 import { useKubearchiveListResourceQuery } from '../kubearchive/hooks';
-import { K8sModelCommon, K8sResourceCommon, WatchK8sResource } from '../types/k8s';
+import {
+  K8sModelCommon,
+  K8sResourceCommon,
+  ResourceSource,
+  ResourceWithSource,
+  WatchK8sResource,
+} from '../types/k8s';
 
 export interface K8sAndKarchResourcesResult<T extends K8sResourceCommon> {
   // Combined data (cluster + archive, deduplicated)
@@ -122,8 +131,10 @@ export function useK8sAndKarchResources<T extends K8sResourceCommon>(
 
 export interface useK8sAndKarchResourceResult<TResource extends K8sResourceCommon> {
   data: TResource | undefined;
+  source: ResourceSource | undefined;
   isLoading: boolean;
-  error: unknown;
+  fetchError: unknown;
+  wsError: unknown;
   isError: boolean;
 }
 
@@ -133,45 +144,71 @@ export interface useK8sAndKarchResourceResult<TResource extends K8sResourceCommo
  * Uses the tanstack query integrated functions directly.
  *
  * @param resourceInit - K8s resource read options
- * @param options - Optional query options
+ * @param queryOptions - Optional query options
+ * @param watch - Whether to watch the resource (default: false)
+ * @param watchOptions - Optional watch options
  * @param enabled - Whether the query should be enabled (default: true)
  * @returns Object with data, loading, and error states
  */
 export function useK8sAndKarchResource<TResource extends K8sResourceCommon>(
   resourceInit: K8sResourceReadOptions | null,
-  options?: TQueryOptions<TResource>,
+  queryOptions?: TQueryOptions<TResource>,
+  watch: boolean = false,
+  watchOptions: Partial<
+    WebSocketOptions & RequestInit & { wsPrefix?: string; pathPrefix?: string }
+  > = {},
   enabled: boolean = true,
 ): useK8sAndKarchResourceResult<TResource> {
-  const [data, setData] = React.useState<TResource | undefined>(undefined);
+  const [result, setResult] = React.useState<ResourceWithSource<TResource> | undefined>(undefined);
   const [isLoading, setIsLoading] = React.useState<boolean>(true);
-  const [error, setError] = React.useState<unknown>(null);
+  const [fetchError, setFetchError] = React.useState<unknown>(null);
 
   React.useEffect(() => {
     if (!enabled || !resourceInit) {
+      setIsLoading(false);
       return;
     }
 
     setIsLoading(true);
-    setError(null);
+    setFetchError(null);
 
-    fetchResourceWithK8sAndKubeArchive<TResource>(resourceInit, options)
-      .then((result) => {
-        setData(result);
-        setError(null);
+    fetchResourceWithK8sAndKubeArchive<TResource>(resourceInit, queryOptions)
+      .then((res) => {
+        setResult(res);
+        setFetchError(null);
       })
       .catch((err) => {
-        setError(err);
-        setData(undefined);
+        setFetchError(err);
+        setResult(undefined);
       })
       .finally(() => {
         setIsLoading(false);
       });
-  }, [resourceInit, enabled, options]);
+  }, [resourceInit, enabled, queryOptions]);
+
+  const shouldWatch = enabled && watch && result?.source === ResourceSource.Cluster && resourceInit;
+
+  const wsError = useK8sQueryWatch(
+    shouldWatch ? resourceInit : null,
+    false,
+    shouldWatch
+      ? hashKey(
+          createQueryKeys({
+            model: resourceInit.model,
+            queryOptions: resourceInit.queryOptions,
+            prefix: watchOptions?.pathPrefix ?? resourceInit.fetchOptions?.requestInit?.pathPrefix,
+          }),
+        )
+      : hashKey(['disabled', 'no-resource']),
+    watchOptions,
+  );
 
   return {
-    data,
+    data: result?.resource,
+    source: result?.source,
     isLoading,
-    error,
-    isError: !!error,
+    fetchError,
+    wsError,
+    isError: !!(fetchError || wsError),
   };
 }

--- a/src/hooks/useReleases.ts
+++ b/src/hooks/useReleases.ts
@@ -30,7 +30,10 @@ export const useReleases = (
   return [data, !isLoading, error];
 };
 
-export const useRelease = (namespace: string, name: string): [ReleaseKind, boolean, unknown] => {
+export const useRelease = (
+  namespace: string,
+  name: string,
+): [ReleaseKind, boolean, unknown, unknown, boolean] => {
   const resourceInit = React.useMemo(
     () => ({
       model: ReleaseModel,
@@ -41,6 +44,7 @@ export const useRelease = (namespace: string, name: string): [ReleaseKind, boole
     }),
     [namespace, name],
   );
-  const { data, isLoading, error } = useK8sAndKarchResource<ReleaseKind>(resourceInit);
-  return [data, !isLoading, error];
+  const { data, isLoading, fetchError, wsError, isError } =
+    useK8sAndKarchResource<ReleaseKind>(resourceInit);
+  return [data, !isLoading, fetchError, wsError, isError];
 };

--- a/src/hooks/useSnapshots.ts
+++ b/src/hooks/useSnapshots.ts
@@ -4,7 +4,10 @@ import { SnapshotGroupVersionKind, SnapshotModel } from '../models';
 import { Snapshot } from '../types/coreBuildService';
 import { useK8sAndKarchResource, useK8sAndKarchResources } from './useK8sAndKarchResources';
 
-export const useSnapshot = (namespace: string, name: string): [Snapshot, boolean, unknown] => {
+export const useSnapshot = (
+  namespace: string,
+  name: string,
+): [Snapshot | undefined, boolean, unknown, unknown, boolean] => {
   const resourceInit = React.useMemo(
     () =>
       namespace
@@ -19,9 +22,15 @@ export const useSnapshot = (namespace: string, name: string): [Snapshot, boolean
     [namespace, name],
   );
 
-  const { data: snapshot, isLoading, error } = useK8sAndKarchResource<Snapshot>(resourceInit);
+  const {
+    data: snapshot,
+    isLoading,
+    fetchError,
+    wsError,
+    isError,
+  } = useK8sAndKarchResource<Snapshot>(resourceInit);
 
-  return [snapshot, !isLoading, error];
+  return [snapshot, !isLoading, fetchError, wsError, isError];
 };
 
 export const useSnapshotsForApplication = (namespace, applicationName) => {

--- a/src/k8s/watch-utils.ts
+++ b/src/k8s/watch-utils.ts
@@ -88,7 +88,7 @@ export const watchObjectResource = (
   return k8sWatch(
     model,
     {
-      labelSelector: queryOptions.queryParams.labelSelector,
+      labelSelector: queryOptions.queryParams?.labelSelector,
       ns: queryOptions.ns,
       fieldSelector: `metadata.name=${queryOptions.name}`,
     },

--- a/src/kubearchive/__tests__/fetch-utils.spec.ts
+++ b/src/kubearchive/__tests__/fetch-utils.spec.ts
@@ -1,7 +1,7 @@
 import { createK8sUtilMock, createKubearchiveUtilMock } from '~/utils/test-utils';
 import { HttpError } from '../../k8s/error';
 import { TQueryOptions } from '../../k8s/query/type';
-import { K8sResourceCommon } from '../../types/k8s';
+import { K8sResourceCommon, ResourceSource } from '../../types/k8s';
 import { fetchResourceWithK8sAndKubeArchive } from '../resource-utils';
 
 const mockK8sQueryGetResource = createK8sUtilMock('k8sQueryGetResource');
@@ -39,23 +39,31 @@ describe('fetchResourceWithK8sAndKubeArchive', () => {
   });
 
   it('should return resource from cluster when cluster request succeeds', async () => {
+    const mockResult = {
+      resource: mockResource,
+      source: ResourceSource.Cluster,
+    };
     mockK8sQueryGetResource.mockResolvedValue(mockResource);
 
     const result = await fetchResourceWithK8sAndKubeArchive(mockResourceInit, mockOptions);
 
     // Assert
-    expect(result).toEqual(mockResource);
+    expect(result).toEqual(mockResult);
     expect(mockK8sQueryGetResource).toHaveBeenCalledWith(mockResourceInit, mockOptions);
     expect(mockKubearchiveQueryGetResource).not.toHaveBeenCalled();
   });
 
   it('should return resource from kubearchive when cluster returns 404', async () => {
+    const mockResult = {
+      resource: mockResource,
+      source: ResourceSource.Archive,
+    };
     mockK8sQueryGetResource.mockRejectedValue(HttpError.fromCode(404));
     mockKubearchiveQueryGetResource.mockResolvedValueOnce(mockResource);
 
     const result = await fetchResourceWithK8sAndKubeArchive(mockResourceInit, mockOptions);
 
-    expect(result).toEqual(mockResource);
+    expect(result).toEqual(mockResult);
     expect(mockK8sQueryGetResource).toHaveBeenCalledWith(mockResourceInit, mockOptions);
     expect(mockKubearchiveQueryGetResource).toHaveBeenCalledWith(mockResourceInit, mockOptions);
   });

--- a/src/types/k8s.ts
+++ b/src/types/k8s.ts
@@ -166,3 +166,13 @@ export type WatchK8sResource = {
   partialMetadata?: boolean;
   watch?: boolean;
 };
+
+export enum ResourceSource {
+  Cluster = 'cluster',
+  Archive = 'archive',
+}
+
+export type ResourceWithSource<TResource extends K8sResourceCommon> = {
+  resource: TResource;
+  source: ResourceSource;
+};


### PR DESCRIPTION
## Fixes 
[KFLUXUI-713](https://issues.redhat.com/browse/KFLUXUI-713)


## Description
This PR adds the support to watch a resource when queried using the useK8sAndKarchResource hook. Watching of the resource is enabled if the `watch` parameter is true and the resource is still in the cluster.


## Type of change
<!-- Please delete options that are not relevant. -->

- [X] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Optional real-time updates for resource data; resource origin (cluster vs archive) is exposed and error reporting split into fetch vs connection.

- **Bug Fixes**
  - More robust handling when query parameters are absent during resource watching.

- **Refactor**
  - Unified data/watch handling across releases and snapshots for more reliable fetching and fallback behavior.

- **Tests**
  - Updated and added tests to reflect expanded return shapes and new watch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->