### PR TITLE
fix(KFLUXUI-786): delete test GH repo after local e2e tests pass

### DIFF
--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -26,7 +26,7 @@ Find the supported variables in the table below:
 | Variable name | Description | Required | Default Value |
 | -- | -- | -- | -- |
 | `KONFLUX_BASE_URL` | The URL to the main page of Konflux | Yes | 'https://localhost:8080' |
-| `USERNAME` | Username for local Konflux | Only with PR_CHECK=true | 'user2@konflux.dev' |
+| `USERNAME` | Username for local Konflux | Yes | 'user2@konflux.dev' |
 | `PASSWORD` | Password for local Konflux | Only with PR_CHECK=true | 'password' |
 | `PR_CHECK` | Assume the test is a PR check, using flow for local login | For PR checks | '' |
 | `REMOVE_APP_ON_FAIL` | Clean up applications from the cluster even if tests fail | No | false |

--- a/e2e-tests/tests/basic-happy-path.spec.ts
+++ b/e2e-tests/tests/basic-happy-path.spec.ts
@@ -68,7 +68,7 @@ describe('Basic Happy Path', () => {
           });
       }
 
-      APIHelper.deleteGitHubRepository(repoName);
+      APIHelper.deleteGitHubRepository(repoOwner, repoName);
     }
   });
 

--- a/e2e-tests/utils/APIEndpoints.ts
+++ b/e2e-tests/utils/APIEndpoints.ts
@@ -25,7 +25,8 @@ export const hacAPIEndpoints = {
 
 export const githubAPIEndpoints = {
   orgRepos: `https://api.github.com/orgs/redhat-hac-qe/repos`,
-  qeRepos: (repoName: string) => `https://api.github.com/repos/redhat-hac-qe/${repoName}`,
+  testRepo: (owner: string, repoName: string) =>
+    `https://api.github.com/repos/${owner}/${repoName}`,
   templateRepo: (owner: string, templateName: string) =>
     `https://api.github.com/repos/${owner}/${templateName}/generate`,
   merge: (owner: string, repoName: string, pullNumber: number) =>

--- a/e2e-tests/utils/APIHelper.ts
+++ b/e2e-tests/utils/APIHelper.ts
@@ -71,21 +71,8 @@ export class APIHelper {
     });
   }
 
-  static createGitHubRepository(repoName: string) {
-    const body = { name: repoName };
-    this.githubRequest('POST', githubAPIEndpoints.orgRepos, body);
-    this.checkResponseBodyAndStatusCode(
-      githubAPIEndpoints.qeRepos(repoName),
-      `"name":"${repoName}"`,
-      2000,
-      0,
-      3,
-      this.githubHeaders,
-    );
-  }
-
-  static deleteGitHubRepository(repoName: string) {
-    this.githubRequest('DELETE', githubAPIEndpoints.qeRepos(repoName));
+  static deleteGitHubRepository(owner: string, repoName: string) {
+    this.githubRequest('DELETE', githubAPIEndpoints.testRepo(owner, repoName));
   }
 
   static createRepositoryFromTemplate(


### PR DESCRIPTION
Assisted-by: Cursor


## Fixes 
[KFLUXUI-786](https://issues.redhat.com/browse/KFLUXUI-786)


## Description
When the e2e tests pass, they try to delete the test GH repo they created, however with the hard-coded `redhat-hac-qe` repo owner. When the tests are run locally, the repo is created in the users GH instead based on the `GH_REPO_OWNER` env variable. This value should be used when deleting the repo as well.

Additionally, the `USERNAME` variable is required as well, as it is used to determine the users namespace. Otherwise the tests always try to access the default user's namespace - user2@konflux.dev.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [X] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
Before:
<img width="431" height="278" alt="image" src="https://github.com/user-attachments/assets/503d5973-5b56-407a-8567-93c93e221fa5" />


After:
<img width="450" height="131" alt="image" src="https://github.com/user-attachments/assets/67faa506-2f45-43a4-b177-f6685ccef1fb" />



## How to test or reproduce?
Run the e2e tests locally, all tests must pass or the `REMOVE_APP_ON_FAIL` variable must be set to `true`

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Documentation
  * Updated environment docs: USERNAME is now required (default user2@konflux.dev); added GH_TOKEN and GH_REPO_OWNER variables (both required).

* Tests
  * End-to-end tests now delete test repositories using owner + repo for more reliable cleanup.
  * Tests updated to support owner-specific repository URLs, improving coverage and robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->