### PR TITLE
fix(KFLUXUI-917): don't show too many components

### DIFF
--- a/src/components/Commits/CommitsListPage/CommitsListRow.scss
+++ b/src/components/Commits/CommitsListPage/CommitsListRow.scss
@@ -6,9 +6,19 @@
 .commits-component-list {
   display: flex;
   flex-direction: column;
-  gap: var(--pf-v5-global--spacer--sm)
+  gap: var(--pf-v5-global--spacer--sm);
 }
 
 .commits-list__branch {
   word-break: break-all;
+}
+
+.commits-popover-stack {
+  > * {
+    margin-bottom: var(--pf-v5-global--spacer--xs);
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
 }

--- a/src/components/Commits/CommitsListPage/__tests__/CommitsListRow.spec.tsx
+++ b/src/components/Commits/CommitsListPage/__tests__/CommitsListRow.spec.tsx
@@ -1,4 +1,5 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { useComponents } from '../../../../hooks/useComponents';
 import * as dateTime from '../../../../shared/components/timestamp/datetime';
 import { getCommitsFromPLRs } from '../../../../utils/commits-utils';
@@ -78,5 +79,109 @@ describe('CommitsListRow', () => {
       />,
     );
     screen.getByText(status);
+  });
+
+  describe('Component list display', () => {
+    it('should display first 3 components when there are more than 3 components', () => {
+      const commitWithManyComponents = {
+        ...commits[0],
+        components: ['frontend', 'backend', 'database', 'auth-service', 'api-gateway'],
+      };
+
+      renderWithQueryClient(
+        <CommitsListRow
+          visibleColumns={defaultVisibleColumns}
+          obj={commitWithManyComponents}
+          pipelineRuns={pipelineWithCommits}
+        />,
+      );
+
+      expect(screen.getByText('frontend')).toBeInTheDocument();
+      expect(screen.getByText('backend')).toBeInTheDocument();
+      expect(screen.getByText('database')).toBeInTheDocument();
+      expect(screen.queryByText('auth-service')).not.toBeInTheDocument();
+      expect(screen.queryByText('api-gateway')).not.toBeInTheDocument();
+    });
+
+    it('should show "more" popover button when there are more than 3 components', () => {
+      const commitWithManyComponents = {
+        ...commits[0],
+        components: ['frontend', 'backend', 'database', 'auth-service', 'api-gateway'],
+      };
+
+      renderWithQueryClient(
+        <CommitsListRow
+          visibleColumns={defaultVisibleColumns}
+          obj={commitWithManyComponents}
+          pipelineRuns={pipelineWithCommits}
+        />,
+      );
+
+      expect(screen.getByText('2 more')).toBeInTheDocument();
+    });
+
+    it('should display all hidden components in popover when clicked', async () => {
+      const user = userEvent.setup();
+      const commitWithManyComponents = {
+        ...commits[0],
+        components: ['frontend', 'backend', 'database', 'auth-service', 'api-gateway'],
+      };
+
+      renderWithQueryClient(
+        <CommitsListRow
+          visibleColumns={defaultVisibleColumns}
+          obj={commitWithManyComponents}
+          pipelineRuns={pipelineWithCommits}
+        />,
+      );
+
+      const moreButton = screen.getByText('2 more');
+      await user.click(moreButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('auth-service')).toBeInTheDocument();
+        expect(screen.getByText('api-gateway')).toBeInTheDocument();
+      });
+    });
+
+    it('should not show popover when there are 3 or fewer components', () => {
+      const commitWithFewComponents = {
+        ...commits[0],
+        components: ['frontend', 'backend'],
+      };
+
+      renderWithQueryClient(
+        <CommitsListRow
+          visibleColumns={defaultVisibleColumns}
+          obj={commitWithFewComponents}
+          pipelineRuns={pipelineWithCommits}
+        />,
+      );
+
+      expect(screen.getByText('frontend')).toBeInTheDocument();
+      expect(screen.getByText('backend')).toBeInTheDocument();
+      expect(screen.queryByText(/more/)).not.toBeInTheDocument();
+      expect(screen.queryByTestId('more-components-popover')).not.toBeInTheDocument();
+    });
+
+    it('should display "-" when there are no components', () => {
+      const commitWithNoComponents = {
+        ...commits[0],
+        components: [],
+      };
+
+      const { container } = renderWithQueryClient(
+        <CommitsListRow
+          visibleColumns={defaultVisibleColumns}
+          obj={commitWithNoComponents}
+          pipelineRuns={pipelineWithCommits}
+        />,
+      );
+
+      const componentListDiv = container.querySelector('.commits-component-list');
+      expect(componentListDiv).toBeInTheDocument();
+      expect(componentListDiv).toHaveTextContent('-');
+      expect(screen.queryByTestId('more-components-popover')).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Assisted-by: Cursor


## Fixes 
https://issues.redhat.com/browse/KFLUXUI-917


## Description
In some cases, where a commit was associated with a lot of components, the commit list view would get very cluttered as the rows would take the whole page height. To prevent this, any number of components above 3 are hidden in the table and accessible by a popover.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [X] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
Before:
<img width="2247" height="1169" alt="image" src="https://github.com/user-attachments/assets/c45cd55f-ac74-4476-ac32-59968d452d84" />


After:
<img width="1614" height="863" alt="image" src="https://github.com/user-attachments/assets/eadc0007-1710-40df-8152-6f315df82317" />



## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Component lists show the first three items with an "X more" trigger that opens a popover revealing remaining components; displays "-" when none.

* **Tests**
  * Added tests validating first-three rendering, presence of the "X more" trigger, popover reveal of hidden items, absence of popover for ≤3 items, and empty-placeholder behavior.

* **Style**
  * Minor layout and spacing fixes for the component list and popover display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->