### PR TITLE
fix(KFLUXUI-818): don't query tekton when plr kubearchive is enabled

### DIFF
--- a/src/components/PipelineRun/PipelineRunDetailsView/index.ts
+++ b/src/components/PipelineRun/PipelineRunDetailsView/index.ts
@@ -1,12 +1,19 @@
-import { PipelineRunModel, TaskRunModel } from '../../../models';
-import { RouterParams } from '../../../routes/utils';
-import { QueryPipelineRun } from '../../../utils/pipelinerun-utils';
-import { createLoaderWithAccessCheck } from '../../../utils/rbac';
+import { isFeatureFlagOn } from '~/feature-flags/utils';
+import { PipelineRunModel, TaskRunModel } from '~/models';
+import { RouterParams } from '~/routes/utils';
+import { QueryPipelineRun, QueryPipelineRunWithKubearchive } from '~/utils/pipelinerun-utils';
+import { createLoaderWithAccessCheck } from '~/utils/rbac';
 
 export const pipelineRunDetailsViewLoader = createLoaderWithAccessCheck(
   ({ params }) => {
     const ns = params[RouterParams.workspaceName];
-    return QueryPipelineRun(ns, params[RouterParams.pipelineRunName]);
+    const pipelineRunName = params[RouterParams.pipelineRunName];
+
+    if (isFeatureFlagOn('pipelineruns-kubearchive')) {
+      return QueryPipelineRunWithKubearchive(ns, pipelineRunName);
+    }
+
+    return QueryPipelineRun(ns, pipelineRunName);
   },
   [
     { model: PipelineRunModel, verb: 'list' },


### PR DESCRIPTION
Assisted-by: Cursor


## Fixes
[KFLUXUI-818](https://issues.redhat.com/browse/KFLUXUI-818)

## Description
The loader for PipelineneRunDetailsView was not update to use kubearchive when the feature flag is enabled.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [X] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
Before:
<img width="1920" height="1090" alt="image" src="https://github.com/user-attachments/assets/e4911475-efa0-48a9-a232-1f98995f0833" />


After:
<img width="1920" height="1090" alt="image" src="https://github.com/user-attachments/assets/64474f8a-6931-4ae0-a801-63e3389c27e2" />


## How to test or reproduce?
Look at the network tab on any of the pipeline run details view tabs and filter out "record".

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a feature-flag controlled query path for pipeline run details to enable a staged rollout of an enhanced data retrieval method.
  * When the feature is enabled, the details view uses the new retrieval path; when disabled, it falls back to the existing behavior to ensure continuity and safer migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->