### PR TITLE
feat(/KFLUXUI-757): Migrated from taskRuns to taskRunsV2 in useEnterpriseContractResultFromLogs() hook

### DIFF
--- a/src/components/EnterpriseContract/useEnterpriseContractResultFromLogs.tsx
+++ b/src/components/EnterpriseContract/useEnterpriseContractResultFromLogs.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useTaskRuns } from '../../hooks/useTaskRuns';
+import { useTaskRunsForPipelineRuns } from '../../hooks/useTaskRunsV2';
 import { commonFetchJSON, getK8sResourceURL } from '../../k8s';
 import { PodModel } from '../../models/pod';
 import { useNamespace } from '../../shared/providers/Namespace';
@@ -17,7 +17,7 @@ export const useEnterpriseContractResultFromLogs = (
   pipelineRunName: string,
 ): [ComponentEnterpriseContractResult[], boolean] => {
   const namespace = useNamespace();
-  const [taskRun, loaded, error] = useTaskRuns(namespace, pipelineRunName, 'verify');
+  const [taskRun, loaded, error] = useTaskRunsForPipelineRuns(namespace, pipelineRunName, 'verify');
   const [fetchTknLogs, setFetchTknLogs] = React.useState<boolean>(false);
   const [ecJson, setEcJson] = React.useState<EnterpriseContractResult>();
   const [ecLoaded, setEcLoaded] = React.useState<boolean>(false);


### PR DESCRIPTION
## Fixes 
<a href="https://issues.redhat.com/browse/KFLUXUI-757">KFLUXUI-757</a>

## Description
Migrated from taskRuns to taskRunsV2 in useEnterpriseContractResultFromLogs() hook

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
SecurityEnterpriseContractTab

<img width="1432" height="682" alt="image" src="https://github.com/user-attachments/assets/331cc651-879b-4577-b110-ee3ce310a6c7" />


## How to test or reproduce?
1. Go to Application
2. Go to Integration Test Tab
3. Select any Integration Test(any one row) & go to its details
4. Go to Pipeline Runs Tab
5. Select any pipeline run(any one row)
6. Go to Security Tab


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

