### PR TITLE
fix(KonfluxBanner): debounce updateBannerHeight callback

### DIFF
--- a/src/components/KonfluxBanner/KonfluxBanner.tsx
+++ b/src/components/KonfluxBanner/KonfluxBanner.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Banner } from '@patternfly/react-core';
 import { useBanner } from '~/components/KonfluxBanner/useBanner';
 import { useResizeObserver } from '~/shared/hooks';
+import { useDebounceCallback } from '../../shared/hooks/useDebounceCallback';
 import { BannerContent, bannerTypeToVariant } from './BannerContent';
 
 export const KonfluxBanner: React.FC = () => {
@@ -25,7 +26,8 @@ export const KonfluxBanner: React.FC = () => {
     }
   }, [bannerElement]);
 
-  useResizeObserver(updateBannerHeight, bannerElement);
+  const debouncedUpdateBannerHeight = useDebounceCallback(updateBannerHeight, 100);
+  useResizeObserver(debouncedUpdateBannerHeight as ResizeObserverCallback, bannerElement);
 
   if (!banner) return null;
 


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Use `useDebounceCallback` hook to debounce the `updateBannerHeight` callback. This prevents an error "ResizeObserver loop completed with undelivered notifications", which could be cause by the `updateBannerHeight` callback being called too frequently, potentially creating a loop.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

https://github.com/user-attachments/assets/f975a50f-3440-447c-a5b5-7ecbec9302a7

After:

https://github.com/user-attachments/assets/29ea78a4-a9b2-45f4-9a48-c1f938cb42ed

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->