### PR TITLE
fix: infinit loading on the snapshot list page

### DIFF
--- a/src/components/Releases/index.ts
+++ b/src/components/Releases/index.ts
@@ -1,3 +1,4 @@
+import { PipelineRunLabel } from '~/consts/pipelinerun';
 import { k8sQueryGetResource, K8sQueryListResourceItems } from '../../k8s';
 import { ReleaseModel } from '../../models';
 import { RouterParams } from '../../routes/utils';
@@ -5,11 +6,15 @@ import { getLastUsedNamespace } from '../../shared/providers/Namespace/utils';
 import { createLoaderWithAccessCheck } from '../../utils/rbac';
 
 export const releaseListViewTabLoader = createLoaderWithAccessCheck(
-  async () => {
-    const ns = getLastUsedNamespace();
+  async ({ params }) => {
+    const ns = params[RouterParams.workspaceName];
+    const applicationName = params[RouterParams.applicationName];
     return K8sQueryListResourceItems({
       model: ReleaseModel,
-      queryOptions: { ns },
+      queryOptions: {
+        ns,
+        queryParams: { matchLabels: { [PipelineRunLabel.APPLICATION]: applicationName } },
+      },
     });
   },
   { model: ReleaseModel, verb: 'list' },

--- a/src/components/Snapshots/SnapshotsListView/SnapshotsList.tsx
+++ b/src/components/Snapshots/SnapshotsListView/SnapshotsList.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Spinner, Bullseye, Stack } from '@patternfly/react-core';
 import { SortByDirection } from '@patternfly/react-table';
 import { useSortedResources } from '../../../hooks/useSortedResources';
 import { Table } from '../../../shared';
@@ -29,6 +30,7 @@ const getLastSuccessfulReleaseTimestamp = (snapshot: Snapshot): string => {
 const SnapshotsList: React.FC<React.PropsWithChildren<SnapshotsListProps>> = ({
   snapshots,
   applicationName,
+  infiniteLoadingProps,
 }) => {
   const [activeSortIndex, setActiveSortIndex] = React.useState<number>(
     SortableSnapshotHeaders.name,
@@ -88,7 +90,28 @@ const SnapshotsList: React.FC<React.PropsWithChildren<SnapshotsListProps>> = ({
           id: `${obj.metadata.name}-snapshot-list-item`,
           'aria-label': obj.metadata.name,
         })}
+        isInfiniteLoading
+        infiniteLoaderProps={{
+          isRowLoaded: (args) => {
+            return !!sortedSnapshots[args.index];
+          },
+          loadMoreRows: () => {
+            infiniteLoadingProps?.hasNextPage &&
+              !infiniteLoadingProps?.isFetchingNextPage &&
+              infiniteLoadingProps?.fetchNextPage?.();
+          },
+          rowCount: infiniteLoadingProps?.hasNextPage
+            ? sortedSnapshots.length + 1
+            : sortedSnapshots.length,
+        }}
       />
+      {infiniteLoadingProps?.isFetchingNextPage ? (
+        <Stack style={{ marginTop: 'var(--pf-v5-global--spacer--md)' }} hasGutter>
+          <Bullseye>
+            <Spinner size="lg" aria-label="Loading more snapshots" />
+          </Bullseye>
+        </Stack>
+      ) : null}
     </>
   );
 };

--- a/src/components/Snapshots/SnapshotsListView/SnapshotsListView.tsx
+++ b/src/components/Snapshots/SnapshotsListView/SnapshotsListView.tsx
@@ -45,6 +45,9 @@ const SnapshotsListView: React.FC<React.PropsWithChildren<SnapshotsListViewProps
     isLoading,
     clusterError,
     archiveError,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
   } = useK8sAndKarchResources<Snapshot>(
     {
       groupVersionKind: SnapshotGroupVersionKind,
@@ -133,7 +136,11 @@ const SnapshotsListView: React.FC<React.PropsWithChildren<SnapshotsListViewProps
           {filteredSnapshots.length === 0 ? (
             <FilteredEmptyState onClearFilters={onClearFilters} />
           ) : (
-            <SnapshotsList snapshots={filteredSnapshots} applicationName={applicationName} />
+            <SnapshotsList
+              snapshots={filteredSnapshots}
+              applicationName={applicationName}
+              infiniteLoadingProps={{ hasNextPage, isFetchingNextPage, fetchNextPage }}
+            />
           )}
         </>
       )}

--- a/src/components/Snapshots/SnapshotsListView/types.ts
+++ b/src/components/Snapshots/SnapshotsListView/types.ts
@@ -8,6 +8,11 @@ export type SnapshotsListViewProps = {
 export type SnapshotsListProps = {
   snapshots: Snapshot[];
   applicationName: string;
+  infiniteLoadingProps?: {
+    hasNextPage: boolean;
+    isFetchingNextPage: boolean;
+    fetchNextPage: () => void;
+  };
 };
 
 export type SnapshotsListRowProps = RowFunctionArgs<Snapshot> & {


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR fixes the infinite loading on Snapshot lists page. Additionally, adds the application label to the release page loader.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Snapshots list now supports infinite loading, allowing users to seamlessly navigate and load additional items when working with large result sets.

* **Bug Fixes**
  * Release list view now correctly filters releases by the selected application from the current route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->