### PR TITLE
fix(KONFLUX-11122): don't throw 404 for recent pipeline runs when kubearchive is enabled

### DIFF
--- a/src/kubearchive/__tests__/hooks.spec.ts
+++ b/src/kubearchive/__tests__/hooks.spec.ts
@@ -197,4 +197,19 @@ describe('useKubearchiveListResourceQuery', () => {
     expect(result.current.isLoading).toBe(true);
     expect(result.current.data).toBeUndefined();
   });
+
+  it('should not fail if resourceInit is undefined', () => {
+    mockK8sListResource.mockResolvedValue(mockListResponse);
+
+    const { result } = renderHook(
+      () => useKubearchiveListResourceQuery(undefined as WatchK8sResource, mockModel),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    expect(result.current).toBeDefined();
+    expect(result.current.status).toBeDefined();
+    expect(result.current.isError).toBe(false);
+  });
 });

--- a/src/kubearchive/fetch-utils.ts
+++ b/src/kubearchive/fetch-utils.ts
@@ -60,7 +60,7 @@ export function kubearchiveQueryListResource<TResource extends K8sResourceCommon
 
 export const convertToKubearchiveQueryParams = (
   resourceInit?: WatchK8sResource,
-): QueryOptionsWithSelector => {
+): QueryOptionsWithSelector | undefined => {
   if (!resourceInit) {
     return undefined;
   }

--- a/src/kubearchive/hooks.ts
+++ b/src/kubearchive/hooks.ts
@@ -48,10 +48,10 @@ export function useKubearchiveListResourceQuery<
       const pagedOptions = {
         model,
         queryOptions: {
-          ...k8sQueryOptions,
+          ...(k8sQueryOptions || {}),
           queryParams: {
             limit: KUBEARCHIVE_RESOURCE_LIMIT,
-            ...k8sQueryOptions.queryParams,
+            ...(k8sQueryOptions?.queryParams || {}),
             continue: (pageParam ? pageParam : undefined) as string | undefined,
           },
         },


### PR DESCRIPTION
Assisted-by: Cursor


## Fixes 
https://issues.redhat.com/browse/KONFLUX-11122


## Description
When Kubearchive feature flag was enabled for pipeline runs, the commit details page would incorrectly show 404 error. This was due to accessing fields on an undefined `k8sQueryoptions`.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [X] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
Access a very recent commit details page (less than 5-10 minutes old) with and without this fix to check the difference.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of undefined query parameters to prevent runtime errors
  * Enhanced robustness in data source initialization and query processing

* **Tests**
  * Added test coverage for edge case handling in data source initialization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->