### PR TITLE
feat(release-monitor): virtualize table and add total count display

### DIFF
--- a/src/components/ReleaseMonitor/ReleaseListHeader.tsx
+++ b/src/components/ReleaseMonitor/ReleaseListHeader.tsx
@@ -1,3 +1,5 @@
+import { SortByDirection, ThProps } from '@patternfly/react-table';
+import { ComponentProps } from '~/shared/components/table/Table';
 import { createTableHeaders } from '~/shared/components/table/utils';
 
 export const releaseTableColumnClasses = {
@@ -8,6 +10,7 @@ export const releaseTableColumnClasses = {
   application: 'pf-m-width-20  pf-m-width-10-on-xl',
   releasePlan: 'pf-m-width-20  pf-m-width-10-on-xl',
   namespace: 'pf-m-width-20  pf-m-width-10-on-xl',
+  count: 'pf-m-width-10  pf-m-width-5-on-xl',
 } as const;
 
 export type ReleaseMonitorColumnKey = keyof typeof releaseTableColumnClasses;
@@ -49,5 +52,38 @@ const releaseColumns = [
     className: releaseTableColumnClasses.namespace,
   },
 ] satisfies Parameters<typeof createTableHeaders>[0];
+
+export const getReleasesListHeader = (
+  activeSortIndex: number,
+  activeSortDirection: SortByDirection,
+  onSort: ThProps['sort']['onSort'],
+  totalCount?: number,
+) => {
+  return (componentProps: ComponentProps) => {
+    const baseHeaders = createTableHeaders(releaseColumns)(
+      activeSortIndex,
+      activeSortDirection,
+      onSort,
+    )(componentProps);
+
+    if (totalCount !== undefined) {
+      const countColumn = {
+        title: (
+          <span style={{ fontWeight: 'bold', fontSize: '0.875rem' }}>
+            {totalCount} {totalCount === 1 ? 'release' : 'releases'}
+          </span>
+        ),
+        props: {
+          className: releaseTableColumnClasses.count,
+          style: { textAlign: 'center' as const },
+        },
+      };
+
+      return [...baseHeaders, countColumn];
+    }
+
+    return baseHeaders;
+  };
+};
 
 export default createTableHeaders(releaseColumns);

--- a/src/components/ReleaseMonitor/ReleaseListRow.tsx
+++ b/src/components/ReleaseMonitor/ReleaseListRow.tsx
@@ -71,6 +71,10 @@ const ReleaseListRow: React.FC<RowFunctionArgs<MonitoredReleaseKind>> = ({ obj }
       <TableData className={releaseTableColumnClasses.namespace}>
         {obj.metadata.namespace}
       </TableData>
+
+      <TableData className={releaseTableColumnClasses.count}>
+        {/* Empty cell for count column - count is shown in header only */}
+      </TableData>
     </>
   );
 };

--- a/src/components/ReleaseMonitor/ReleaseMonitorListView.tsx
+++ b/src/components/ReleaseMonitor/ReleaseMonitorListView.tsx
@@ -20,7 +20,7 @@ import { getErrorState } from '~/shared/utils/error-utils';
 import { MonitoredReleaseKind } from '~/types';
 import { statuses } from '~/utils/commits-utils';
 import MonitoredReleaseEmptyState from './ReleaseEmptyState';
-import getReleasesListHeader, { SortableHeaders } from './ReleaseListHeader';
+import { getReleasesListHeader, SortableHeaders } from './ReleaseListHeader';
 import ReleaseListRow from './ReleaseListRow';
 import ReleasesInNamespace from './ReleasesInNamespace';
 
@@ -51,15 +51,6 @@ const ReleaseMonitorListView: React.FunctionComponent = () => {
   );
   const [activeSortDirection, setActiveSortDirection] = React.useState<SortByDirection>(
     SortByDirection.desc,
-  );
-
-  const ReleasesListHeader = React.useMemo(
-    () =>
-      getReleasesListHeader(activeSortIndex, activeSortDirection, (_, index, direction) => {
-        setActiveSortIndex(index);
-        setActiveSortDirection(direction);
-      }),
-    [activeSortDirection, activeSortIndex],
   );
 
   const { name, status, application, releasePlan, namespace, component } = filters;
@@ -122,10 +113,10 @@ const ReleaseMonitorListView: React.FunctionComponent = () => {
     const applicationFilterOptions =
       noApplication > 0
         ? {
-          'No application': noApplication,
-          [MENU_DIVIDER]: 1,
-          ...applicationOptions,
-        }
+            'No application': noApplication,
+            [MENU_DIVIDER]: 1,
+            ...applicationOptions,
+          }
         : applicationOptions;
 
     const componentOptions = createFilterObj(
@@ -138,10 +129,10 @@ const ReleaseMonitorListView: React.FunctionComponent = () => {
     const componentFilterOptions =
       noComponent > 0
         ? {
-          'No component': noComponent,
-          [MENU_DIVIDER]: 1,
-          ...componentOptions,
-        }
+            'No component': noComponent,
+            [MENU_DIVIDER]: 1,
+            ...componentOptions,
+          }
         : componentOptions;
 
     return {
@@ -156,6 +147,20 @@ const ReleaseMonitorListView: React.FunctionComponent = () => {
   const filteredMRs = React.useMemo(
     () => filterMonitoredReleases(sortedMonitoredReleases, filters),
     [sortedMonitoredReleases, filters],
+  );
+
+  const ReleasesListHeader = React.useMemo(
+    () =>
+      getReleasesListHeader(
+        activeSortIndex,
+        activeSortDirection,
+        (_event: React.MouseEvent, index: number, direction: SortByDirection) => {
+          setActiveSortIndex(index);
+          setActiveSortDirection(direction);
+        },
+        filteredMRs.length,
+      ),
+    [activeSortDirection, activeSortIndex, filteredMRs.length],
   );
 
   const EmptyMsg = React.useCallback(
@@ -207,6 +212,7 @@ const ReleaseMonitorListView: React.FunctionComponent = () => {
       )}
 
       <Table
+        virtualize
         data={filteredMRs}
         unfilteredData={sortedMonitoredReleases}
         EmptyMsg={EmptyMsg}


### PR DESCRIPTION
- Enable table virtualization for Release Monitor dashboard performance
- Add dedicated count column to table header showing total number of releases
- Position count column at the end to avoid shifting existing data columns
- Use appropriate terminology 'releases' instead of generic 'items'
- Update ReleaseListHeader and ReleaseListRow components for new layout

Resolves: RHELWF-11639


## Fixes 
Fixes: https://issues.redhat.com/browse/RHELWF-11639


## Description
- Virtualised the Release Monitor dashboard table to ensure smooth rendering with large datasets.
- Added a dedicated count column to the table header that displays the total number of releases currently shown (respects active filters).
- Placed the count column at the end to avoid shifting existing data columns.
- Updated wording from “items” to “releases”, with correct singular/plural handling.
- Addressed TypeScript/ESLint issues by using proper types for SortByDirection, ThProps['sort']['onSort'], and ComponentProps.

### Touched files:
- src/components/ReleaseMonitor/ReleaseMonitorListView.tsx
- src/components/ReleaseMonitor/ReleaseListHeader.tsx
- src/components/ReleaseMonitor/ReleaseListRow.tsx


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
![Image 01-10-25 at 2 17 PM](https://github.com/user-attachments/assets/5f875da5-f8a9-450b-9ea5-d5c3116f858c)


## How to test or reproduce?
- Go to Release Monitor dashboard.
- Verify the table is virtualised (smooth scroll; DOM nodes not overly large).
- Confirm a new header at the end shows “X releases”.
- Apply filters (status, application, component, namespace, release plan):
- Verify the count updates to the number of visible rows.
- Verify singular/plural: “1 release” vs “N releases”.
- Confirm existing columns retain their positions and sorting still works (Name and Completion Time).
- Clear filters; count should equal total unfiltered rows.
- Resize window; verify header layout remains aligned.


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge