### PR TITLE
fix(KONFLUX-9322): wrong snapshot link

### DIFF
--- a/src/components/PipelineRun/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
+++ b/src/components/PipelineRun/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
@@ -117,6 +117,11 @@ const PipelineRunDetailsTab: React.FC = () => {
     pipelineRun.metadata?.annotations?.[PipelineRunLabel.SNAPSHOT] ||
     pipelineRun.metadata?.labels?.[PipelineRunLabel.SNAPSHOT];
 
+  const plrNamespace =
+    pipelineRun.metadata?.annotations?.[PipelineRunLabel.RELEASE_NAMESPACE] ||
+    pipelineRun.metadata?.labels?.[PipelineRunLabel.RELEASE_NAMESPACE] ||
+    namespace;
+
   return (
     <>
       <Title headingLevel="h4" className="pf-v5-c-title pf-v5-u-mt-lg pf-v5-u-mb-lg" size="lg">
@@ -222,7 +227,7 @@ const PipelineRunDetailsTab: React.FC = () => {
                             <Link
                               {...props}
                               to={PIPELINE_RUNS_LOG_PATH.createPath({
-                                workspaceName: namespace,
+                                workspaceName: plrNamespace,
                                 applicationName,
                                 pipelineRunName: pipelineRun.metadata?.name,
                               })}
@@ -247,7 +252,7 @@ const PipelineRunDetailsTab: React.FC = () => {
                     <DescriptionListDescription>
                       <Link
                         to={SNAPSHOT_DETAILS_PATH.createPath({
-                          workspaceName: namespace,
+                          workspaceName: plrNamespace,
                           applicationName,
                           snapshotName: snapshot,
                         })}
@@ -284,7 +289,7 @@ const PipelineRunDetailsTab: React.FC = () => {
                     {pipelineRun.metadata?.labels?.[PipelineRunLabel.APPLICATION] ? (
                       <Link
                         to={APPLICATION_DETAILS_PATH.createPath({
-                          workspaceName: namespace,
+                          workspaceName: plrNamespace,
                           applicationName:
                             pipelineRun.metadata?.labels[PipelineRunLabel.APPLICATION],
                         })}
@@ -304,7 +309,7 @@ const PipelineRunDetailsTab: React.FC = () => {
                       pipelineRun.metadata?.labels?.[PipelineRunLabel.APPLICATION] ? (
                         <Link
                           to={COMPONENT_DETAILS_PATH.createPath({
-                            workspaceName: namespace,
+                            workspaceName: plrNamespace,
                             applicationName:
                               pipelineRun.metadata.labels[PipelineRunLabel.APPLICATION],
                             componentName: pipelineRun.metadata.labels[PipelineRunLabel.COMPONENT],
@@ -326,7 +331,7 @@ const PipelineRunDetailsTab: React.FC = () => {
                     <DescriptionListDescription>
                       <Link
                         to={COMMIT_DETAILS_PATH.createPath({
-                          workspaceName: namespace,
+                          workspaceName: plrNamespace,
                           applicationName:
                             pipelineRun.metadata.labels[PipelineRunLabel.APPLICATION],
                           commitName: sha,
@@ -351,7 +356,7 @@ const PipelineRunDetailsTab: React.FC = () => {
                     <DescriptionListDescription>
                       <Link
                         to={INTEGRATION_TEST_DETAILS_PATH.createPath({
-                          workspaceName: namespace,
+                          workspaceName: plrNamespace,
                           applicationName:
                             pipelineRun.metadata.labels[PipelineRunLabel.APPLICATION],
                           integrationTestName,

--- a/src/consts/pipelinerun.ts
+++ b/src/consts/pipelinerun.ts
@@ -26,6 +26,7 @@ export enum PipelineRunLabel {
   COMMIT_EVENT_TYPE_LABEL = 'pipelinesascode.tekton.dev/event-type',
   PULL_REQUEST_NUMBER_LABEL = 'pipelinesascode.tekton.dev/pull-request',
   CREATE_SNAPSHOT_STATUS = 'test.appstudio.openshift.io/create-snapshot-status',
+  RELEASE_NAMESPACE = 'release.appstudio.openshift.io/namespace',
 
   TEST_SERVICE_COMMIT = 'pac.test.appstudio.openshift.io/sha',
   TEST_SERVICE_EVENT_TYPE_LABEL = 'pac.test.appstudio.openshift.io/event-type',


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/KONFLUX-9322

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Snapshot and application had wrong namespace in link (current) instead of provided one in labels/annotations (if provided).

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pipeline Run details now respect the release’s namespace when available, ensuring all links (logs, snapshot, application, component, commit, and integration test) navigate to the correct, release-scoped pages.
  * “See logs” reliably opens the correct logs for release-scoped runs, avoiding cross-namespace or broken navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->