### PR TITLE
KFLUXUI-930: [Snapshot Overview] move CommitLabel outside commit link

### DIFF
--- a/src/components/SnapshotDetails/tabs/SnapshotOverview.tsx
+++ b/src/components/SnapshotDetails/tabs/SnapshotOverview.tsx
@@ -98,12 +98,12 @@ const SnapshotOverviewTab: React.FC = () => {
                       title={commit.displayName || commit.shaTitle}
                     >
                       {commit.displayName || commit.shaTitle}{' '}
-                      <CommitLabel
-                        gitProvider={commit.gitProvider}
-                        sha={commit.sha}
-                        shaURL={commit.shaURL}
-                      />
                     </Link>
+                    <CommitLabel
+                      gitProvider={commit.gitProvider}
+                      sha={commit.sha}
+                      shaURL={commit.shaURL}
+                    />
                   </DescriptionListDescription>
                 </DescriptionListGroup>
               )}

--- a/src/components/SnapshotDetails/tabs/__tests__/SnapshotOverview.spec.tsx
+++ b/src/components/SnapshotDetails/tabs/__tests__/SnapshotOverview.spec.tsx
@@ -90,6 +90,15 @@ describe('SnapshotOverview', () => {
     );
   });
 
+  it('renders CommitLabel when commit is available', () => {
+    useNamespaceMock.mockReturnValue('test-ns');
+    renderWithQueryClientAndRouter(<SnapshotOverview />);
+
+    const commitLabel = screen.queryByTestId('commit-label-c782c8f');
+
+    expect(commitLabel).toBeInTheDocument();
+  });
+
   it('omits commit section when pipelinerun load fails', () => {
     usePipelineRunV2Mock.mockReturnValue([basePipelineRun, true, true]);
     renderWithQueryClientAndRouter(<SnapshotOverview />);


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

Fixes https://issues.redhat.com/browse/KFLUXUI-930

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Prior to this patch, `CommitLabel` was rendered inside the `Link` component, which prevented the CommitLabel's external GitHub/GitLab link from working since it was being overridden by its parent link. Moving `CommitLabel` outside the `Link` allows both links to function correctly.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

https://github.com/user-attachments/assets/f97e53ab-9992-491d-aab9-e6d9c001fac0

After:

https://github.com/user-attachments/assets/fc1f1a1f-b179-4812-8a51-69f76fda50b5

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

* open any snapshot details/overview page
* both links under "Triggered by" section should work separately
  * 1st one should open the "Commit Details Page"
  * 2nd one should open the commit on GitHub/GitLab 
  * ☕ 

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the structure of the commit information display on snapshot details, repositioning the commit label outside the clickable link region.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->