### PR TITLE
feat(KFLUXUI-327): Show message explaining why the pipelineRun failed

### DIFF
--- a/src/components/PipelineRun/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
+++ b/src/components/PipelineRun/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
@@ -217,7 +217,7 @@ const PipelineRunDetailsTab: React.FC = () => {
                         {pipelineRunFailed.title ?? '-'}
                         {showFailedMessage && (
                           <CodeBlock>
-                            <CodeBlockCode id="message-code-content">
+                            <CodeBlockCode data-test="message-code-block" id="message-code-content">
                               {pipelineRun.status?.conditions[0]?.message}
                             </CodeBlockCode>
                           </CodeBlock>

--- a/src/components/PipelineRun/PipelineRunDetailsView/tabs/__tests__/PipelineRunDetailsTab.spec.tsx
+++ b/src/components/PipelineRun/PipelineRunDetailsView/tabs/__tests__/PipelineRunDetailsTab.spec.tsx
@@ -38,6 +38,27 @@ const mockPipelineRun = {
   },
 } as unknown as PipelineRunKind;
 
+const baseFailedRun = testPipelineRuns[DataState.FAILED];
+const failedPipelineRun = {
+  ...baseFailedRun,
+  status: {
+    ...baseFailedRun.status,
+    conditions: [
+      {
+        status: 'True',
+        type: 'Failure',
+        message: 'Pipeline execution failed with detailed error information',
+      },
+      {
+        status: 'False',
+        type: 'Succeeded',
+        message: 'Error retrieving pipeline for pipelinerun',
+        reason: 'CouldntGetPipeline',
+      },
+    ],
+  },
+} as PipelineRunKind;
+
 const mockTaskRuns: TaskRunKind[] = [];
 
 jest.mock('~/hooks/usePipelineRunsV2', () => ({
@@ -190,5 +211,36 @@ describe('PipelineRunDetailsTab', () => {
     // Check Duration label and value (5 minutes from mock data)
     expect(screen.getByText('Duration')).toBeInTheDocument();
     expect(screen.getByText('5 minutes')).toBeInTheDocument();
+  });
+
+  it('should display code block in message field when pipeline run failed', () => {
+    mockUsePipelineRunV2.mockReturnValue(mockPipelineRunStates.loaded(failedPipelineRun));
+    mockUseTaskRunsForPipelineRuns.mockReturnValue(mockTaskRunsStates.loaded(mockTaskRuns));
+
+    renderWithQueryClientAndRouter(<PipelineRunDetailsTab />);
+
+    expect(screen.getByTestId('message-code-block')).toBeInTheDocument();
+  });
+
+  it('should not display code block in message field when pipeline run failed and message is the same as the static message', () => {
+    mockUsePipelineRunV2.mockReturnValue(
+      mockPipelineRunStates.loaded(testPipelineRuns[DataState.TASK_RUN_CANCELLED]),
+    );
+    mockUseTaskRunsForPipelineRuns.mockReturnValue(mockTaskRunsStates.loaded(mockTaskRuns));
+
+    renderWithQueryClientAndRouter(<PipelineRunDetailsTab />);
+
+    expect(screen.queryByTestId('message-code-block')).toBeNull();
+  });
+
+  it('should not display code block in message field when pipeline run succeeded', () => {
+    mockUsePipelineRunV2.mockReturnValue(
+      mockPipelineRunStates.loaded(testPipelineRuns[DataState.SUCCEEDED]),
+    );
+    mockUseTaskRunsForPipelineRuns.mockReturnValue(mockTaskRunsStates.loaded(mockTaskRuns));
+
+    renderWithQueryClientAndRouter(<PipelineRunDetailsTab />);
+
+    expect(screen.queryByTestId('message-code-block')).toBeNull();
   });
 });


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/KFLUXUI-327

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Adds a CodeBlock into `Message` field inside `PipelineRunDetailView` with count of succeeded/failed/canceled/skipped tasks for failed pipelined with status failed and different message than `Log snippet`, if it is the same, no extra field in `Message` is displayed.

## Type of change
<!-- Please delete options that are not relevant. -->

- [X] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
![Screenshot 2025-11-21 at 14 52 22](https://github.com/user-attachments/assets/19c5460a-9000-489e-a8d6-662beb62077d)
![Screenshot 2025-11-21 at 14 53 00](https://github.com/user-attachments/assets/7c2ff6c1-e2b6-4b4c-bc74-7bf268cd3772)


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [X] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pipeline Run Details now shows the run's detailed failure message in a separate readable block when a run fails (avoiding duplicate static messages), improving diagnostics.

* **Tests**
  * Added tests verifying the failure message block appears for genuine failures and is omitted when the run succeeded or the message matches the static placeholder.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->