### PR TITLE
fix: correct sorting for release monitor date

### DIFF
--- a/src/components/ReleaseMonitor/ReleaseListHeader.tsx
+++ b/src/components/ReleaseMonitor/ReleaseListHeader.tsx
@@ -13,8 +13,9 @@ export const releaseTableColumnClasses = {
 export type ReleaseMonitorColumnKey = keyof typeof releaseTableColumnClasses;
 
 export enum SortableHeaders {
-  name,
-  completionTime,
+  // Column indices must match the actual table column order
+  name = 0,
+  completionTime = 2,
 }
 
 const releaseColumns = [


### PR DESCRIPTION
Assisted-by: Cursor


## Fixes 
- sorting by completion date was broken in the Release Monitor
- added test coverage

## Type of change
- [x] Bugfix

## Screen shots / Gifs for design review 
- earliest item is **Apr 29**
- before fix
<img width="850" height="744" alt="with-bug" src="https://github.com/user-attachments/assets/d59d21ea-4438-4d05-af1a-26758fb7e5ec" />
- after fix
<img width="1228" height="671" alt="bug-fix" src="https://github.com/user-attachments/assets/cb9019a0-9379-4bb5-bb1c-47c867a11a35" />


## How to test or reproduce?
- enable Release Monitor
- go to Release Monitor
- sort by Completed Date
- observe incorrectly sorted items

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- 
- [ ] Code follows the style guidelines
- [x] Self-reviewed the code
- [x] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed header-to-column mapping so clicking table headers sorts the intended column.
  * Sorting by Name and Completion Time now consistently toggles between ascending and descending.
  * Default sort now correctly applies to completion time for completed items.

* **Tests**
  * Added tests verifying default sort order and toggling behavior for completion time, and enhanced table mocks to exercise sortable headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->