### PR TITLE
Support proxy image url for private image repo

### DIFF
--- a/src/components/Components/ComponentDetails/tabs/ComponentDetails.tsx
+++ b/src/components/Components/ComponentDetails/tabs/ComponentDetails.tsx
@@ -12,7 +12,7 @@ import GitRepoLink from '~/components/GitLink/GitRepoLink';
 import HelpPopover from '~/components/HelpPopover';
 import { useLatestPushBuildPipelineRunForComponentV2 } from '~/hooks/useLatestPushBuildPipeline';
 import { useIsImageControllerEnabled } from '~/image-controller/conditional-checks';
-import ExternalLink from '~/shared/components/links/ExternalLink';
+import { ImageUrlDisplay } from '~/shared/components/image-display';
 import { useNamespace } from '~/shared/providers/Namespace/useNamespaceInfo';
 import { ComponentKind } from '~/types';
 import { getLastestImage } from '~/utils/component-utils';
@@ -118,15 +118,26 @@ const ComponentDetails: React.FC<React.PropsWithChildren<ComponentDetailsProps>>
             }}
           >
             <DescriptionListGroup>
-              <DescriptionListTerm>Latest image</DescriptionListTerm>
-              <DescriptionListDescription data-test="component-latest-image">
-                <ExternalLink
-                  href={
-                    componentImageURL.startsWith('http')
-                      ? componentImageURL
-                      : `https://${componentImageURL}`
+              <DescriptionListTerm>
+                Latest image{' '}
+                <HelpPopover
+                  bodyContent={
+                    <>
+                      For private repositories, shows the proxied URL when available, otherwise
+                      shows the original URL.
+                      <br />
+                      <br />
+                      Use with the &apos;Registry Login Information&apos; below to pull private
+                      images.
+                    </>
                   }
-                  text={componentImageURL}
+                />
+              </DescriptionListTerm>
+              <DescriptionListDescription data-test="component-latest-image">
+                <ImageUrlDisplay
+                  imageUrl={componentImageURL}
+                  namespace={component.metadata.namespace}
+                  componentName={component.metadata.name}
                   isHighlightable
                 />
               </DescriptionListDescription>

--- a/src/components/Components/ComponentDetails/tabs/__tests__/ComponentDetailsTab.spec.tsx
+++ b/src/components/Components/ComponentDetails/tabs/__tests__/ComponentDetailsTab.spec.tsx
@@ -3,6 +3,7 @@ import { fireEvent, screen } from '@testing-library/dom';
 import { mockPublicImageRepository } from '~/__data__/image-repository-data';
 import { useModalLauncher } from '~/components/modal/ModalProvider';
 import { useComponent } from '~/hooks/useComponents';
+import { useImageProxyHost } from '~/hooks/useImageProxyHost';
 import { useImageRepository } from '~/hooks/useImageRepository';
 import {
   useLatestPushBuildPipelineRunForComponentV2,
@@ -50,6 +51,10 @@ jest.mock('~/hooks/useImageRepository', () => ({
   useImageRepository: jest.fn(),
 }));
 
+jest.mock('~/hooks/useImageProxyHost', () => ({
+  useImageProxyHost: jest.fn(),
+}));
+
 jest.mock('~/image-controller/conditional-checks', () => ({
   useIsImageControllerEnabled: jest.fn(),
 }));
@@ -66,6 +71,7 @@ const useLatestPushBuildPipelineRunForComponentMock =
   useLatestPushBuildPipelineRunForComponentV2 as jest.Mock;
 const useModalLauncherMock = useModalLauncher as jest.Mock;
 const useTaskRunsV2Mock = useTaskRunsForPipelineRuns as jest.Mock;
+const useImageProxyHostMock = useImageProxyHost as jest.Mock;
 const useImageRepositoryMock = useImageRepository as jest.Mock;
 const useIsImageControllerEnabledMock = useIsImageControllerEnabled as jest.Mock;
 const useAccessReviewForModelMock = useAccessReviewForModel as jest.Mock;
@@ -89,6 +95,7 @@ describe('ComponentDetailTab', () => {
       true,
     ]);
     useTaskRunsV2Mock.mockReturnValue([mockTaskRuns, true]);
+    useImageProxyHostMock.mockReturnValue([null, true, null]);
     useImageRepositoryMock.mockReturnValue([null, true, null]);
     useIsImageControllerEnabledMock.mockReturnValue({ isImageControllerEnabled: true });
     useAccessReviewForModelMock.mockReturnValue([true, true]);
@@ -140,21 +147,11 @@ describe('ComponentDetailTab', () => {
 
   it('should renderWithQueryClientAndRouter Component latest build image URL when latest build exists', () => {
     useComponentMock.mockReturnValue([
-      { ...mockComponent, spec: { containerImage: 'test-url', ...mockComponent.spec } },
-      true,
-    ]);
-    useLatestPushBuildPipelineRunForComponentMock.mockReturnValue([
       {
-        ...mockLatestSuccessfulBuild,
+        ...mockComponent,
         status: {
-          results: [
-            {
-              description: '',
-              name: 'IMAGE_URL',
-              value: 'build-container.image.url',
-            },
-          ],
-          ...mockLatestSuccessfulBuild.status,
+          ...mockComponent.status,
+          lastPromotedImage: 'build-container.image.url',
         },
       },
       true,

--- a/src/components/Components/ComponentsListView/ComponentsListRow.tsx
+++ b/src/components/Components/ComponentsListView/ComponentsListRow.tsx
@@ -5,7 +5,7 @@ import { PacStatesForComponents } from '../../../hooks/usePACStatesForComponents
 import { COMPONENT_DETAILS_PATH, COMMIT_DETAILS_PATH } from '../../../routes/paths';
 import { RowFunctionArgs, TableData } from '../../../shared';
 import ActionMenu from '../../../shared/components/action-menu/ActionMenu';
-import ExternalLink from '../../../shared/components/links/ExternalLink';
+import { ImageUrlDisplay } from '../../../shared/components/image-display';
 import { useNamespace } from '../../../shared/providers/Namespace/useNamespaceInfo';
 import { ComponentKind, PipelineRunKind } from '../../../types';
 import { getCommitsFromPLRs } from '../../../utils/commits-utils';
@@ -20,11 +20,6 @@ import { componentsTableColumnClasses } from './ComponentsListHeader';
 
 type ComponentWithLatestBuildPipeline = ComponentKind & {
   latestBuildPipelineRun?: PipelineRunKind;
-};
-
-export const getContainerImageLink = (url: string) => {
-  const imageUrl = url.includes('@sha') ? url.split('@sha')[0] : url;
-  return imageUrl.startsWith('http') ? imageUrl : `https://${imageUrl}`;
 };
 
 const ComponentsListRow: React.FC<
@@ -75,12 +70,10 @@ const ComponentsListRow: React.FC<
           )}
           {latestImage && (
             <FlexItem>
-              <ExternalLink
-                /** by default patternfly button disable text selection on Button component
-                    this enables it on <a /> tag */
-                style={{ userSelect: 'auto' }}
-                href={getContainerImageLink(latestImage)}
-                text={latestImage}
+              <ImageUrlDisplay
+                imageUrl={latestImage}
+                namespace={component.metadata.namespace}
+                componentName={component.metadata.name}
               />
             </FlexItem>
           )}

--- a/src/components/Components/ComponentsListView/__tests__/ComponentListView.spec.tsx
+++ b/src/components/Components/ComponentsListView/__tests__/ComponentListView.spec.tsx
@@ -10,7 +10,6 @@ import { createK8sWatchResourceMock, createUseApplicationMock } from '../../../.
 import { componentCRMocks } from '../../__data__/mock-data';
 import { mockPipelineRuns } from '../../__data__/mock-pipeline-run';
 import ComponentListView from '../ComponentListView';
-import { getContainerImageLink } from '../ComponentsListRow';
 
 jest.useFakeTimers();
 
@@ -198,20 +197,5 @@ describe('ComponentListViewPage', () => {
     useTRPipelineRunsMock.mockReturnValue([[], true, undefined, getNextPageMock]);
     renderWithQueryClient(<ComponentList />);
     expect(getNextPageMock).toHaveBeenCalled();
-  });
-});
-
-describe('getContainerImageLink', () => {
-  it('should return valid container image url', () => {
-    expect(getContainerImageLink('https://quay.io/repo/image')).toEqual(
-      'https://quay.io/repo/image',
-    );
-    expect(getContainerImageLink('quay.io/repo/image')).toEqual('https://quay.io/repo/image');
-    expect(getContainerImageLink('quay.io/repo/image@sha256:asd23412s1243')).toEqual(
-      'https://quay.io/repo/image',
-    );
-    expect(getContainerImageLink('https://quay.io/repo/image@sha256:asd23412s1243')).toEqual(
-      'https://quay.io/repo/image',
-    );
   });
 });

--- a/src/components/SnapshotDetails/tabs/__tests__/SnapshotComponentsListRow.spec.tsx
+++ b/src/components/SnapshotDetails/tabs/__tests__/SnapshotComponentsListRow.spec.tsx
@@ -1,12 +1,20 @@
-import { screen, render } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import { useImageRepository } from '~/hooks/useImageRepository';
+import { renderWithQueryClientAndRouter } from '~/unit-test-utils/rendering-utils';
 import { mockComponentsData } from '../../../ApplicationDetails/__data__';
 import SnapshotComponentsListRow, {
   SnapshotComponentTableData,
 } from '../SnapshotComponentsListRow';
 
-jest.mock('react-router-dom', () => ({
-  Link: (props) => <a href={props.to}>{props.children}</a>,
+jest.mock('~/hooks/useImageRepository', () => ({
+  useImageRepository: jest.fn(),
 }));
+
+jest.mock('~/hooks/useImageProxyHost', () => ({
+  useImageProxyHost: () => ['image-rbac-proxy', true, null],
+}));
+
+const useImageRepositoryMock = useImageRepository as jest.Mock;
 
 const rowData: SnapshotComponentTableData = {
   metadata: { uid: mockComponentsData[1].metadata.uid, name: mockComponentsData[1].metadata.name },
@@ -17,13 +25,24 @@ const rowData: SnapshotComponentTableData = {
 };
 
 describe('SnapshotComponentsListRow', () => {
+  beforeEach(() => {
+    // Mock useImageRepository to return null (no image repository data)
+    useImageRepositoryMock.mockReturnValue([null, true, null]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should list correct Component ', () => {
-    const { queryByText } = render(<SnapshotComponentsListRow columns={null} obj={rowData} />);
+    const { queryByText } = renderWithQueryClientAndRouter(
+      <SnapshotComponentsListRow columns={null} obj={rowData} />,
+    );
     expect(queryByText('test-go')).toBeInTheDocument();
   });
 
   it('should list Git URL as a link ', () => {
-    render(<SnapshotComponentsListRow columns={null} obj={rowData} />);
+    renderWithQueryClientAndRouter(<SnapshotComponentsListRow columns={null} obj={rowData} />);
     const githubLink = screen.queryByTestId('snapshot-component-git-url');
     expect(githubLink.getAttribute('href')).toBe(
       'https://github.com/test-user-1/devfile-sample-go-basic',
@@ -31,13 +50,15 @@ describe('SnapshotComponentsListRow', () => {
   });
 
   it('should not show git section when url is not available ', () => {
-    render(<SnapshotComponentsListRow columns={null} obj={{ ...rowData, source: null }} />);
+    renderWithQueryClientAndRouter(
+      <SnapshotComponentsListRow columns={null} obj={{ ...rowData, source: null }} />,
+    );
     const githubLink = screen.queryByTestId('snapshot-component-git-url');
     expect(githubLink).toBeNull();
   });
 
   it('should list Revision correctly ', () => {
-    render(
+    renderWithQueryClientAndRouter(
       <SnapshotComponentsListRow
         columns={null}
         obj={{
@@ -50,7 +71,7 @@ describe('SnapshotComponentsListRow', () => {
   });
 
   it('should list Revision as a link ', () => {
-    render(
+    renderWithQueryClientAndRouter(
       <SnapshotComponentsListRow
         columns={null}
         obj={{
@@ -66,7 +87,7 @@ describe('SnapshotComponentsListRow', () => {
     );
   });
   it('should show hyphen when revision is not available ', () => {
-    render(
+    renderWithQueryClientAndRouter(
       <SnapshotComponentsListRow
         columns={null}
         obj={{
@@ -76,5 +97,21 @@ describe('SnapshotComponentsListRow', () => {
       />,
     );
     expect(screen.getByText('-')).toBeInTheDocument();
+  });
+
+  it('should show skeleton while loading image repository', () => {
+    useImageRepositoryMock.mockReturnValue([null, false, null]);
+    renderWithQueryClientAndRouter(<SnapshotComponentsListRow columns={null} obj={rowData} />);
+    expect(screen.getByLabelText('Loading image URL')).toBeInTheDocument();
+  });
+
+  it('should show ClipboardCopy for private image with proxy URL', () => {
+    useImageRepositoryMock.mockReturnValue([
+      { spec: { image: { visibility: 'private' } } },
+      true,
+      null,
+    ]);
+    renderWithQueryClientAndRouter(<SnapshotComponentsListRow columns={null} obj={rowData} />);
+    expect(screen.getByRole('button', { name: /copy/i })).toBeInTheDocument();
   });
 });

--- a/src/hooks/useImageProxyHost.ts
+++ b/src/hooks/useImageProxyHost.ts
@@ -1,0 +1,19 @@
+import { useKonfluxPublicInfo } from './useKonfluxPublicInfo';
+
+/**
+ * Hook to get the image proxy host from Konflux public info.
+ * Extracts the hostname from the imageProxyUrl (e.g., "https://image-proxy.example.com" -> "image-proxy.example.com")
+ *
+ * @returns [host: string | null, loaded: boolean, error: unknown]
+ * - host: The image proxy hostname or null if imageProxyUrl is not available
+ * - loaded: Whether the data has finished loading
+ * - error: Any error that occurred while fetching the data
+ */
+export const useImageProxyHost = (): [string | null, boolean, unknown] => {
+  const [publicInfo, loaded, error] = useKonfluxPublicInfo();
+
+  // Remove http:// or https:// prefix if present
+  const host = publicInfo?.imageProxyUrl?.replace(/^https?:\/\//, '') ?? null;
+
+  return [host, loaded, error];
+};

--- a/src/k8s/query/fetch.ts
+++ b/src/k8s/query/fetch.ts
@@ -53,10 +53,11 @@ export const K8sQueryUpdateResource = <TResource extends K8sResourceCommon>(
   });
 };
 
-export const K8sQueryPatchResource = <TResource extends K8sResourceCommon>(
-  requestInit: K8sResourcePatchOptions,
-) => {
-  return k8sPatchResource<K8sResourceCommon, TResource>(requestInit).finally(() => {
+export const K8sQueryPatchResource = <
+  TResource extends K8sResourceCommon,
+  TPatchedResource extends TResource = TResource,
+>(requestInit: K8sResourcePatchOptions): Promise<TPatchedResource> => {
+  return k8sPatchResource<TResource, TPatchedResource>(requestInit).finally(() => {
     !requestInit.queryOptions?.queryParams?.dryRun &&
       void queryClient.invalidateQueries({
         queryKey: createQueryKeys({

--- a/src/shared/components/image-display/ImageUrlDisplay.tsx
+++ b/src/shared/components/image-display/ImageUrlDisplay.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import { ClipboardCopy, Skeleton } from '@patternfly/react-core';
+import { useImageProxyHost } from '~/hooks/useImageProxyHost';
+import { useImageRepository } from '~/hooks/useImageRepository';
+import ExternalLink from '~/shared/components/links/ExternalLink';
+import { ImageRepositoryVisibility } from '~/types';
+import { getImageUrlForVisibility } from '~/utils/component-utils';
+
+export interface ImageUrlDisplayProps {
+  /** Original image URL */
+  imageUrl: string;
+  /** Component namespace */
+  namespace: string;
+  /** Component name */
+  componentName: string;
+  /** Whether the external link should be selectable as highlighted text */
+  isHighlightable?: boolean;
+}
+
+/**
+ * Default formatter — ensures URL starts with https://
+ */
+const getContainerImageLink = (url: string) => {
+  const imageUrl = url.includes('@sha') ? url.split('@sha')[0] : url;
+  return imageUrl.startsWith('http') ? imageUrl : `https://${imageUrl}`;
+};
+
+/**
+ * Renders an image URL using:
+ * - `ClipboardCopy` for private images (shows proxy URL when available, original URL as fallback)
+ * - `ExternalLink` for public or unspecified visibility
+ * - `Skeleton` while loading image repository or proxy host information
+ *
+ * Uses dynamic proxy host and visibility from Konflux public info and image repository.
+ */
+export const ImageUrlDisplay: React.FC<ImageUrlDisplayProps> = ({
+  imageUrl,
+  namespace,
+  componentName,
+  isHighlightable = false,
+}) => {
+  const [proxyHost, proxyHostLoaded, proxyHostError] = useImageProxyHost();
+  const [imageRepository, imageRepoLoaded, imageRepoError] = useImageRepository(
+    namespace,
+    componentName,
+    false,
+  );
+
+  const visibility = imageRepository?.spec?.image?.visibility ?? null;
+  const isPrivate = visibility === ImageRepositoryVisibility.private;
+
+  // Show loading while fetching data (only if no error)
+  // Once error occurs, fallback to display the content
+  if ((!imageRepoLoaded && !imageRepoError) || (isPrivate && !proxyHostLoaded && !proxyHostError)) {
+    return <Skeleton aria-label="Loading image URL" />;
+  }
+
+  if (isPrivate) {
+    // If proxyHost has error, fallback to original URL
+    const displayImageUrl = getImageUrlForVisibility(
+      imageUrl,
+      visibility,
+      proxyHostError ? null : proxyHost,
+    );
+    return (
+      <ClipboardCopy isReadOnly hoverTip="Copy" clickTip="Copied" variant="inline-compact">
+        {displayImageUrl}
+      </ClipboardCopy>
+    );
+  }
+
+  return (
+    <ExternalLink
+      href={getContainerImageLink(imageUrl)}
+      text={imageUrl}
+      isHighlightable={isHighlightable}
+    />
+  );
+};

--- a/src/shared/components/image-display/__tests__/ImageUrlDisplay.spec.tsx
+++ b/src/shared/components/image-display/__tests__/ImageUrlDisplay.spec.tsx
@@ -1,0 +1,200 @@
+import { screen } from '@testing-library/react';
+import {
+  mockPrivateImageRepository,
+  mockPublicImageRepository,
+} from '~/__data__/image-repository-data';
+import { renderWithQueryClient } from '~/utils/test-utils';
+import { ImageUrlDisplay } from '../ImageUrlDisplay';
+
+// Mock useImageProxyHost hook
+const mockUseImageProxyHost = jest.fn();
+jest.mock('~/hooks/useImageProxyHost', () => ({
+  useImageProxyHost: () => mockUseImageProxyHost(),
+}));
+
+// Mock useImageRepository hook
+const mockUseImageRepository = jest.fn();
+jest.mock('~/hooks/useImageRepository', () => ({
+  useImageRepository: (namespace: string, name: string, watch: boolean) =>
+    mockUseImageRepository(namespace, name, watch),
+}));
+
+const testImageUrl = 'quay.io/test-namespace/test-image@sha256:abc123';
+const testNamespace = 'test-namespace';
+const testComponentName = 'test-component';
+
+// Helper function to verify external link
+const expectExternalLink = (expectedText: string, expectedHref: string) => {
+  const link = screen.getByRole('link');
+  expect(link).toBeInTheDocument();
+  expect(link).toHaveTextContent(expectedText);
+  expect(link).toHaveAttribute('href', expectedHref);
+  expect(link).toHaveAttribute('target', '_blank');
+  return link;
+};
+
+// Helper function to verify copyable text
+const expectCopyableText = (expectedText: string) => {
+  expect(screen.getByText(expectedText)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /copy/i })).toBeInTheDocument();
+  expect(screen.queryByRole('link')).not.toBeInTheDocument();
+};
+
+describe('ImageUrlDisplay', () => {
+  beforeEach(() => {
+    mockUseImageRepository.mockClear();
+    mockUseImageProxyHost.mockClear();
+    // Default: proxy host is loaded
+    mockUseImageProxyHost.mockReturnValue(['image-rbac-proxy', true, null]);
+  });
+
+  it('should show loading skeleton while loading image repository', () => {
+    mockUseImageRepository.mockReturnValue([null, false, null]);
+
+    renderWithQueryClient(
+      <ImageUrlDisplay
+        imageUrl={testImageUrl}
+        namespace={testNamespace}
+        componentName={testComponentName}
+      />,
+    );
+
+    expect(screen.getByLabelText('Loading image URL')).toBeInTheDocument();
+  });
+
+  it('should show loading skeleton while loading proxy host for private images', () => {
+    // Mock useImageProxyHost to return loading state
+    mockUseImageProxyHost.mockReturnValue([null, false, null]);
+    mockUseImageRepository.mockReturnValue([mockPrivateImageRepository, true, null]);
+
+    renderWithQueryClient(
+      <ImageUrlDisplay
+        imageUrl={testImageUrl}
+        namespace={testNamespace}
+        componentName={testComponentName}
+      />,
+    );
+
+    expect(screen.getByLabelText('Loading image URL')).toBeInTheDocument();
+  });
+
+  it('should show copyable text with proxy URL for private images', () => {
+    mockUseImageRepository.mockReturnValue([mockPrivateImageRepository, true, null]);
+
+    renderWithQueryClient(
+      <ImageUrlDisplay
+        imageUrl={testImageUrl}
+        namespace={testNamespace}
+        componentName={testComponentName}
+      />,
+    );
+
+    expectCopyableText('image-rbac-proxy/test-namespace/test-image@sha256:abc123');
+  });
+
+  it('should show external link for public images', () => {
+    mockUseImageRepository.mockReturnValue([mockPublicImageRepository, true, null]);
+
+    renderWithQueryClient(
+      <ImageUrlDisplay
+        imageUrl={testImageUrl}
+        namespace={testNamespace}
+        componentName={testComponentName}
+      />,
+    );
+
+    expectExternalLink(testImageUrl, 'https://quay.io/test-namespace/test-image');
+  });
+
+  it('should show external link when imageRepository is null', () => {
+    mockUseImageRepository.mockReturnValue([null, true, null]);
+
+    renderWithQueryClient(
+      <ImageUrlDisplay
+        imageUrl={testImageUrl}
+        namespace={testNamespace}
+        componentName={testComponentName}
+      />,
+    );
+
+    expectExternalLink(testImageUrl, 'https://quay.io/test-namespace/test-image');
+  });
+
+  it('should gracefully fall back to external link on error', () => {
+    const error = new Error('Failed to fetch image repository');
+    mockUseImageRepository.mockReturnValue([null, true, error]);
+
+    renderWithQueryClient(
+      <ImageUrlDisplay
+        imageUrl={testImageUrl}
+        namespace={testNamespace}
+        componentName={testComponentName}
+      />,
+    );
+
+    expectExternalLink(testImageUrl, 'https://quay.io/test-namespace/test-image');
+    // Should NOT show error message
+    expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
+  });
+
+  it('should add https:// prefix for URLs without protocol', () => {
+    mockUseImageRepository.mockReturnValue([mockPublicImageRepository, true, null]);
+
+    renderWithQueryClient(
+      <ImageUrlDisplay
+        imageUrl={testImageUrl}
+        namespace={testNamespace}
+        componentName={testComponentName}
+      />,
+    );
+
+    expectExternalLink(testImageUrl, 'https://quay.io/test-namespace/test-image');
+  });
+
+  it('should not add https:// prefix for URLs that already have protocol', () => {
+    const urlWithProtocol = `https://${testImageUrl}`;
+    mockUseImageRepository.mockReturnValue([mockPublicImageRepository, true, null]);
+
+    renderWithQueryClient(
+      <ImageUrlDisplay
+        imageUrl={urlWithProtocol}
+        namespace={testNamespace}
+        componentName={testComponentName}
+      />,
+    );
+
+    expectExternalLink(urlWithProtocol, 'https://quay.io/test-namespace/test-image');
+  });
+
+  it('should call useImageRepository with correct parameters', () => {
+    mockUseImageRepository.mockReturnValue([mockPublicImageRepository, true, null]);
+
+    renderWithQueryClient(
+      <ImageUrlDisplay
+        imageUrl={testImageUrl}
+        namespace={testNamespace}
+        componentName={testComponentName}
+      />,
+    );
+
+    // Verify the hook was called with correct parameters
+    expect(mockUseImageRepository).toHaveBeenCalledWith(testNamespace, testComponentName, false);
+  });
+
+  it('should apply isHighlightable prop', () => {
+    mockUseImageRepository.mockReturnValue([mockPublicImageRepository, true, null]);
+
+    renderWithQueryClient(
+      <ImageUrlDisplay
+        imageUrl={testImageUrl}
+        namespace={testNamespace}
+        componentName={testComponentName}
+        isHighlightable={true}
+      />,
+    );
+
+    const link = screen.getByRole('link');
+    expect(link).toBeInTheDocument();
+    // ExternalLink component applies specific styling when isHighlightable is true
+  });
+});

--- a/src/shared/components/image-display/index.ts
+++ b/src/shared/components/image-display/index.ts
@@ -1,0 +1,2 @@
+export { ImageUrlDisplay } from './ImageUrlDisplay';
+export type { ImageUrlDisplayProps } from './ImageUrlDisplay';

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -8,5 +8,6 @@ export * from './markdown-view';
 export * from './help-tooltip';
 export * from './pipeline-run-logs';
 export * from './ContextSwitcher';
+export * from './image-display';
 export { default as ExternalLink } from './links/ExternalLink';
 export * from './skeleton';


### PR DESCRIPTION
## Fixes 
[KFLUXUI-881](https://issues.redhat.com/browse/KFLUXUI-881)


## Description
We have image url in component details page, components page and snapshot page.
Before the PR, we always get the default image url quay.io/.... there.
However, for the private images, users do not have permission to pull them.

With the PR, for the private image url, we provide the proxy image url for user to copy  with the login cmd provided by 'Registry Login Information'.
If the proxy image url is not set in konflux-info, we could show the original image url 'quay.io' as the fallback.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
In the video, we visit the public component to check its image urls first, then visit the private component.

https://github.com/user-attachments/assets/b2c48345-a91f-4aa2-a6c0-ed5dc26c1e40

**see the screenshots directly:** 

For component details page:
<img width="1304" height="274" alt="image" src="https://github.com/user-attachments/assets/a61098d4-a19c-4283-8a97-fe50b4371b57" />


<img width="1627" height="247" alt="image" src="https://github.com/user-attachments/assets/868c0867-c502-460d-b495-d3aa0672fefd" />


For components page:
<img width="1584" height="497" alt="image" src="https://github.com/user-attachments/assets/7ce705a2-ee11-4b8f-892c-ecdaab7593d7" />

For snapshots page:

<img width="1578" height="621" alt="image" src="https://github.com/user-attachments/assets/57401b7d-847b-4d9f-8288-10d636ea9c7e" />


## How to test or reproduce?
1.  find a  private component and check its component details, components, snapshots page to see the image url could be copied. If there is no proxyImageUrl in konflux-info, you would see quay.io.... as the image url.
2. create below configmap with name  konflux-public-info in your tenant. Please do not forget to change the namespace to your tenant. Retest step 1.
```
apiVersion: v1
data:
  info.json: |
    {
        "environment": "staging",
        "imageProxyUrl": "https://image-rbac-proxy.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com",
        "integrations": {
            "github": {
                "application_url": "https://github.com/apps/konflux-staging"
            },
            "sbom_server": {
                "url": "https://atlas.build.stage.devshift.net/sbom/content/<PLACEHOLDER>",
                "sbom_sha": "https://atlas.build.stage.devshift.net/sboms/<PLACEHOLDER>"
            },
            "image_controller": {
                "enabled": true,
                "notifications": [
                    {
                        "title": "SBOM-event-to-Bombino",
                        "event": "repo_push",
                        "method": "webhook",
                        "config": {
                            "url": "https://bombino.preprod.api.redhat.com/v1/sbom/quay/push"
                        }
                    }
                ]
            }
        },
        "rbac": [
            {
                "displayName": "admin",
                "description": "Full access to Konflux resources including secrets",
                "roleRef": {
                    "apiGroup": "rbac.authorization.k8s.io",
                    "kind": "ClusterRole",
                    "name": "konflux-admin-user-actions"
                }
            },
            {
                "displayName": "maintainer",
                "description": "Partial access to Konflux resources without access to secrets",
                "roleRef": {
                    "apiGroup": "rbac.authorization.k8s.io",
                    "kind": "ClusterRole",
                    "name": "konflux-maintainer-user-actions"
                }
            },
            {
                "displayName": "contributor",
                "description": "View access to Konflux resources without access to secrets",
                "roleRef": {
                    "apiGroup": "rbac.authorization.k8s.io",
                    "kind": "ClusterRole",
                    "name": "konflux-contributor-user-actions"
                }
            }
        ],
        "statusPageUrl": "https://grafana.app-sre.devshift.net/d/aes1ns0htwni8a/konflux-status-page?var-cluster=stone-stg-rh01",
        "visibility": "public"
    }
kind: ConfigMap
metadata:
  name: konflux-public-info
  namespace: wlin-tenant
```
3. check public component and its related pages. They should be same as previous.

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New ImageUrlDisplay component for image links with proxy-aware behavior and copy-to-clipboard for proxied/private images; new hook to obtain image proxy host.

* **Improvements**
  * Visibility-aware image URL resolution across lists and details, loading skeletons, and a Help popover for "Latest image"; clipboard copies the resolved display URL.

* **Refactor**
  * Centralized image-display exports and minor component prop signature adjustments.

* **Tests**
  * Added and updated tests covering proxying, display behaviors, formatting, and loading states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->