### PR TITLE
fix(KFLUXUI-831): move plr commit filtering from UI to server

### DIFF
--- a/src/hooks/__tests__/usePipelineRunsForCommitV2.spec.ts
+++ b/src/hooks/__tests__/usePipelineRunsForCommitV2.spec.ts
@@ -206,7 +206,13 @@ describe('usePipelineRunsForCommitV2', () => {
         usePipelineRunsForCommitV2('test-ns', 'test-app', 'sample-sha'),
       );
 
-      expect(result.current).toEqual([[], false, null, undefined, undefined]);
+      expect(result.current).toEqual([
+        [],
+        false,
+        null,
+        undefined,
+        { hasNextPage: false, isFetchingNextPage: false },
+      ]);
     });
     it('should handle error', () => {
       const error = new Error('Kubearchive error');
@@ -226,7 +232,13 @@ describe('usePipelineRunsForCommitV2', () => {
         usePipelineRunsForCommitV2('test-ns', 'test-app', 'sample-sha'),
       );
 
-      expect(result.current).toEqual([[], true, error, undefined, undefined]);
+      expect(result.current).toEqual([
+        [],
+        true,
+        error,
+        undefined,
+        { hasNextPage: false, isFetchingNextPage: false },
+      ]);
     });
   });
 
@@ -332,7 +344,13 @@ describe('usePipelineRunsForCommitV2', () => {
         usePipelineRunsForCommitV2('test-ns', 'test-app', 'sample-sha'),
       );
 
-      expect(result.current).toEqual([[], false, null, undefined, undefined]);
+      expect(result.current).toEqual([
+        [],
+        false,
+        null,
+        undefined,
+        { hasNextPage: false, isFetchingNextPage: false },
+      ]);
     });
 
     it('should handle error', () => {
@@ -350,7 +368,13 @@ describe('usePipelineRunsForCommitV2', () => {
         usePipelineRunsForCommitV2('test-ns', 'test-app', 'sample-sha'),
       );
 
-      expect(result.current).toEqual([[], false, error, undefined, undefined]);
+      expect(result.current).toEqual([
+        [],
+        false,
+        error,
+        undefined,
+        { hasNextPage: false, isFetchingNextPage: false },
+      ]);
     });
   });
 });

--- a/src/hooks/usePipelineRunsForCommitV2.ts
+++ b/src/hooks/usePipelineRunsForCommitV2.ts
@@ -6,6 +6,11 @@ import { useComponents } from './useComponents';
 import { usePipelineRunsV2 } from './usePipelineRunsV2';
 import { GetNextPage, NextPageProps } from './useTektonResults';
 
+const COMMIT_LABEL_FOR_PLR_TYPE = {
+  [PipelineRunType.TEST]: PipelineRunLabel.TEST_SERVICE_COMMIT,
+  [PipelineRunType.BUILD]: PipelineRunLabel.COMMIT_LABEL,
+};
+
 export const usePipelineRunsForCommitV2 = (
   namespace: string,
   applicationName: string,
@@ -23,27 +28,40 @@ export const usePipelineRunsForCommitV2 = (
   );
 
   const enabled = !!namespace && !!applicationName && !!commit;
+  const commitLabelKey = plrType ? COMMIT_LABEL_FOR_PLR_TYPE[plrType] : undefined;
+
+  const options = React.useMemo(
+    () => ({
+      selector: {
+        filterByCreationTimestampAfter: application?.metadata?.creationTimestamp,
+        matchLabels: {
+          [PipelineRunLabel.APPLICATION]: applicationName,
+          ...(plrType && { [PipelineRunLabel.PIPELINE_TYPE]: plrType }),
+          // Server-side commit filter when type is known
+          ...(commitLabelKey && { [commitLabelKey]: commit }),
+        },
+        // Client-side commit filter when type is unknown (handles OR logic)
+        ...(!commitLabelKey && { filterByCommit: commit }),
+      },
+      ...(limit && { limit }),
+    }),
+    [applicationName, commit, application, limit, plrType, commitLabelKey],
+  );
+
   const [pipelineRuns, plrsLoaded, plrError, getNextPage, nextPageProps] = usePipelineRunsV2(
     enabled ? namespace : null,
-    React.useMemo(
-      () => ({
-        selector: {
-          filterByCreationTimestampAfter: application?.metadata?.creationTimestamp,
-          matchLabels: {
-            [PipelineRunLabel.APPLICATION]: applicationName,
-            ...(plrType && { [PipelineRunLabel.PIPELINE_TYPE]: plrType }),
-          },
-          filterByCommit: commit,
-        },
-        ...(limit && { limit }),
-      }),
-      [applicationName, commit, application, limit, plrType],
-    ),
+    options,
   );
 
   return React.useMemo(() => {
     if (!plrsLoaded || plrError) {
-      return [[], plrsLoaded, plrError, undefined, undefined];
+      return [
+        [],
+        plrsLoaded,
+        plrError,
+        undefined,
+        { hasNextPage: false, isFetchingNextPage: false },
+      ];
     }
     return [
       pipelineRuns.filter((plr) =>

--- a/src/hooks/usePipelineRunsV2.ts
+++ b/src/hooks/usePipelineRunsV2.ts
@@ -141,25 +141,10 @@ export const usePipelineRunsV2 = (
 
   const queryTr = !kubearchiveEnabled && shouldQueryExternalSources;
 
-  // Tekton Results (raw) and mirrored commit filtering
-  const [trResourcesRaw, trLoaded, trError, trGetNextPage, nextPageProps] = useTRPipelineRuns(
+  const [trResources, trLoaded, trError, trGetNextPage, nextPageProps] = useTRPipelineRuns(
     queryTr ? namespace : null,
     optionsMemo,
   );
-
-  const trResources = React.useMemo((): PipelineRunKind[] => {
-    if (!trResourcesRaw || trResourcesRaw.length === 0) {
-      return [];
-    }
-
-    if (optionsMemo?.selector?.filterByCommit) {
-      return trResourcesRaw.filter(
-        (plr) => getCommitSha(plr) === optionsMemo.selector.filterByCommit,
-      );
-    }
-
-    return trResourcesRaw;
-  }, [trResourcesRaw, optionsMemo?.selector?.filterByCommit]);
 
   // KubeArchive query config when enabled
   const resourceInit = React.useMemo(

--- a/src/utils/__tests__/kubearchive-filter-transforms.spec.ts
+++ b/src/utils/__tests__/kubearchive-filter-transforms.spec.ts
@@ -1,5 +1,3 @@
-import { PipelineRunLabel } from '~/consts/pipelinerun';
-import { createEquals } from '~/k8s/k8s-utils';
 import { MatchExpression, MatchLabels } from '~/types/k8s';
 import {
   convertFilterToKubearchiveSelectors,
@@ -44,37 +42,6 @@ describe('task-run-filter-transforms', () => {
       });
 
       expect(result.selector.matchExpressions).toEqual(matchExpressions);
-    });
-
-    it('should convert filterByCommit to match expression', () => {
-      const commitSha = 'abc123def456';
-      const result = convertFilterToKubearchiveSelectors({
-        filterByCommit: commitSha,
-      });
-
-      expect(result.selector.matchExpressions).toEqual([
-        createEquals(PipelineRunLabel.COMMIT_LABEL, commitSha),
-      ]);
-    });
-
-    it('should combine existing matchExpressions with commit expression', () => {
-      const existingExpressions: MatchExpression[] = [
-        {
-          key: 'custom.label',
-          operator: 'Exists',
-        },
-      ];
-
-      const result = convertFilterToKubearchiveSelectors({
-        matchExpressions: existingExpressions,
-        filterByCommit: 'abc123',
-      });
-
-      expect(result.selector.matchExpressions).toHaveLength(2); // 1 existing + 1 commit expression
-      expect(result.selector.matchExpressions[0]).toEqual(existingExpressions[0]);
-      expect(result.selector.matchExpressions[1]).toEqual(
-        createEquals(PipelineRunLabel.COMMIT_LABEL, 'abc123'),
-      );
     });
 
     it('should handle empty input', () => {

--- a/src/utils/kubearchive-filter-transform.ts
+++ b/src/utils/kubearchive-filter-transform.ts
@@ -1,6 +1,4 @@
 import { MatchExpression, Selector, WatchK8sResource } from '~/types/k8s';
-import { PipelineRunLabel } from '../consts/pipelinerun';
-import { createEquals } from '../k8s';
 
 export type KubearchiveFilterTransformSelector = Selector &
   Partial<{
@@ -33,13 +31,7 @@ export const convertFilterToKubearchiveSelectors = (
         .join(',')
     : undefined;
 
-  // Build matchExpressions (including commit filter)
-  const matchExpressions: MatchExpression[] = [
-    ...(filterBy.matchExpressions ?? []),
-    ...(filterBy.filterByCommit
-      ? [createEquals(PipelineRunLabel.COMMIT_LABEL, filterBy.filterByCommit)]
-      : []),
-  ];
+  const matchExpressions: MatchExpression[] = [...(filterBy.matchExpressions ?? [])];
 
   // Build the final selector (excluding custom filter fields)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
Assisted-by: Cursor


## Fixes 
[KFLUXUI-831](https://issues.redhat.com/browse/KFLUXUI-831)


## Description
Commit details page sometimes yields 404 due to UI side filtering by commit, when the limit is small enough. This is especially noticeable for Commit details page, which uses usePipelineRunsForCommitsV2 hook with limit set to 1.

There's no single label which is present for all types of pipeline runs (test pipeline runs use `'pac.test.appstudio.openshift.io/sha'`, build pipeline runs use `'pipelinesascode.tekton.dev/sha'`). Kubernetes (and Kubearchive) don't support query where only some of the labels are present.

Tekton Results supports this, filtering is moved completely from UI to there.

For Kubernetes/Kubearchive, when the type of the pipeline runs we want to query is known, it's specialized label is used and pipeline runs are filtered on the server. If the query requires more pipeline run types, the filtering is done on the UI side.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [X] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
Can be consistently reproduced on this commit `/ns/rh-ee-mmarcin-tenant/applications/application/commit/d8ab69e2e6df5504d99e56c4eda956a5da86673a?ff_pipelineruns-kubearchive=true` when Kubearchive is enabled for pipeline runs.

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent pagination state is now returned across loading/error scenarios for pipeline run views.
  * Improved filtering behavior so pipeline run lists are more reliable.

* **Refactor**
  * Consolidated and simplified pipeline run filtering logic for maintainability and clearer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->