### PR TITLE
chore: add tests for IntegrationTests

### DIFF
--- a/src/components/IntegrationTests/IntegrationTestForm/IntegrationTestForm.tsx
+++ b/src/components/IntegrationTests/IntegrationTestForm/IntegrationTestForm.tsx
@@ -10,7 +10,7 @@ import { useApplicationBreadcrumbs } from '../../../utils/breadcrumb-utils';
 import PageLayout from '../../PageLayout/PageLayout';
 import IntegrationTestSection from './IntegrationTestSection';
 // [TODO]: Refactor form styles from the shared style sheet
-import '../../../shared/style.scss';
+import '~/shared/style.scss';
 import './IntegrationTestForm.scss';
 
 type IntegrationTestFormProps = {

--- a/src/components/IntegrationTests/IntegrationTestForm/__tests__/IntegrationTestCreateForm.spec.tsx
+++ b/src/components/IntegrationTests/IntegrationTestForm/__tests__/IntegrationTestCreateForm.spec.tsx
@@ -1,0 +1,56 @@
+import '@testing-library/jest-dom';
+import { screen } from '@testing-library/react';
+import { createUseParamsMock, routerRenderer } from '~/unit-test-utils/mock-react-router';
+import { IntegrationTestCreateForm } from '../IntegrationTestCreateForm';
+
+// IntegrationTestView has its own tests. We mock it here to focus on
+// testing IntegrationTestCreateForm's specific logic: extracting applicationName
+// from URL params and passing it to IntegrationTestView.
+jest.mock('../IntegrationTestView', () => ({
+  __esModule: true,
+  default: jest.fn(({ applicationName }) => (
+    <div data-test="integration-test-view">IntegrationTestView - {applicationName}</div>
+  )),
+}));
+
+describe('IntegrationTestCreateForm', () => {
+  const useParamsMock = createUseParamsMock();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render IntegrationTestView with applicationName from params', () => {
+    const mockApplicationName = 'test-application';
+    useParamsMock.mockReturnValue({ applicationName: mockApplicationName });
+
+    routerRenderer(<IntegrationTestCreateForm />);
+
+    expect(screen.getByTestId('integration-test-view')).toBeInTheDocument();
+    expect(screen.getByText(`IntegrationTestView - ${mockApplicationName}`)).toBeInTheDocument();
+  });
+
+  it('should pass undefined applicationName when not in params', () => {
+    useParamsMock.mockReturnValue({});
+
+    routerRenderer(<IntegrationTestCreateForm />);
+
+    const view = screen.getByTestId('integration-test-view');
+    expect(view).toBeInTheDocument();
+    expect(view.textContent).toMatch(/IntegrationTestView -\s*$/);
+  });
+
+  it('should update when applicationName param changes', () => {
+    const firstApp = 'first-app';
+    useParamsMock.mockReturnValue({ applicationName: firstApp });
+
+    const { rerender } = routerRenderer(<IntegrationTestCreateForm />);
+    expect(screen.getByText(`IntegrationTestView - ${firstApp}`)).toBeInTheDocument();
+
+    const secondApp = 'second-app';
+    useParamsMock.mockReturnValue({ applicationName: secondApp });
+
+    rerender(<IntegrationTestCreateForm />);
+    expect(screen.getByText(`IntegrationTestView - ${secondApp}`)).toBeInTheDocument();
+  });
+});

--- a/src/components/IntegrationTests/IntegrationTestForm/__tests__/IntegrationTestEditForm.spec.tsx
+++ b/src/components/IntegrationTests/IntegrationTestForm/__tests__/IntegrationTestEditForm.spec.tsx
@@ -1,0 +1,133 @@
+import '@testing-library/jest-dom';
+import { screen } from '@testing-library/react';
+import { MockIntegrationTestsWithGit } from '~/components/IntegrationTests/IntegrationTestsListView/__data__/mock-integration-tests';
+import { IntegrationTestScenarioKind } from '~/types/coreBuildService';
+import { mockUseNamespaceHook } from '~/unit-test-utils/mock-namespace';
+import { createUseParamsMock, routerRenderer } from '~/unit-test-utils/mock-react-router';
+import { IntegrationTestEditForm } from '../IntegrationTestEditForm';
+
+// IntegrationTestView has its own tests. We mock it here to focus on
+// testing IntegrationTestEditForm's specific logic: loading integration test data,
+// handling loading and error states, and passing the loaded data to IntegrationTestView.
+jest.mock('../IntegrationTestView', () => ({
+  __esModule: true,
+  default: jest.fn(({ applicationName, integrationTest }) => (
+    <div data-test="integration-test-view">
+      IntegrationTestView - {applicationName} - {integrationTest?.metadata?.name || 'no-test'}
+    </div>
+  )),
+}));
+
+const mockIntegrationTest: IntegrationTestScenarioKind = MockIntegrationTestsWithGit[0];
+
+const mockUseIntegrationTestScenario = jest.fn();
+
+jest.mock('../../../../hooks/useIntegrationTestScenarios', () => ({
+  useIntegrationTestScenario: (...args: unknown[]) => mockUseIntegrationTestScenario(...args),
+}));
+
+describe('IntegrationTestEditForm', () => {
+  const mockNamespace = 'test-namespace';
+  const mockApplicationName = 'test-app';
+  const mockIntegrationTestName = 'test-app-test-1';
+
+  const useNamespaceMock = mockUseNamespaceHook(mockNamespace);
+  const useParamsMock = createUseParamsMock();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useNamespaceMock.mockReturnValue(mockNamespace);
+    useParamsMock.mockReturnValue({
+      applicationName: mockApplicationName,
+      integrationTestName: mockIntegrationTestName,
+    });
+  });
+
+  it('should render spinner when loading integration test data', () => {
+    mockUseIntegrationTestScenario.mockReturnValue([null, false, undefined]);
+
+    routerRenderer(<IntegrationTestEditForm />);
+
+    expect(screen.getByTestId('spinner')).toBeInTheDocument();
+    expect(screen.queryByTestId('integration-test-view')).not.toBeInTheDocument();
+  });
+
+  it('should call useIntegrationTestScenario with correct parameters', () => {
+    mockUseIntegrationTestScenario.mockReturnValue([mockIntegrationTest, true, undefined]);
+
+    routerRenderer(<IntegrationTestEditForm />);
+
+    expect(mockUseIntegrationTestScenario).toHaveBeenCalledWith(
+      mockNamespace,
+      mockApplicationName,
+      mockIntegrationTestName,
+    );
+  });
+
+  it('should render IntegrationTestView when data is loaded', () => {
+    mockUseIntegrationTestScenario.mockReturnValue([mockIntegrationTest, true, undefined]);
+
+    routerRenderer(<IntegrationTestEditForm />);
+
+    expect(screen.getByTestId('integration-test-view')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        `IntegrationTestView - ${mockApplicationName} - ${mockIntegrationTest.metadata.name}`,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should render error state when integration test fails to load', () => {
+    const mockError = { message: 'Integration test not found', code: 404 };
+    mockUseIntegrationTestScenario.mockReturnValue([null, true, mockError]);
+
+    routerRenderer(<IntegrationTestEditForm />);
+
+    expect(screen.getByText('404: Page not found')).toBeInTheDocument();
+    expect(screen.queryByTestId('integration-test-view')).not.toBeInTheDocument();
+  });
+
+  it('should render error state for server errors', () => {
+    const mockError = { message: 'Server error', code: 500 };
+    mockUseIntegrationTestScenario.mockReturnValue([null, true, mockError]);
+
+    routerRenderer(<IntegrationTestEditForm />);
+
+    expect(screen.getByText(/Server error/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('integration-test-view')).not.toBeInTheDocument();
+  });
+
+  it('should not render spinner when data is loaded', () => {
+    mockUseIntegrationTestScenario.mockReturnValue([mockIntegrationTest, true, undefined]);
+
+    routerRenderer(<IntegrationTestEditForm />);
+
+    expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
+  });
+
+  it('should update when integration test name param changes', () => {
+    mockUseIntegrationTestScenario.mockReturnValue([mockIntegrationTest, true, undefined]);
+
+    const { rerender } = routerRenderer(<IntegrationTestEditForm />);
+
+    expect(mockUseIntegrationTestScenario).toHaveBeenCalledWith(
+      mockNamespace,
+      mockApplicationName,
+      mockIntegrationTestName,
+    );
+
+    const newTestName = 'different-test';
+    useParamsMock.mockReturnValue({
+      applicationName: mockApplicationName,
+      integrationTestName: newTestName,
+    });
+
+    rerender(<IntegrationTestEditForm />);
+
+    expect(mockUseIntegrationTestScenario).toHaveBeenCalledWith(
+      mockNamespace,
+      mockApplicationName,
+      newTestName,
+    );
+  });
+});


### PR DESCRIPTION
Assisted-by: Claude


## Fix
[KFLUXUI-809](https://issues.redhat.com/browse/KFLUXUI-809)

## Description
As the subject.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for integration test form components (create and edit), covering rendering of the forms and embedded views, spinner/loading visibility during data fetch, handling of success and error states (including not-found and server errors), correct parameter passing, and dynamic behavior when URL parameters change that triggers re-fetches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->