### PR TITLE
fix(KFLUXUI-740): add Cursor trailer if it is active

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -83,7 +83,7 @@ if [ "$is_authorized" -eq 1 ]; then
   elif [ "$claude_active" = "true" ]; then
     TRAILER="Assisted-by: Claude"
   elif [ "$cursor_active" = "true" ]; then
-    TRAILERS="Assisted-by: Cursor"
+    TRAILER="Assisted-by: Cursor"
   fi
 
   if ! grep -qiE "^$TRAILER" "$COMMIT_MSG_FILE"; then


### PR DESCRIPTION
Assisted-by: Cursor


## Fixes 
[KFLUXUI-740](https://issues.redhat.com/browse/KFLUXUI-740)


## Description
If only Cursor was active, message informing that it was used during the development was not appended to the commit message.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [X] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## How to test or reproduce?
Commit any changes and check the new commit message with `git log`

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->




<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Fixed the commit-message hook so the "Assisted-by" trailer is consistently detected and appended when only the Cursor AI helper is active.
  * Aligned hook behavior across paths so automation and tooling recognize the trailer reliably.
  * No runtime or user-facing app changes; reduces contributor friction when creating commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->