### PR TITLE
fix(KONFLUX-10363): load commit details with many test PLRs

### DIFF
--- a/src/components/Commits/CommitDetails/CommitDetailsView.tsx
+++ b/src/components/Commits/CommitDetails/CommitDetailsView.tsx
@@ -6,7 +6,7 @@ import { usePipelineRunsForCommitV2 } from '~/hooks/usePipelineRunsForCommitV2';
 import { HttpError } from '~/k8s/error';
 import { useNamespace } from '~/shared/providers/Namespace';
 import { getErrorState } from '~/shared/utils/error-utils';
-import { PipelineRunLabel, PipelineRunType } from '../../../consts/pipelinerun';
+import { PipelineRunType } from '../../../consts/pipelinerun';
 import { ACTIVITY_PATH_LATEST_COMMIT, COMMIT_DETAILS_PATH } from '../../../routes/paths';
 import { RouterParams } from '../../../routes/utils';
 import ErrorEmptyState from '../../../shared/components/empty-state/ErrorEmptyState';
@@ -32,17 +32,13 @@ const CommitDetailsView: React.FC = () => {
     namespace,
     applicationName,
     commitName,
+    1,
+    undefined,
+    PipelineRunType.BUILD,
   );
 
   const commit = React.useMemo(
-    () =>
-      loaded &&
-      pipelineruns?.length &&
-      createCommitObjectFromPLR(
-        pipelineruns.find(
-          (p) => p.metadata.labels[PipelineRunLabel.PIPELINE_TYPE] === PipelineRunType.BUILD,
-        ),
-      ),
+    () => loaded && pipelineruns?.length && createCommitObjectFromPLR(pipelineruns[0]),
     [loaded, pipelineruns],
   );
 

--- a/src/components/Commits/CommitDetails/tabs/CommitOverviewTab.tsx
+++ b/src/components/Commits/CommitDetails/tabs/CommitOverviewTab.tsx
@@ -13,7 +13,7 @@ import {
 } from '@patternfly/react-core';
 import { usePipelineRunsForCommitV2 } from '~/hooks/usePipelineRunsForCommitV2';
 import { getErrorState } from '~/shared/utils/error-utils';
-import { PipelineRunLabel, PipelineRunType } from '../../../../consts/pipelinerun';
+import { PipelineRunType } from '../../../../consts/pipelinerun';
 import { RouterParams } from '../../../../routes/utils';
 import { Timestamp } from '../../../../shared';
 import ExternalLink from '../../../../shared/components/links/ExternalLink';
@@ -37,17 +37,13 @@ const CommitOverviewTab: React.FC = () => {
     namespace,
     applicationName,
     commitName,
+    1,
+    undefined,
+    PipelineRunType.BUILD,
   );
 
   const commit = React.useMemo(
-    () =>
-      loaded &&
-      pipelineRuns?.length &&
-      createCommitObjectFromPLR(
-        pipelineRuns.find(
-          (p) => p.metadata.labels[PipelineRunLabel.PIPELINE_TYPE] === PipelineRunType.BUILD,
-        ),
-      ),
+    () => loaded && pipelineRuns?.length && createCommitObjectFromPLR(pipelineRuns[0]),
     [loaded, pipelineRuns],
   );
 

--- a/src/hooks/usePipelineRuns.ts
+++ b/src/hooks/usePipelineRuns.ts
@@ -255,6 +255,7 @@ export const usePipelineRunsForCommit = (
   commit: string,
   limit?: number,
   filterByComponents = true,
+  plrType?: PipelineRunType,
 ): [PipelineRunKind[], boolean, unknown, GetNextPage, NextPageProps] => {
   const [components, componentsLoaded] = useComponents(namespace, applicationName);
   const [application, applicationLoaded] = useApplication(namespace, applicationName);
@@ -274,13 +275,14 @@ export const usePipelineRunsForCommit = (
           filterByCreationTimestampAfter: application?.metadata?.creationTimestamp,
           matchLabels: {
             [PipelineRunLabel.APPLICATION]: applicationName,
+            ...(plrType && { [PipelineRunLabel.PIPELINE_TYPE]: plrType }),
           },
           filterByCommit: commit,
         },
         // TODO: Add limit when filtering by component name AND only PLRs are returned
         // limit,
       }),
-      [applicationName, commit, application],
+      [applicationName, commit, application, plrType],
     ),
   );
 

--- a/src/hooks/usePipelineRunsForCommitV2.ts
+++ b/src/hooks/usePipelineRunsForCommitV2.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PipelineRunLabel } from '~/consts/pipelinerun';
+import { PipelineRunLabel, PipelineRunType } from '~/consts/pipelinerun';
 import { PipelineRunKind } from '../types';
 import { useApplication } from './useApplications';
 import { useComponents } from './useComponents';
@@ -12,6 +12,7 @@ export const usePipelineRunsForCommitV2 = (
   commit: string,
   limit?: number,
   filterByComponents = true,
+  plrType?: PipelineRunType,
 ): [PipelineRunKind[], boolean, unknown, GetNextPage, NextPageProps] => {
   const [components, componentsLoaded] = useComponents(namespace, applicationName);
   const [application] = useApplication(namespace, applicationName);
@@ -30,12 +31,13 @@ export const usePipelineRunsForCommitV2 = (
           filterByCreationTimestampAfter: application?.metadata?.creationTimestamp,
           matchLabels: {
             [PipelineRunLabel.APPLICATION]: applicationName,
+            ...(plrType && { [PipelineRunLabel.PIPELINE_TYPE]: plrType }),
           },
           filterByCommit: commit,
         },
         ...(limit && { limit }),
       }),
-      [applicationName, commit, application, limit],
+      [applicationName, commit, application, limit, plrType],
     ),
   );
 


### PR DESCRIPTION
Assisted-by: Cursor


## Fixes 
[KONFLUX-10363](https://issues.redhat.com/browse/KONFLUX-10363)


## Description
In cases where there were many test pipeline runs associated with a single commit, it could happen that the commit details page would incorrectly yield a 404. This happened because the details page queried all types of PLRs for a commit (compared to the commit list page, which queried only build PLRs). This query had a default limit of 30, which in some cases could be just the test PLRs, causing the page to yield 404.

This PR adds the ability to filter the fetched PLRs based on their type, and additionally limits the query to 1 item, as just one build PLR is used to get the commit data.

Updated the deprecated `usePipelineRunsForCommit` hook for consistency.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [X] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hooks now accept an optional pipeline-run type to refine commit-related data retrieval.
  * Commit views can be instructed to focus on a specific run type when showing commit info.

* **Refactor**
  * Commit selection simplified to consistently use the first pipeline run for details and overview.
  * Retrieval and memoization aligned between commit details and overview for more predictable data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->