### PR TITLE
fix(KFLUXUI-726): [Release Plans Page] restrict access check to list permission only

### DIFF
--- a/src/components/ReleaseService/ReleasePlan/ReleasePlanListView.tsx
+++ b/src/components/ReleaseService/ReleasePlan/ReleasePlanListView.tsx
@@ -138,8 +138,5 @@ const ReleasePlanListViewWithContext = (
 );
 
 export default withPageAccessCheck(ReleasePlanListViewWithContext)({
-  accessReviewResources: [
-    { model: ReleasePlanModel, verb: 'patch' },
-    { model: ReleasePlanModel, verb: 'create' },
-  ],
+  accessReviewResources: [{ model: ReleasePlanModel, verb: 'list' }],
 });

--- a/src/components/ReleaseService/ReleasePlan/__tests__/ReleasePlanListView.spec.tsx
+++ b/src/components/ReleaseService/ReleasePlan/__tests__/ReleasePlanListView.spec.tsx
@@ -136,4 +136,38 @@ describe('ReleasePlanListView', () => {
     const clearFilterButton = screen.getAllByRole('button', { name: 'Clear all filters' })[0];
     fireEvent.click(clearFilterButton);
   });
+
+  describe('Access Control Scenarios', () => {
+    it('should show access denied state when user lacks list permissions', () => {
+      mockAccessReviewUtil('useAccessReviewForModels', [false, true]);
+      mockReleasePlanHook.mockReturnValue([[mockReleasePlan], true]);
+
+      render(ReleasePlanList);
+
+      expect(screen.getByTestId('no-access-state')).toBeInTheDocument();
+      expect(screen.queryByTestId('release-plan-list-toolbar')).not.toBeInTheDocument();
+    });
+
+    it('should show loading spinner while access review is being checked', () => {
+      mockAccessReviewUtil('useAccessReviewForModels', [true, false]);
+      mockReleasePlanHook.mockReturnValue([[mockReleasePlan], true]);
+
+      render(ReleasePlanList);
+
+      expect(screen.getByTestId('spinner')).toBeInTheDocument();
+    });
+
+    it('should render list view when user has proper list access', async () => {
+      mockAccessReviewUtil('useAccessReviewForModels', [true, true]);
+      mockReleasePlanHook.mockReturnValue([[mockReleasePlan], true]);
+
+      render(ReleasePlanList);
+
+      expect(screen.queryByTestId('no-access-state')).not.toBeInTheDocument();
+      expect(screen.getByTestId('release-plan-list-toolbar')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByRole('grid')).toBeInTheDocument();
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

Fixes https://issues.redhat.com/browse/KFLUXUI-726

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In this PR we're fixing an issue in the "Release Plans" page in which it was checking for user's access for both `'patch'` and `'create'` verbs on the `releaseplans` resource, which is overly restrictive. Users only need `'list'` access to view the release plans page.

This patch updates the access check to only require: `{ model: ReleasePlanModel, verb: 'list' }`


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

![release-plans-list-access-ISSUE](https://github.com/user-attachments/assets/aaaea0e5-51ac-498f-982b-1a93e8a784f6)

After:

![release-plans-list-access-FIX](https://github.com/user-attachments/assets/04be3de1-d3d7-44c4-9f6f-03ef3b9ecf46)

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

To reproduce this issue, you must have `list` access to `releaseplans` resource, but NO access to `patch` or `create`.
You can update the utility functions in `src/utils/rbac.ts` to set `allowed` as `false` for such accesses, so you can simulate the same scenario :coffee:

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted access control for the Release Plans list to require only view permission, allowing users with list-only access to see the page.
  * When access is denied, a no-access message is shown and the toolbar is hidden.
  * A loading indicator is displayed while access is being verified.
* **Tests**
  * Added test coverage for access scenarios: no access, access under review (loading), and granted access (toolbar and grid appear).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->