### PR TITLE
fix: fixing logs css to allow non standard screens

### DIFF
--- a/src/shared/components/pipeline-run-logs/PipelineRunLogs.scss
+++ b/src/shared/components/pipeline-run-logs/PipelineRunLogs.scss
@@ -44,6 +44,8 @@
   &__container {
     flex: 1;
     display: flex;
+    //ensure log viewer can be seen on narrow screens
+    flex-direction: column;
   }
   &__container .pane-body {
     padding: 0;

--- a/src/shared/components/pipeline-run-logs/PipelineRunLogs.scss
+++ b/src/shared/components/pipeline-run-logs/PipelineRunLogs.scss
@@ -43,6 +43,7 @@
   }
   &__container {
     flex: 1;
+    display: flex;
   }
   &__container .pane-body {
     padding: 0;

--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.scss
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.scss
@@ -25,6 +25,8 @@
     font-family: Menlo, Monaco, 'Courier New', monospace;
     max-height: 100% !important;
     overflow-y: auto;
+    display: flex;
+    flex-direction: column;
   }
 
   &__resume-stream-button-wrapper {

--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.scss
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.scss
@@ -23,6 +23,8 @@
   &__container {
     position: relative;
     font-family: Menlo, Monaco, 'Courier New', monospace;
+    max-height: 100% !important;
+    overflow-y: auto;
   }
 
   &__resume-stream-button-wrapper {
@@ -35,9 +37,8 @@
 }
 
 .pf-v5-c-log-viewer {
-  .pf-v5-c-log-viewer__list {
-    overflow-x: hidden !important;
-    width: 100% !important;
+  &__main {
+    margin-bottom: var(--pf-v5-global--spacer--md);
   }
 
   .pf-v5-c-log-viewer__scroll-container {

--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.scss
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.scss
@@ -39,7 +39,10 @@
 }
 
 .pf-v5-c-log-viewer {
-  
+  .pf-v5-c-log-viewer__list {
+    overflow-x: hidden !important;
+    width: 100% !important;
+  }
   &__main {
     margin-bottom: var(--pf-v5-global--spacer--md);
     height: 100% !important;

--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.scss
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.scss
@@ -39,11 +39,13 @@
 }
 
 .pf-v5-c-log-viewer {
+  
   &__main {
     margin-bottom: var(--pf-v5-global--spacer--md);
+    height: 100% !important;
   }
 
-  .pf-v5-c-log-viewer__scroll-container {
+  &__scroll-container {
     overflow-y: visible !important;
   }
 }


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
### Before
![Screenshot 2025-10-03 at 14 17 45](https://github.com/user-attachments/assets/d011747e-b33f-4386-a292-771feb724ded)

### After
![Screenshot 2025-10-03 at 13 58 59](https://github.com/user-attachments/assets/62b27a92-3c10-4c61-8bab-e868d3b3d519)
![Screenshot 2025-10-03 at 13 59 06](https://github.com/user-attachments/assets/01ca9dc0-3875-4c82-b519-707e0f371409)





## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved Pipeline Run Logs layout by making the logs container a vertical flex layout for more consistent child positioning.
  * Enhanced Log Viewer usability with full-height support and vertical scrolling so logs remain accessible without overflowing the page.
  * Refined spacing within the Log Viewer for clearer separation of content and cleaner appearance.
  * Relaxed restrictive width and horizontal overflow rules to allow more natural sizing and better responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->