### PR TITLE
Update Cosign installation link in PipelineRun details view

### DIFF
--- a/src/components/PipelineRun/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
+++ b/src/components/PipelineRun/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
@@ -269,7 +269,7 @@ const PipelineRunDetailsTab: React.FC = () => {
                       <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied">
                         {`cosign download sbom ${buildImage}`}
                       </ClipboardCopy>
-                      <ExternalLink href="https://docs.sigstore.dev/cosign/installation">
+                      <ExternalLink href="https://docs.sigstore.dev/cosign/system_config/installation">
                         Install Cosign
                       </ExternalLink>
                     </DescriptionListDescription>


### PR DESCRIPTION
This PR updates the Cosign installation link in the PipelineRunDetailsTab to point to the right location in the Sigstore documentation (`system_config/installation`).
The previous link (`/cosign/installation`) seems to be broken, so this ensures users are taken to the correct installation instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Cosign documentation link to direct to the latest system configuration resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->