### PR TITLE
fix(KONFLUX-10576): get SBOM sha from task runs

### DIFF
--- a/src/components/PipelineRun/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
+++ b/src/components/PipelineRun/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
@@ -18,6 +18,7 @@ import {
 } from '@patternfly/react-core';
 import GitRepoLink from '~/components/GitLink/GitRepoLink';
 import MetadataList from '~/components/MetadataList';
+import { useModalLauncher } from '~/components/modal/ModalProvider';
 import { StatusIconWithText } from '~/components/StatusIcon/StatusIcon';
 import { PipelineRunLabel } from '~/consts/pipelinerun';
 import { usePipelineRunV2 } from '~/hooks/usePipelineRunsV2';
@@ -44,11 +45,11 @@ import {
   getPipelineRunStatusResultForName,
   getPipelineRunStatusResults,
   pipelineRunStatus,
-  SBOMResultKeys,
 } from '~/utils/pipeline-utils';
 import RelatedPipelineRuns from '../RelatedPipelineRuns';
-import { getSourceUrl } from '../utils/pipelinerun-utils';
+import { getSourceUrl, getSBOMsFromTaskRuns } from '../utils/pipelinerun-utils';
 import PipelineRunVisualization from '../visualization/PipelineRunVisualization';
+import { createPipelineRunSBOMsModal } from './PipelineRunSBOMsModal';
 import RunResultsList from './RunResultsList';
 import ScanDescriptionListGroup from './ScanDescriptionListGroup';
 
@@ -56,6 +57,7 @@ const PipelineRunDetailsTab: React.FC = () => {
   const pipelineRunName = useParams<RouterParams>().pipelineRunName;
   const namespace = useNamespace();
   const generateSbomUrl = useSbomUrl();
+  const showModal = useModalLauncher();
   const [pipelineRun, loaded, error] = usePipelineRunV2(namespace, pipelineRunName);
   const [taskRuns, taskRunsLoaded, taskRunError] = useTaskRunsForPipelineRuns(
     namespace,
@@ -76,16 +78,10 @@ const PipelineRunDetailsTab: React.FC = () => {
     }
   }, [snapshotStatusAnnotation]);
 
-  const imageDigest = getPipelineRunStatusResultForName(
-    SBOMResultKeys.IMAGE_DIGEST,
-    pipelineRun,
-  )?.value;
-  const sbomSha = getPipelineRunStatusResultForName(SBOMResultKeys.SBOM_SHA, pipelineRun)?.value;
-
-  const sbomURL = React.useMemo(() => {
-    if (!imageDigest) return null;
-    return generateSbomUrl(imageDigest, sbomSha) || null;
-  }, [generateSbomUrl, imageDigest, sbomSha]);
+  const sboms = React.useMemo(
+    () => (taskRuns ? getSBOMsFromTaskRuns(taskRuns, generateSbomUrl) : []),
+    [taskRuns, generateSbomUrl],
+  );
 
   if (!(loaded && taskRunsLoaded)) {
     return (
@@ -124,6 +120,8 @@ const PipelineRunDetailsTab: React.FC = () => {
     pipelineRun.metadata?.annotations?.[PipelineRunLabel.RELEASE_NAMESPACE] ||
     pipelineRun.metadata?.labels?.[PipelineRunLabel.RELEASE_NAMESPACE] ||
     namespace;
+
+  const showSbom = sboms && ((sboms.length === 1 && sboms[0].url) || sboms.length > 1);
 
   return (
     <>
@@ -278,11 +276,21 @@ const PipelineRunDetailsTab: React.FC = () => {
                     </DescriptionListDescription>
                   </DescriptionListGroup>
                 )}
-                {sbomURL && (
+                {showSbom && (
                   <DescriptionListGroup>
                     <DescriptionListTerm>SBOM</DescriptionListTerm>
                     <DescriptionListDescription>
-                      <ExternalLink href={sbomURL}>View SBOM</ExternalLink>
+                      {sboms.length === 1 ? (
+                        <ExternalLink href={sboms[0].url}>View SBOM</ExternalLink>
+                      ) : (
+                        <Button
+                          variant="link"
+                          onClick={() => showModal(createPipelineRunSBOMsModal({ sboms }))}
+                          style={{ padding: 0 }}
+                        >
+                          View SBOMs
+                        </Button>
+                      )}
                     </DescriptionListDescription>
                   </DescriptionListGroup>
                 )}

--- a/src/components/PipelineRun/PipelineRunDetailsView/tabs/PipelineRunSBOMsModal.tsx
+++ b/src/components/PipelineRun/PipelineRunDetailsView/tabs/PipelineRunSBOMsModal.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Modal, ModalVariant, Stack, StackItem, Text } from '@patternfly/react-core';
+import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
+import { createRawModalLauncher, RawComponentProps } from '~/components/modal/createModalLauncher';
+import ExternalLink from '~/shared/components/links/ExternalLink';
+import { TaskRunSBOM } from '../utils/pipelinerun-utils';
+
+type PipelineRunSBOMsProps = {
+  sboms: TaskRunSBOM[];
+};
+
+type PipelineRunSBOMsModalProps = RawComponentProps & PipelineRunSBOMsProps;
+
+const PipelineRunSBOMsModal: React.FC<PipelineRunSBOMsModalProps> = ({ modalProps, sboms }) => {
+  return (
+    <Modal {...modalProps} title="SBOMs" variant={ModalVariant.small}>
+      <Stack hasGutter>
+        <StackItem>
+          <Table variant="compact" borders>
+            <Thead>
+              <Tr>
+                <Th>Note</Th>
+                <Th>Link</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {sboms.map((sbom, i) => (
+                <Tr key={`${sbom.url}-${i}`}>
+                  <Td>
+                    {sbom.isIndex ? (
+                      <Text style={{ fontWeight: 'bold' }}>Index</Text>
+                    ) : (
+                      sbom.platform || '-'
+                    )}
+                  </Td>
+                  <Td>
+                    <ExternalLink href={sbom.url}>View SBOM</ExternalLink>
+                  </Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </Table>
+        </StackItem>
+      </Stack>
+    </Modal>
+  );
+};
+
+export const createPipelineRunSBOMsModal = (props: PipelineRunSBOMsProps) =>
+  createRawModalLauncher<PipelineRunSBOMsProps, Record<string, unknown>>(PipelineRunSBOMsModal, {
+    'data-test': 'pipelinerun-sboms-modal',
+  })(props);

--- a/src/components/PipelineRun/PipelineRunDetailsView/utils/__tests__/pipelinerun-utils.spec.ts
+++ b/src/components/PipelineRun/PipelineRunDetailsView/utils/__tests__/pipelinerun-utils.spec.ts
@@ -1,9 +1,26 @@
 import '@testing-library/jest-dom';
 import { PipelineRunLabel } from '~/consts/pipelinerun';
-import { PipelineRunKind } from '~/types';
-import { getSourceUrl, stripQueryStringParams } from '../pipelinerun-utils';
+import { PipelineRunKind, TaskRunKind, TektonResourceLabel } from '~/types';
+import { SBOMResultKeys } from '~/utils/pipeline-utils';
+import {
+  getSourceUrl,
+  stripQueryStringParams,
+  getSBOMSha,
+  getSBOMsFromTaskRuns,
+} from '../pipelinerun-utils';
 
 describe('pipelinerun-utils', () => {
+  const mockGenerateUrl = jest.fn((sha?: string) =>
+    sha ? `https://sbom.example.com/${sha}` : undefined,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGenerateUrl.mockImplementation((sha?: string) =>
+      sha ? `https://sbom.example.com/${sha}` : undefined,
+    );
+  });
+
   describe('stripQueryStringParams', () => {
     it('should remove query string parameters from URL', () => {
       const url = 'https://github.com/user/repo?foo=bar&baz=qux';
@@ -113,6 +130,359 @@ describe('pipelinerun-utils', () => {
 
       const result = getSourceUrl(pipelineRun);
       expect(result).toBe('https://github.com/user/repo');
+    });
+  });
+
+  describe('getSBOMSha', () => {
+    const mockSha256 = '4bc75035d73f6083683e040fc31f28e0ec6d1cbce5cb0a5e2611eb89bceb6c16';
+    const mockSha512 =
+      '058c06c944002099dd6254cba4e951c2f7989bbaafd8963fce4e8223199e902c371a2fda326275502992f312197cb8c4a4f9207d3940b59bbd23d76963f12214';
+
+    it('should extract SHA from valid SBOM blob URL with @ separator', () => {
+      const result = getSBOMSha(`quay.io/repo@sha256:${mockSha256}`);
+      expect(result).toBe(`sha256:${mockSha256}`);
+    });
+
+    it('should return null for invalid SBOM blob URL without @ separator', () => {
+      const result = getSBOMSha('invalid-url-without-separator');
+      expect(result).toBeNull();
+    });
+
+    it('should return null for SBOM blob URL with multiple @ separators', () => {
+      const result = getSBOMSha(`quay.io@repo@sha256:${mockSha256}`);
+      expect(result).toBeNull();
+    });
+
+    it('should return null for empty string', () => {
+      const result = getSBOMSha('');
+      expect(result).toBeNull();
+    });
+
+    it('should handle URL with only @ separator and no SHA', () => {
+      const result = getSBOMSha('quay.io/repo@');
+      expect(result).toBe('');
+    });
+
+    it('should extract SHA correctly with different SHA formats', () => {
+      expect(getSBOMSha(`registry.example.com/image@sha256:${mockSha256}`)).toBe(
+        `sha256:${mockSha256}`,
+      );
+      expect(getSBOMSha(`quay.io/namespace/repo@sha512:${mockSha512}`)).toBe(
+        `sha512:${mockSha512}`,
+      );
+    });
+  });
+
+  describe('getSBOMsFromTaskRuns', () => {
+    it('should return empty array for empty task runs', () => {
+      const result = getSBOMsFromTaskRuns([], mockGenerateUrl);
+      expect(result).toEqual([]);
+    });
+
+    it('should filter out task runs without SBOM results', () => {
+      const taskRun: TaskRunKind = {
+        metadata: {
+          name: 'test-task',
+          labels: {},
+        },
+        status: {
+          results: [
+            {
+              name: 'OTHER_RESULT',
+              value: 'some-value',
+            },
+          ],
+        },
+      } as unknown as TaskRunKind;
+
+      const result = getSBOMsFromTaskRuns([taskRun], mockGenerateUrl);
+      expect(result).toHaveLength(0);
+    });
+
+    it('should filter out task runs with undefined status', () => {
+      const taskRun: TaskRunKind = {
+        metadata: {
+          name: 'test-task',
+          labels: {},
+        },
+      } as unknown as TaskRunKind;
+
+      const result = getSBOMsFromTaskRuns([taskRun], mockGenerateUrl);
+      expect(result).toHaveLength(0);
+    });
+
+    it('should identify index SBOM when task label is build-image-index', () => {
+      const taskRun: TaskRunKind = {
+        metadata: {
+          name: 'test-task',
+          labels: {
+            [TektonResourceLabel.task]: 'build-image-index',
+          },
+        },
+        status: {
+          results: [
+            {
+              name: SBOMResultKeys.SBOM_SHA,
+              value: 'quay.io/repo@sha256:index123',
+            },
+          ],
+        },
+      } as unknown as TaskRunKind;
+
+      const result = getSBOMsFromTaskRuns([taskRun], mockGenerateUrl);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        url: 'https://sbom.example.com/sha256:index123',
+        isIndex: true,
+      });
+    });
+
+    it('should identify index SBOM when pipelineTask label is build-image-index', () => {
+      const taskRun: TaskRunKind = {
+        metadata: {
+          name: 'test-task',
+          labels: {
+            [TektonResourceLabel.pipelineTask]: 'build-image-index',
+          },
+        },
+        status: {
+          results: [
+            {
+              name: SBOMResultKeys.SBOM_SHA,
+              value: 'quay.io/repo@sha256:index456',
+            },
+          ],
+        },
+      } as unknown as TaskRunKind;
+
+      const result = getSBOMsFromTaskRuns([taskRun], mockGenerateUrl);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        url: 'https://sbom.example.com/sha256:index456',
+        isIndex: true,
+      });
+    });
+
+    it('should identify platform-specific SBOM when targetPlatform label exists', () => {
+      const taskRun: TaskRunKind = {
+        metadata: {
+          name: 'test-task',
+          labels: {
+            [TektonResourceLabel.targetPlatform]: 'linux/amd64',
+          },
+        },
+        status: {
+          results: [
+            {
+              name: SBOMResultKeys.SBOM_SHA,
+              value: 'quay.io/repo@sha256:platform123',
+            },
+          ],
+        },
+      } as unknown as TaskRunKind;
+
+      const result = getSBOMsFromTaskRuns([taskRun], mockGenerateUrl);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        url: 'https://sbom.example.com/sha256:platform123',
+        platform: 'linux/amd64',
+        isIndex: false,
+      });
+    });
+
+    it('should return SBOM without platform when no platform label exists', () => {
+      const taskRun: TaskRunKind = {
+        metadata: {
+          name: 'test-task',
+          labels: {},
+        },
+        status: {
+          results: [
+            {
+              name: SBOMResultKeys.SBOM_SHA,
+              value: 'quay.io/repo@sha256:no-platform123',
+            },
+          ],
+        },
+      } as unknown as TaskRunKind;
+
+      const result = getSBOMsFromTaskRuns([taskRun], mockGenerateUrl);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        url: 'https://sbom.example.com/sha256:no-platform123',
+        isIndex: false,
+      });
+    });
+
+    it('should handle v1beta1 task runs with taskResults', () => {
+      const taskRun: TaskRunKind = {
+        apiVersion: 'tekton.dev/v1beta1',
+        kind: 'TaskRun',
+        metadata: {
+          name: 'test-task',
+          labels: {
+            [TektonResourceLabel.targetPlatform]: 'linux/arm64',
+          },
+        },
+        status: {
+          taskResults: [
+            {
+              name: SBOMResultKeys.SBOM_SHA,
+              value: 'quay.io/repo@sha256:v1beta1-123',
+            },
+          ],
+        },
+      } as unknown as TaskRunKind;
+
+      const result = getSBOMsFromTaskRuns([taskRun], mockGenerateUrl);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        url: 'https://sbom.example.com/sha256:v1beta1-123',
+        platform: 'linux/arm64',
+        isIndex: false,
+      });
+    });
+
+    it('should handle multiple task runs with mixed types', () => {
+      const indexTaskRun: TaskRunKind = {
+        metadata: {
+          name: 'index-task',
+          labels: {
+            [TektonResourceLabel.task]: 'build-image-index',
+          },
+        },
+        status: {
+          results: [
+            {
+              name: SBOMResultKeys.SBOM_SHA,
+              value: 'quay.io/repo@sha256:index-sha',
+            },
+          ],
+        },
+      } as unknown as TaskRunKind;
+
+      const platformTaskRun: TaskRunKind = {
+        metadata: {
+          name: 'platform-task',
+          labels: {
+            [TektonResourceLabel.targetPlatform]: 'linux/amd64',
+          },
+        },
+        status: {
+          results: [
+            {
+              name: SBOMResultKeys.SBOM_SHA,
+              value: 'quay.io/repo@sha256:platform-sha',
+            },
+          ],
+        },
+      } as unknown as TaskRunKind;
+
+      const noPlatformTaskRun: TaskRunKind = {
+        metadata: {
+          name: 'no-platform-task',
+          labels: {},
+        },
+        status: {
+          results: [
+            {
+              name: SBOMResultKeys.SBOM_SHA,
+              value: 'quay.io/repo@sha256:no-platform-sha',
+            },
+          ],
+        },
+      } as unknown as TaskRunKind;
+
+      const noSbomTaskRun: TaskRunKind = {
+        metadata: {
+          name: 'no-sbom-task',
+          labels: {},
+        },
+        status: {
+          results: [
+            {
+              name: 'OTHER_RESULT',
+              value: 'some-value',
+            },
+          ],
+        },
+      } as unknown as TaskRunKind;
+
+      const result = getSBOMsFromTaskRuns(
+        [indexTaskRun, platformTaskRun, noPlatformTaskRun, noSbomTaskRun],
+        mockGenerateUrl,
+      );
+
+      expect(result).toHaveLength(3);
+      expect(result[0]).toEqual({
+        url: 'https://sbom.example.com/sha256:index-sha',
+        isIndex: true,
+      });
+      expect(result[1]).toEqual({
+        url: 'https://sbom.example.com/sha256:platform-sha',
+        platform: 'linux/amd64',
+        isIndex: false,
+      });
+      expect(result[2]).toEqual({
+        url: 'https://sbom.example.com/sha256:no-platform-sha',
+        isIndex: false,
+      });
+    });
+
+    it('should handle generateUrl returning undefined', () => {
+      const taskRun: TaskRunKind = {
+        metadata: {
+          name: 'test-task',
+          labels: {},
+        },
+        status: {
+          results: [
+            {
+              name: SBOMResultKeys.SBOM_SHA,
+              value: 'quay.io/repo@sha256:test123',
+            },
+          ],
+        },
+      } as unknown as TaskRunKind;
+
+      mockGenerateUrl.mockReturnValue(undefined);
+
+      const result = getSBOMsFromTaskRuns([taskRun], mockGenerateUrl);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should prioritize index over platform when both labels exist', () => {
+      const taskRun: TaskRunKind = {
+        metadata: {
+          name: 'test-task',
+          labels: {
+            [TektonResourceLabel.task]: 'build-image-index',
+            [TektonResourceLabel.targetPlatform]: 'linux/amd64',
+          },
+        },
+        status: {
+          results: [
+            {
+              name: SBOMResultKeys.SBOM_SHA,
+              value: 'quay.io/repo@sha256:test123',
+            },
+          ],
+        },
+      } as unknown as TaskRunKind;
+
+      const result = getSBOMsFromTaskRuns([taskRun], mockGenerateUrl);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        url: 'https://sbom.example.com/sha256:test123',
+        isIndex: true,
+      });
     });
   });
 });

--- a/src/components/PipelineRun/PipelineRunDetailsView/utils/pipelinerun-utils.ts
+++ b/src/components/PipelineRun/PipelineRunDetailsView/utils/pipelinerun-utils.ts
@@ -1,5 +1,6 @@
+import { isTaskV1Beta1, SBOMResultKeys } from '~/utils/pipeline-utils';
 import { PipelineRunLabel } from '../../../../consts/pipelinerun';
-import { PipelineRunKind } from '../../../../types';
+import { PipelineRunKind, TaskRunKind, TektonResourceLabel } from '../../../../types';
 
 export const stripQueryStringParams = (url: string) => {
   if (!url) return undefined;
@@ -19,4 +20,64 @@ export const getSourceUrl = (pipelineRun: PipelineRunKind): string => {
     pipelineRun.metadata?.annotations?.[PipelineRunLabel.COMMIT_FULL_REPO_URL_ANNOTATION];
 
   return stripQueryStringParams(repoFromPACAnnotation || repoFromBuildServiceAnnotation);
+};
+
+export type TaskRunSBOM = {
+  url?: string;
+  platform?: string;
+  isIndex: boolean;
+};
+
+export const getSBOMSha = (sbomBlobUrl: string) => {
+  const parts = sbomBlobUrl.split('@');
+  return parts.length === 2 ? parts[1] : null;
+};
+
+export const getSBOMsFromTaskRuns = (
+  taskRuns: TaskRunKind[],
+  generateUrl: (sbomSha?: string) => string | undefined,
+) => {
+  return taskRuns
+    .map((taskRun): TaskRunSBOM | undefined => {
+      const results = isTaskV1Beta1(taskRun)
+        ? taskRun.status?.taskResults
+        : taskRun.status?.results;
+      const sbomResult = results?.find((res) => res.name === SBOMResultKeys.SBOM_SHA);
+
+      if (!sbomResult) {
+        return;
+      }
+
+      const sha = getSBOMSha(sbomResult.value);
+      if (!sha) {
+        return;
+      }
+
+      const url = generateUrl(sha);
+
+      if (
+        taskRun.metadata?.labels[TektonResourceLabel.task] === 'build-image-index' ||
+        taskRun.metadata?.labels[TektonResourceLabel.pipelineTask] === 'build-image-index'
+      ) {
+        return {
+          url,
+          isIndex: true,
+        };
+      }
+
+      const platform = taskRun.metadata?.labels[TektonResourceLabel.targetPlatform];
+      if (platform) {
+        return {
+          url,
+          platform,
+          isIndex: false,
+        };
+      }
+
+      return {
+        url,
+        isIndex: false,
+      };
+    })
+    .filter((sbom) => sbom !== undefined && sbom.url);
 };

--- a/src/hooks/__tests__/useUIInstance.spec.ts
+++ b/src/hooks/__tests__/useUIInstance.spec.ts
@@ -6,7 +6,14 @@ import {
   KonfluxPublicInfo,
 } from '~/types/konflux-public-info';
 import { mockUseKonfluxPublicInfo } from '~/unit-test-utils';
-import { useSbomUrl, useBombinoUrl, useUIInstance, useInstanceVisibility, useNotifications, useApplicationUrl } from '../useUIInstance';
+import {
+  useSbomUrl,
+  useBombinoUrl,
+  useUIInstance,
+  useInstanceVisibility,
+  useNotifications,
+  useApplicationUrl,
+} from '../useUIInstance';
 
 const useKonfluxPublicInfoMock = mockUseKonfluxPublicInfo();
 
@@ -43,7 +50,7 @@ describe('useSbomUrl', () => {
       {
         integrations: {
           sbom_server: {
-            url: 'https://atlas.devshift.net/sbom/content/<PLACEHOLDER>',
+            sbom_sha: 'https://atlas.devshift.net/sboms/<PLACEHOLDER>',
           },
         },
         rbac: [],
@@ -53,30 +60,8 @@ describe('useSbomUrl', () => {
     ]);
 
     const { result } = renderHook(() => useSbomUrl());
-    const sbomUrl = result.current('test-image-hash');
-    expect(sbomUrl).toBe('https://atlas.devshift.net/sbom/content/test-image-hash');
-  });
-
-  it('should return an empty string if SBOM URL is not available', () => {
-    useKonfluxPublicInfoMock.mockReturnValue([
-      {
-        integrations: {
-          image_controller: {
-            notifications: [],
-          },
-          sbom_server: {
-            url: '',
-          },
-        },
-        rbac: [],
-      },
-      true,
-      null,
-    ]);
-
-    const { result } = renderHook(() => useSbomUrl());
-    const sbomUrl = result.current('test-image-hash');
-    expect(sbomUrl).toBe('');
+    const sbomUrl = result.current('test-sbom-sha');
+    expect(sbomUrl).toBe('https://atlas.devshift.net/sboms/test-sbom-sha');
   });
 
   it('should handle undefined integrations gracefully', () => {
@@ -90,7 +75,7 @@ describe('useSbomUrl', () => {
     ]);
 
     const { result } = renderHook(() => useSbomUrl());
-    const sbomUrl = result.current('test-image-hash');
+    const sbomUrl = result.current('test-sbom-sha');
     expect(sbomUrl).toBe('');
   });
 
@@ -107,48 +92,8 @@ describe('useSbomUrl', () => {
     ]);
 
     const { result } = renderHook(() => useSbomUrl());
-    const sbomUrl = result.current('test-image-hash');
+    const sbomUrl = result.current('test-sbom-sha');
     expect(sbomUrl).toBe('');
-  });
-
-  it('should prioritize sbom_sha URL when both sbom_sha and imageHash are provided', () => {
-    useKonfluxPublicInfoMock.mockReturnValue([
-      {
-        integrations: {
-          sbom_server: {
-            url: 'https://atlas.devshift.net/sbom/content/<PLACEHOLDER>',
-            sbom_sha: 'https://atlas.devshift.net/sbom/sha/<PLACEHOLDER>',
-          },
-        },
-        rbac: [],
-      },
-      true,
-      null,
-    ]);
-
-    const { result } = renderHook(() => useSbomUrl());
-    const sbomUrl = result.current('test-image-hash', 'test-sbom-sha');
-    expect(sbomUrl).toBe('https://atlas.devshift.net/sbom/sha/test-sbom-sha');
-  });
-
-  it('should fallback to regular URL when sbom_sha is undefined but sbomSha parameter is provided', () => {
-    useKonfluxPublicInfoMock.mockReturnValue([
-      {
-        integrations: {
-          sbom_server: {
-            url: 'https://atlas.devshift.net/sbom/content/<PLACEHOLDER>',
-            sbom_sha: undefined,
-          },
-        },
-        rbac: [],
-      },
-      true,
-      null,
-    ]);
-
-    const { result } = renderHook(() => useSbomUrl());
-    const sbomUrl = result.current('test-image-hash', 'test-sbom-sha');
-    expect(sbomUrl).toBe('https://atlas.devshift.net/sbom/content/test-image-hash');
   });
 
   it('should handle empty sbom_sha gracefully', () => {
@@ -156,7 +101,6 @@ describe('useSbomUrl', () => {
       {
         integrations: {
           sbom_server: {
-            url: 'https://atlas.devshift.net/sbom/content/<PLACEHOLDER>',
             sbom_sha: '',
           },
         },
@@ -167,15 +111,15 @@ describe('useSbomUrl', () => {
     ]);
 
     const { result } = renderHook(() => useSbomUrl());
-    const sbomUrl = result.current('test-image-hash', 'test-sbom-sha');
-    expect(sbomUrl).toBe('https://atlas.devshift.net/sbom/content/test-image-hash');
+    const sbomUrl = result.current('test-sbom-sha');
+    expect(sbomUrl).toBe('');
   });
 
   it('should return undefined when data is still loading', () => {
     useKonfluxPublicInfoMock.mockReturnValue([{ rbac: [] }, false, null]);
 
     const { result } = renderHook(() => useSbomUrl());
-    const sbomUrl = result.current('test-image-hash');
+    const sbomUrl = result.current('test-sbom-sha');
     expect(sbomUrl).toBe(undefined);
   });
 
@@ -183,7 +127,7 @@ describe('useSbomUrl', () => {
     useKonfluxPublicInfoMock.mockReturnValue([{ rbac: [] }, true, new Error('Failed to load')]);
 
     const { result } = renderHook(() => useSbomUrl());
-    const sbomUrl = result.current('test-image-hash');
+    const sbomUrl = result.current('test-sbom-sha');
     expect(sbomUrl).toBe(undefined);
   });
 });
@@ -298,7 +242,7 @@ describe('useApplicationUrl', () => {
         rbac: [],
       },
       true,
-      undefined
+      undefined,
     ]);
 
     const { result } = renderHook(() => useApplicationUrl());
@@ -312,7 +256,7 @@ describe('useApplicationUrl', () => {
         rbac: [],
       },
       true,
-      undefined
+      undefined,
     ]);
 
     const { result } = renderHook(() => useApplicationUrl());
@@ -328,7 +272,7 @@ describe('useApplicationUrl', () => {
         rbac: [],
       },
       true,
-      undefined
+      undefined,
     ]);
 
     const { result } = renderHook(() => useApplicationUrl());
@@ -360,7 +304,7 @@ describe('useApplicationUrl', () => {
         rbac: [],
       },
       true,
-      undefined
+      undefined,
     ]);
 
     const { result } = renderHook(() => useApplicationUrl());
@@ -403,7 +347,7 @@ describe('useNotifications', () => {
         rbac: [],
       },
       true,
-      null
+      null,
     ]);
 
     const { result } = renderHook(() => useNotifications());
@@ -418,7 +362,7 @@ describe('useNotifications', () => {
         },
       } as KonfluxPublicInfo,
       true,
-      undefined
+      undefined,
     ]);
 
     const { result } = renderHook(() => useNotifications());
@@ -435,7 +379,7 @@ describe('useNotifications', () => {
         },
       } as KonfluxPublicInfo,
       true,
-      undefined
+      undefined,
     ]);
 
     const { result } = renderHook(() => useNotifications());

--- a/src/hooks/useUIInstance.ts
+++ b/src/hooks/useUIInstance.ts
@@ -26,27 +26,17 @@ const getBombinoUrl = (
   return notification?.config?.url ?? '';
 };
 
-export const useSbomUrl = (): ((imageHash: string, sbomSha?: string) => string | undefined) => {
+export const useSbomUrl = (): ((sbomSha?: string) => string | undefined) => {
   const [konfluxPublicInfo, loaded, error] = useKonfluxPublicInfo();
   return React.useCallback(
-    (imageHash: string, sbomSha?: string) => {
+    (sbomSha?: string) => {
       if (loaded && !error) {
         const sbomSHAUrl = konfluxPublicInfo.integrations?.sbom_server?.sbom_sha ?? '';
-        const sbomServerUrl = konfluxPublicInfo.integrations?.sbom_server?.url ?? '';
 
-        if (sbomSHAUrl && sbomSha) {
-          return sbomSHAUrl.replace(PLACEHOLDER, sbomSha);
-        }
-        // fallback if sbom sha data not available
-        return sbomServerUrl.replace(PLACEHOLDER, imageHash);
+        return sbomSHAUrl && sbomSha ? sbomSHAUrl.replace(PLACEHOLDER, sbomSha) : '';
       }
     },
-    [
-      error,
-      konfluxPublicInfo.integrations?.sbom_server?.sbom_sha,
-      konfluxPublicInfo.integrations?.sbom_server?.url,
-      loaded,
-    ],
+    [error, konfluxPublicInfo.integrations?.sbom_server?.sbom_sha, loaded],
   );
 };
 

--- a/src/types/coreTekton.ts
+++ b/src/types/coreTekton.ts
@@ -185,4 +185,5 @@ export enum TektonResourceLabel {
   taskrun = 'tekton.dev/taskRun',
   task = 'tekton.dev/task',
   pipelineTask = 'tekton.dev/pipelineTask',
+  targetPlatform = 'build.appstudio.redhat.com/target-platform',
 }


### PR DESCRIPTION
## Fixes 
[KONFLUX-10576](https://issues.redhat.com/browse/KONFLUX-10576)

## Description
The UI tried to get the SBOM url from the pipeline run, which is incorrect. Instead, the SBOM urls are gathered from the PLR's task runs. If there is only one SBOM url, the link stays the same. In the case of more SBOM urls (which is the case when the pipeline run has build tasks for multiple architectures), a modal view will open.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [X] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
Single SBOM:
<img width="1602" height="882" alt="image" src="https://github.com/user-attachments/assets/c3e517c1-ab05-437a-ae84-14a844394c26" />

Multiple SBOMs:

https://github.com/user-attachments/assets/4704527c-c960-4674-a830-28ce43b5e776



No SBOMs:
<img width="1602" height="882" alt="image" src="https://github.com/user-attachments/assets/6e62bd69-e080-4910-925f-a6f7eaecc443" />



## How to test or reproduce?
Go to any build pipeline run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modal to view multiple SBOMs from a pipeline run with platform/index notes and direct "View SBOM" links.
  * Single SBOMs appear as direct links; multiple SBOMs open via a "View SBOMs" button.
  * Recognizes and displays platform-targeted and index SBOMs.

* **Refactor**
  * SBOM URL resolution now derives from SBOM SHA for more consistent link behavior.

* **Tests**
  * Added comprehensive tests for SBOM SHA extraction, SBOM collection from task runs, and URL generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->