### PR TITLE
chore: enable kubearchive flags by default

### DIFF
--- a/src/feature-flags/flags.ts
+++ b/src/feature-flags/flags.ts
@@ -64,7 +64,7 @@ const InternalFLAGS = {
   'kubearchive-logs': {
     key: 'kubearchive-logs',
     description: 'Use Kubearchive to fetch logs instead of Tekton',
-    defaultEnabled: false,
+    defaultEnabled: true,
     status: 'wip',
     guard: {
       allOf: ['isKubearchiveEnabled'],
@@ -86,7 +86,7 @@ const InternalFLAGS = {
   'taskruns-kubearchive': {
     key: 'taskruns-kubearchive',
     description: 'Use Kubearchive as data source for TaskRuns instead of Tekton results',
-    defaultEnabled: false,
+    defaultEnabled: true,
     status: 'wip',
     guard: {
       allOf: ['isKubearchiveEnabled'],
@@ -97,7 +97,7 @@ const InternalFLAGS = {
   'pipelineruns-kubearchive': {
     key: 'pipelineruns-kubearchive',
     description: 'Use KubeArchive as data source for PipelineRuns instead of Tekton Results',
-    defaultEnabled: false,
+    defaultEnabled: true,
     status: 'wip',
     guard: {
       allOf: ['isKubearchiveEnabled'],

--- a/src/feature-flags/forceEnableFlagsOnce.ts
+++ b/src/feature-flags/forceEnableFlagsOnce.ts
@@ -1,0 +1,62 @@
+import type { FlagKey } from './flags';
+import { FeatureFlagsStore } from './store';
+
+type ForceOnceOptions = {
+  releaseId: string;
+};
+
+function cleanupOldMarkers(prefix: string, keepKey: string): void {
+  try {
+    const keysToRemove: string[] = [];
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const key = window.localStorage.key(i);
+      if (!key) continue;
+      if (key.startsWith(prefix) && key !== keepKey) {
+        keysToRemove.push(key);
+      }
+    }
+    for (const key of keysToRemove) {
+      try {
+        window.localStorage.removeItem(key);
+      } catch {
+        // ignore
+      }
+    }
+  } catch {
+    // ignore any cleanup errors
+  }
+}
+
+/**
+ * Force-enable a list of feature flags once per release/build.
+ * Uses a versioned localStorage marker so it re-applies on each new build.
+ */
+export function forceEnableFlagsOnce(flags: FlagKey[], options: ForceOnceOptions): void {
+  try {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return;
+    }
+
+    const markerPrefix = '__ff_once__enable__';
+    const markerKey = `${markerPrefix}${options.releaseId}`;
+
+    // Always clean up older one-time markers to avoid LS bloat
+    cleanupOldMarkers(markerPrefix, markerKey);
+
+    if (window.localStorage.getItem(markerKey) === 'done') {
+      return;
+    }
+
+    for (const flagKey of flags) {
+      try {
+        FeatureFlagsStore.set(flagKey, true);
+      } catch {
+        // Ignore and continue enabling other flags
+      }
+    }
+
+    window.localStorage.setItem(markerKey, 'done');
+  } catch {
+    // Swallow errors to avoid impacting app startup
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import ReactDOM from 'react-dom/client';
 import { AuthProvider } from './auth/AuthContext';
+import { forceEnableFlagsOnce } from './feature-flags/forceEnableFlagsOnce';
 import { FeatureFlagsStore } from './feature-flags/store';
 import { getAllConditionsKeysFromFlags } from './feature-flags/utils';
 import { queryClient } from './k8s/query/core';
@@ -15,6 +16,11 @@ import { ThemeProvider } from './shared/theme/ThemeContext';
 import '@patternfly/react-core/dist/styles/base.css';
 import '@patternfly/react-styles/css/utilities/Spacing/spacing.css';
 import './main.scss';
+
+// TEMP: Force-enable selected flags once per release/build
+forceEnableFlagsOnce(['kubearchive-logs', 'taskruns-kubearchive', 'pipelineruns-kubearchive'], {
+  releaseId: '2025-11-17',
+});
 
 const App = () => {
   React.useEffect(() => {


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kubearchive support is now enabled by default for logs, taskruns, and pipelineruns.
* **Chores**
  * Added a one-time startup mechanism to ensure those feature flags are applied automatically for a given release without changing public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->