### PR TITLE
feat(KFLUXUI-858): support the edit image repo visibility

### DIFF
--- a/e2e-tests/support/pages/ComponentDetailsPage.ts
+++ b/e2e-tests/support/pages/ComponentDetailsPage.ts
@@ -8,6 +8,24 @@ export class ComponentDetailsPage {
     UIhelper.clickTab(tab);
   }
 
+  static checkVisibility(visibility: string) {
+    cy.get('span.pf-v5-c-label__text').should('contain', visibility).and('be.visible');
+  }
+
+  static updateVisibility(visibility: 'public' | 'private') {
+    cy.get('[data-test="edit-visibility-button"]', { timeout: 5000 }).as('btn').click();
+    cy.get('[data-test="visibility-switch"]').then(($input) => {
+      const isPrivate = $input.is(':checked');
+      const shouldToggle =
+        (isPrivate && visibility === 'public') || (!isPrivate && visibility === 'private');
+
+      if (shouldToggle) {
+        cy.get('label[for="visibility-switch"]').click({ force: true });
+      }
+    });
+    cy.get('[data-test="save-visibility-button"]').click();
+  }
+
   static checkBuildImage() {
     cy.get(componentDetailsPO.buildImage)
       .invoke('val')

--- a/e2e-tests/tests/basic-happy-path.spec.ts
+++ b/e2e-tests/tests/basic-happy-path.spec.ts
@@ -235,6 +235,15 @@ describe('Basic Happy Path', () => {
       ComponentsTabPage.openComponent(componentName);
     });
 
+    it('verify the image repo is private by default', () => {
+      ComponentDetailsPage.checkVisibility('private');
+    });
+
+    it('verify the image repo can be edited as public', () => {
+      ComponentDetailsPage.updateVisibility('public');
+      ComponentDetailsPage.checkVisibility('public');
+    });
+
     it('Verify deployed image exists', () => {
       ComponentDetailsPage.checkBuildImage();
     });

--- a/src/__data__/image-repository-data.ts
+++ b/src/__data__/image-repository-data.ts
@@ -1,0 +1,31 @@
+import { ImageRepositoryKind, ImageRepositoryVisibility } from '../types';
+
+export const mockPublicImageRepository: ImageRepositoryKind = {
+  apiVersion: 'appstudio.redhat.com/v1alpha1',
+  kind: 'ImageRepository',
+  metadata: {
+    name: 'test-component',
+    namespace: 'test-ns',
+  },
+  spec: {
+    image: {
+      visibility: ImageRepositoryVisibility.public,
+    },
+  },
+};
+
+export const mockPrivateImageRepository: ImageRepositoryKind = {
+  ...mockPublicImageRepository,
+  spec: {
+    image: {
+      visibility: ImageRepositoryVisibility.private,
+    },
+  },
+};
+
+export const mockImageRepositoryWithoutVisibility: ImageRepositoryKind = {
+  ...mockPublicImageRepository,
+  spec: {
+    image: {},
+  },
+};

--- a/src/components/Components/ComponentDetails/tabs/ComponentDetails.tsx
+++ b/src/components/Components/ComponentDetails/tabs/ComponentDetails.tsx
@@ -8,13 +8,16 @@ import {
   FlexItem,
 } from '@patternfly/react-core';
 import yamlParser from 'js-yaml';
+import GitRepoLink from '~/components/GitLink/GitRepoLink';
+import HelpPopover from '~/components/HelpPopover';
 import { useLatestPushBuildPipelineRunForComponentV2 } from '~/hooks/useLatestPushBuildPipeline';
-import ExternalLink from '../../../../shared/components/links/ExternalLink';
-import { useNamespace } from '../../../../shared/providers/Namespace/useNamespaceInfo';
-import { ComponentKind } from '../../../../types';
-import { getLastestImage } from '../../../../utils/component-utils';
-import { getPipelineRunStatusResults } from '../../../../utils/pipeline-utils';
-import GitRepoLink from '../../../GitLink/GitRepoLink';
+import { useIsImageControllerEnabled } from '~/image-controller/conditional-checks';
+import ExternalLink from '~/shared/components/links/ExternalLink';
+import { useNamespace } from '~/shared/providers/Namespace/useNamespaceInfo';
+import { ComponentKind } from '~/types';
+import { getLastestImage } from '~/utils/component-utils';
+import { getPipelineRunStatusResults } from '~/utils/pipeline-utils';
+import ComponentImageRepositoryVisibility from './ComponentImageRepositoryVisibility';
 
 type ComponentDetailsProps = {
   component: ComponentKind;
@@ -36,6 +39,9 @@ const ComponentDetails: React.FC<React.PropsWithChildren<ComponentDetailsProps>>
   const latestImageURL = results?.find((result) => result.name === RESULT_NAME);
   const componentImageURL = latestImageURL?.value ?? getLastestImage(component);
 
+  // Check if image controller is enabled for this cluster
+  const { isImageControllerEnabled } = useIsImageControllerEnabled();
+
   const runTime = React.useMemo(() => {
     try {
       const loadedYaml = yamlParser?.load(component.status?.devfile) as {
@@ -55,7 +61,7 @@ const ComponentDetails: React.FC<React.PropsWithChildren<ComponentDetailsProps>>
   return (
     <Flex direction={{ default: 'row' }}>
       {component.spec.source?.git && (
-        <FlexItem style={{ flex: 1 }}>
+        <FlexItem flex={{ default: 'flex_1' }}>
           <DescriptionList
             columnModifier={{
               default: '1Col',
@@ -74,8 +80,38 @@ const ComponentDetails: React.FC<React.PropsWithChildren<ComponentDetailsProps>>
           </DescriptionList>
         </FlexItem>
       )}
+      {isImageControllerEnabled && (
+        <FlexItem flex={{ default: 'flex_1' }}>
+          <DescriptionList
+            columnModifier={{
+              default: '1Col',
+            }}
+          >
+            <DescriptionListGroup>
+              <DescriptionListTerm>
+                Image repository visibility{' '}
+                <HelpPopover
+                  bodyContent={
+                    <>
+                      Controls whether the built container images are publicly accessible or
+                      private.
+                      <br />
+                      <br />
+                      Pull and push secrets are automatically created and managed by the image
+                      controller for your build pipelines.
+                    </>
+                  }
+                />
+              </DescriptionListTerm>
+              <DescriptionListDescription data-test="image-repository-visibility">
+                <ComponentImageRepositoryVisibility component={component} />
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          </DescriptionList>
+        </FlexItem>
+      )}
       {componentImageURL && (
-        <FlexItem style={{ flex: 1 }}>
+        <FlexItem flex={{ default: 'flex_1' }}>
           <DescriptionList
             columnModifier={{
               default: '1Col',
@@ -98,7 +134,7 @@ const ComponentDetails: React.FC<React.PropsWithChildren<ComponentDetailsProps>>
           </DescriptionList>
         </FlexItem>
       )}
-      <FlexItem style={{ flex: 1 }}>
+      <FlexItem flex={{ default: 'flex_1' }}>
         <DescriptionList
           data-test="component-details-2"
           columnModifier={{

--- a/src/components/Components/ComponentDetails/tabs/ComponentImageRepositoryVisibility.tsx
+++ b/src/components/Components/ComponentDetails/tabs/ComponentImageRepositoryVisibility.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react';
+import {
+  Button,
+  ButtonVariant,
+  Flex,
+  FlexItem,
+  Label,
+  Skeleton,
+  Tooltip,
+} from '@patternfly/react-core';
+import { EyeIcon, EyeSlashIcon } from '@patternfly/react-icons/dist/esm/icons';
+import { useModalLauncher } from '~/components/modal/ModalProvider';
+import { useImageRepository } from '~/hooks/useImageRepository';
+import { ImageRepositoryModel } from '~/models';
+import { useNamespace } from '~/shared/providers/Namespace/useNamespaceInfo';
+import { getErrorState } from '~/shared/utils/error-utils';
+import { ComponentKind, ImageRepositoryVisibility } from '~/types';
+import { TrackEvents, useTrackEvent } from '~/utils/analytics';
+import { useAccessReviewForModel } from '~/utils/rbac';
+import { createEditImageRepositoryVisibilityModal } from './EditImageRepositoryVisibilityModal';
+
+type ComponentImageRepositoryVisibilityProps = {
+  component: ComponentKind;
+};
+
+const ComponentImageRepositoryVisibility: React.FC<
+  React.PropsWithChildren<ComponentImageRepositoryVisibilityProps>
+> = ({ component }) => {
+  const namespace = useNamespace();
+  const track = useTrackEvent();
+  const showModal = useModalLauncher();
+
+  // Check if user has permission to update image repository
+  const [canUpdateImageRepository] = useAccessReviewForModel(ImageRepositoryModel, 'update');
+
+  // Fetch ImageRepository - will fail with error if user doesn't have permission
+  const [imageRepository, imageRepoLoaded, imageRepoError] = useImageRepository(
+    component?.metadata?.namespace,
+    component?.metadata?.name,
+    false,
+  );
+
+  const handleEditVisibility = () => {
+    track(TrackEvents.ButtonClicked, {
+      link_name: 'edit-image-repository-visibility',
+      link_location: 'component-details',
+      component_name: component?.metadata?.name,
+      app_name: component?.spec?.application,
+      namespace,
+    });
+    showModal(createEditImageRepositoryVisibilityModal({ imageRepository }));
+  };
+
+  // Handle loading state
+  if (!imageRepoLoaded) {
+    return <Skeleton aria-label="Loading image repository visibility" />;
+  }
+
+  // Handle error state
+  if (imageRepoError) {
+    return getErrorState(imageRepoError, imageRepoLoaded, 'image repository', true);
+  }
+
+  const visibility = imageRepository?.spec?.image?.visibility;
+  const isPrivate = visibility === ImageRepositoryVisibility.private;
+
+  const editButton = (
+    <Button
+      variant={ButtonVariant.link}
+      isInline
+      isDisabled={!canUpdateImageRepository}
+      onClick={handleEditVisibility}
+      data-test="edit-visibility-button"
+    >
+      Edit
+    </Button>
+  );
+
+  const tooltipContent = !visibility
+    ? 'The visibility has not been set yet.'
+    : !canUpdateImageRepository
+      ? 'You do not have permission to edit image repository visibility'
+      : null;
+
+  const content = (
+    <Flex alignItems={{ default: 'alignItemsCenter' }} spaceItems={{ default: 'spaceItemsSm' }}>
+      <FlexItem>
+        {visibility ? (
+          <Label
+            color={isPrivate ? 'orange' : 'blue'}
+            icon={isPrivate ? <EyeSlashIcon /> : <EyeIcon />}
+            data-test={`visibility-label-${visibility}`}
+          >
+            {visibility}
+          </Label>
+        ) : (
+          '-'
+        )}
+      </FlexItem>
+      <FlexItem>{editButton}</FlexItem>
+    </Flex>
+  );
+
+  return tooltipContent ? (
+    <Tooltip content={tooltipContent}>
+      <span style={{ display: 'inline-block' }}>{content}</span>
+    </Tooltip>
+  ) : (
+    content
+  );
+};
+
+export default React.memo(ComponentImageRepositoryVisibility);

--- a/src/components/Components/ComponentDetails/tabs/EditImageRepositoryVisibilityModal.tsx
+++ b/src/components/Components/ComponentDetails/tabs/EditImageRepositoryVisibilityModal.tsx
@@ -1,0 +1,119 @@
+import * as React from 'react';
+import {
+  Alert,
+  AlertVariant,
+  Button,
+  ButtonType,
+  ButtonVariant,
+  Flex,
+  Form,
+  ModalVariant,
+  Stack,
+  StackItem,
+  Switch,
+  TextVariants,
+  Text,
+} from '@patternfly/react-core';
+import { Formik } from 'formik';
+import { ComponentProps, createModalLauncher } from '~/components/modal/createModalLauncher';
+import { ImageRepositoryKind, ImageRepositoryVisibility } from '~/types';
+import { updateImageRepositoryVisibility } from '~/utils/component-utils';
+
+type EditImageRepositoryVisibilityModalProps = ComponentProps & {
+  imageRepository: ImageRepositoryKind;
+};
+
+export const EditImageRepositoryVisibilityModal: React.FC<
+  React.PropsWithChildren<EditImageRepositoryVisibilityModalProps>
+> = ({ imageRepository, onClose }) => {
+  const isVisibilitySet = imageRepository?.spec?.image?.visibility !== undefined;
+  // Default to private if not set (consistent with component creation default)
+  const currentIsPrivate =
+    imageRepository?.spec?.image?.visibility !== ImageRepositoryVisibility.public;
+
+  const onSubmit = async (values: { isPrivate: boolean }, { setStatus }) => {
+    try {
+      await updateImageRepositoryVisibility(imageRepository, values.isPrivate);
+      onClose(null, { submitClicked: true });
+    } catch (e) {
+      setStatus({ error: e instanceof Error ? e.message : String(e) });
+    }
+  };
+
+  const onReset = () => {
+    onClose(null, { submitClicked: false });
+  };
+
+  return (
+    <Formik onSubmit={onSubmit} initialValues={{ isPrivate: currentIsPrivate }} onReset={onReset}>
+      {({ handleSubmit, handleReset, isSubmitting, values, setFieldValue, status }) => {
+        // Allow saving if visibility is not set (initial configuration) or if value changed
+        const isChanged = !isVisibilitySet || values.isPrivate !== currentIsPrivate;
+
+        return (
+          <Form
+            onSubmit={handleSubmit}
+            onReset={handleReset}
+            data-test="edit-image-repository-visibility-modal"
+          >
+            <Stack hasGutter>
+              <StackItem>
+                <Flex alignItems={{ default: 'alignItemsCenter' }}>
+                  <Text component={TextVariants.p}>Should the image produced be private?</Text>
+
+                  <Switch
+                    id="visibility-switch"
+                    aria-label="Image repository visibility"
+                    isChecked={values.isPrivate}
+                    onChange={(_, checked) => setFieldValue('isPrivate', checked)}
+                    data-test="visibility-switch"
+                  />
+                </Flex>
+              </StackItem>
+
+              {status?.error && (
+                <StackItem>
+                  <Alert
+                    isInline
+                    variant={AlertVariant.danger}
+                    title="An error occurred"
+                    data-test="error-alert"
+                  >
+                    {status.error}
+                  </Alert>
+                </StackItem>
+              )}
+
+              <StackItem>
+                <Button
+                  type={ButtonType.submit}
+                  isLoading={isSubmitting}
+                  isDisabled={!isChanged || isSubmitting}
+                  data-test="save-visibility-button"
+                >
+                  Save
+                </Button>
+                <Button
+                  type={ButtonType.reset}
+                  variant={ButtonVariant.link}
+                  data-test="cancel-visibility-button"
+                >
+                  Cancel
+                </Button>
+              </StackItem>
+            </Stack>
+          </Form>
+        );
+      }}
+    </Formik>
+  );
+};
+
+export const createEditImageRepositoryVisibilityModal = createModalLauncher(
+  EditImageRepositoryVisibilityModal,
+  {
+    'data-test': 'edit-image-repository-visibility-modal',
+    variant: ModalVariant.medium,
+    title: 'Edit image repository visibility',
+  },
+);

--- a/src/components/Components/ComponentDetails/tabs/__tests__/ComponentDetailsTab.spec.tsx
+++ b/src/components/Components/ComponentDetails/tabs/__tests__/ComponentDetailsTab.spec.tsx
@@ -1,16 +1,17 @@
 import { useNavigate } from 'react-router-dom';
 import { fireEvent, screen } from '@testing-library/dom';
+import { mockPublicImageRepository } from '~/__data__/image-repository-data';
+import { useModalLauncher } from '~/components/modal/ModalProvider';
+import { useComponent } from '~/hooks/useComponents';
+import { useImageRepository } from '~/hooks/useImageRepository';
 import {
   useLatestPushBuildPipelineRunForComponentV2,
   useLatestSuccessfulBuildPipelineRunForComponentV2,
 } from '~/hooks/useLatestPushBuildPipeline';
 import { useTaskRunsForPipelineRuns } from '~/hooks/useTaskRunsV2';
-import { useComponent } from '../../../../../hooks/useComponents';
-import {
-  createUseParamsMock,
-  renderWithQueryClientAndRouter,
-} from '../../../../../utils/test-utils';
-import { useModalLauncher } from '../../../../modal/ModalProvider';
+import { useIsImageControllerEnabled } from '~/image-controller/conditional-checks';
+import { useAccessReviewForModel } from '~/utils/rbac';
+import { createUseParamsMock, renderWithQueryClientAndRouter } from '~/utils/test-utils';
 import {
   mockComponent,
   mockLatestSuccessfulBuild,
@@ -18,8 +19,8 @@ import {
 } from '../../__data__/mockComponentDetails';
 import ComponentDetailsTab from '../ComponentDetailsTab';
 
-jest.mock('../../../../modal/ModalProvider', () => ({
-  ...jest.requireActual('../../../../modal/ModalProvider'),
+jest.mock('~/components/modal/ModalProvider', () => ({
+  ...jest.requireActual('~/components/modal/ModalProvider'),
   useModalLauncher: jest.fn(() => () => {}),
 }));
 
@@ -31,18 +32,30 @@ jest.mock('react-router-dom', () => {
   };
 });
 
-jest.mock('../../../../../hooks/useLatestPushBuildPipeline', () => ({
+jest.mock('~/hooks/useLatestPushBuildPipeline', () => ({
   useLatestSuccessfulBuildPipelineRunForComponentV2: jest.fn(),
   useLatestPushBuildPipelineRunForComponentV2: jest.fn(),
 }));
 
-jest.mock('../../../../../hooks/useComponents', () => ({
-  ...jest.requireActual('../../../../../hooks/useComponents'),
+jest.mock('~/hooks/useComponents', () => ({
+  ...jest.requireActual('~/hooks/useComponents'),
   useComponent: jest.fn(),
 }));
 
-jest.mock('../../../../../hooks/useTaskRunsV2', () => ({
+jest.mock('~/hooks/useTaskRunsV2', () => ({
   useTaskRunsForPipelineRuns: jest.fn(),
+}));
+
+jest.mock('~/hooks/useImageRepository', () => ({
+  useImageRepository: jest.fn(),
+}));
+
+jest.mock('~/image-controller/conditional-checks', () => ({
+  useIsImageControllerEnabled: jest.fn(),
+}));
+
+jest.mock('~/utils/rbac', () => ({
+  useAccessReviewForModel: jest.fn(),
 }));
 
 const useNavigateMock = useNavigate as jest.Mock;
@@ -53,6 +66,9 @@ const useLatestPushBuildPipelineRunForComponentMock =
   useLatestPushBuildPipelineRunForComponentV2 as jest.Mock;
 const useModalLauncherMock = useModalLauncher as jest.Mock;
 const useTaskRunsV2Mock = useTaskRunsForPipelineRuns as jest.Mock;
+const useImageRepositoryMock = useImageRepository as jest.Mock;
+const useIsImageControllerEnabledMock = useIsImageControllerEnabled as jest.Mock;
+const useAccessReviewForModelMock = useAccessReviewForModel as jest.Mock;
 describe('ComponentDetailTab', () => {
   let navigateMock: jest.Mock;
   const showModalMock = jest.fn();
@@ -73,6 +89,9 @@ describe('ComponentDetailTab', () => {
       true,
     ]);
     useTaskRunsV2Mock.mockReturnValue([mockTaskRuns, true]);
+    useImageRepositoryMock.mockReturnValue([null, true, null]);
+    useIsImageControllerEnabledMock.mockReturnValue({ isImageControllerEnabled: true });
+    useAccessReviewForModelMock.mockReturnValue([true, true]);
     navigateMock = jest.fn();
     useNavigateMock.mockImplementation(() => navigateMock);
     useModalLauncherMock.mockImplementation(() => {
@@ -147,4 +166,31 @@ describe('ComponentDetailTab', () => {
       'https://build-container.image.url',
     );
   });
+
+  it('should not show image repository visibility field when image controller is disabled', () => {
+    useIsImageControllerEnabledMock.mockReturnValue({ isImageControllerEnabled: false });
+    useAccessReviewForModelMock.mockReturnValue([true, true]);
+    renderWithQueryClientAndRouter(<ComponentDetailsTab />);
+    expect(screen.queryByText('Image repository visibility')).not.toBeInTheDocument();
+  });
+
+  it('should show image repository visibility field even when user has no permissions', () => {
+    useIsImageControllerEnabledMock.mockReturnValue({ isImageControllerEnabled: true });
+    useAccessReviewForModelMock.mockReturnValue([false, true]);
+    useImageRepositoryMock.mockReturnValue([null, true, null]);
+    renderWithQueryClientAndRouter(<ComponentDetailsTab />);
+    // Field should still be visible, but permissions are checked inside ComponentImageRepositoryVisibility
+    expect(screen.getByText('Image repository visibility')).toBeInTheDocument();
+  });
+
+  it('should show image repository visibility field when image controller is enabled and user has permission', () => {
+    useIsImageControllerEnabledMock.mockReturnValue({ isImageControllerEnabled: true });
+    useAccessReviewForModelMock.mockReturnValue([true, true]);
+    useImageRepositoryMock.mockReturnValue([mockPublicImageRepository, true, null]);
+    renderWithQueryClientAndRouter(<ComponentDetailsTab />);
+    expect(screen.getByText('Image repository visibility')).toBeInTheDocument();
+  });
+
+  // Note: Image repository fetching tests moved to ComponentImageRepositoryVisibility.spec.tsx
+  // since the logic is now inside that component
 });

--- a/src/components/Components/ComponentDetails/tabs/__tests__/ComponentImageRepositoryVisibility.spec.tsx
+++ b/src/components/Components/ComponentDetails/tabs/__tests__/ComponentImageRepositoryVisibility.spec.tsx
@@ -1,0 +1,204 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  mockPrivateImageRepository,
+  mockPublicImageRepository,
+  mockImageRepositoryWithoutVisibility,
+} from '~/__data__/image-repository-data';
+import { useModalLauncher } from '~/components/modal/ModalProvider';
+import { useImageRepository } from '~/hooks/useImageRepository';
+import { useAccessReviewForModel } from '~/utils/rbac';
+import { renderWithQueryClientAndRouter } from '~/utils/test-utils';
+import { mockComponent } from '../../__data__/mockComponentDetails';
+import ComponentImageRepositoryVisibility from '../ComponentImageRepositoryVisibility';
+
+jest.mock('~/components/modal/ModalProvider', () => ({
+  ...jest.requireActual('~/components/modal/ModalProvider'),
+  useModalLauncher: jest.fn(() => () => {}),
+}));
+
+jest.mock('~/hooks/useImageRepository', () => ({
+  useImageRepository: jest.fn(),
+}));
+
+jest.mock('~/utils/rbac', () => ({
+  useAccessReviewForModel: jest.fn(),
+}));
+
+const useModalLauncherMock = useModalLauncher as jest.Mock;
+const useImageRepositoryMock = useImageRepository as jest.Mock;
+const useAccessReviewForModelMock = useAccessReviewForModel as jest.Mock;
+
+describe('ComponentImageRepositoryVisibility', () => {
+  const showModalMock = jest.fn();
+
+  beforeEach(() => {
+    useModalLauncherMock.mockImplementation(() => showModalMock);
+    // Default: user has both list and update permissions
+    useAccessReviewForModelMock.mockReturnValue([true]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('with update permission', () => {
+    beforeEach(() => {
+      // Mock update permission to true
+      useAccessReviewForModelMock.mockReturnValue([true]);
+    });
+
+    it('should show skeleton when loading', () => {
+      useImageRepositoryMock.mockReturnValue([null, false, null]);
+
+      renderWithQueryClientAndRouter(
+        <ComponentImageRepositoryVisibility component={mockComponent} />,
+      );
+      const skeleton = screen.getByText('', { selector: '.pf-v5-c-skeleton' });
+      expect(skeleton).toBeInTheDocument();
+    });
+
+    it('should show error state when there is an error', () => {
+      const error = { code: 500, message: 'Internal server error' };
+      useImageRepositoryMock.mockReturnValue([null, true, error]);
+
+      renderWithQueryClientAndRouter(
+        <ComponentImageRepositoryVisibility component={mockComponent} />,
+      );
+      expect(screen.getByText(/Unable to load image repository/i)).toBeInTheDocument();
+    });
+
+    it('should display "public" label with blue color for public visibility', () => {
+      useImageRepositoryMock.mockReturnValue([mockPublicImageRepository, true, null]);
+
+      renderWithQueryClientAndRouter(
+        <ComponentImageRepositoryVisibility component={mockComponent} />,
+      );
+
+      const label = screen.getByTestId('visibility-label-public');
+      expect(label).toBeInTheDocument();
+      expect(label.textContent).toBe('public');
+      expect(label).toHaveClass('pf-m-blue');
+    });
+
+    it('should display "private" label with orange color for private visibility', () => {
+      useImageRepositoryMock.mockReturnValue([mockPrivateImageRepository, true, null]);
+
+      renderWithQueryClientAndRouter(
+        <ComponentImageRepositoryVisibility component={mockComponent} />,
+      );
+
+      const label = screen.getByTestId('visibility-label-private');
+      expect(label).toBeInTheDocument();
+      expect(label.textContent).toBe('private');
+      expect(label).toHaveClass('pf-m-orange');
+    });
+
+    it('should show "-" with tooltip when visibility field is not set', () => {
+      useImageRepositoryMock.mockReturnValue([mockImageRepositoryWithoutVisibility, true, null]);
+
+      renderWithQueryClientAndRouter(
+        <ComponentImageRepositoryVisibility component={mockComponent} />,
+      );
+
+      // Should show placeholder for visibility (just the "-" text)
+      expect(screen.getByText('-')).toBeInTheDocument();
+
+      // Should still show Edit button to allow setting visibility
+      const editButton = screen.getByTestId('edit-visibility-button');
+      expect(editButton).toBeInTheDocument();
+      expect(editButton).not.toBeDisabled();
+    });
+
+    it('should call modal launcher when Edit button is clicked', async () => {
+      const user = userEvent.setup();
+      useImageRepositoryMock.mockReturnValue([mockPublicImageRepository, true, null]);
+
+      renderWithQueryClientAndRouter(
+        <ComponentImageRepositoryVisibility component={mockComponent} />,
+      );
+
+      const editButton = screen.getByTestId('edit-visibility-button');
+      await user.click(editButton);
+
+      expect(showModalMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('without update permission', () => {
+    beforeEach(() => {
+      // Mock update permission to false
+      useAccessReviewForModelMock.mockReturnValue([false]);
+    });
+
+    it('should show "-" when no data and disable Edit button', () => {
+      useImageRepositoryMock.mockReturnValue([null, true, null]);
+
+      renderWithQueryClientAndRouter(
+        <ComponentImageRepositoryVisibility component={mockComponent} />,
+      );
+
+      // Should show placeholder
+      expect(screen.getByText('-')).toBeInTheDocument();
+
+      // Edit button should be disabled
+      const editButton = screen.getByTestId('edit-visibility-button');
+      expect(editButton).toBeInTheDocument();
+      expect(editButton).toBeDisabled();
+    });
+
+    it('should show visibility but disable Edit button when data is loaded', () => {
+      useImageRepositoryMock.mockReturnValue([mockPublicImageRepository, true, null]);
+
+      renderWithQueryClientAndRouter(
+        <ComponentImageRepositoryVisibility component={mockComponent} />,
+      );
+
+      // Should show visibility label
+      const label = screen.getByTestId('visibility-label-public');
+      expect(label).toBeInTheDocument();
+
+      // Edit button should be disabled
+      const editButton = screen.getByTestId('edit-visibility-button');
+      expect(editButton).toBeInTheDocument();
+      expect(editButton).toBeDisabled();
+    });
+
+    it('should not call modal when disabled Edit button is clicked', async () => {
+      const user = userEvent.setup();
+      useImageRepositoryMock.mockReturnValue([mockPublicImageRepository, true, null]);
+
+      renderWithQueryClientAndRouter(
+        <ComponentImageRepositoryVisibility component={mockComponent} />,
+      );
+
+      const editButton = screen.getByTestId('edit-visibility-button');
+      await user.click(editButton);
+
+      // Modal should not be called when button is disabled
+      expect(showModalMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('data loading behavior', () => {
+    beforeEach(() => {
+      // Permission doesn't affect data loading anymore
+      useAccessReviewForModelMock.mockReturnValue([true]);
+    });
+
+    it('should always call useImageRepository with component namespace and name', () => {
+      useImageRepositoryMock.mockReturnValue([null, true, null]);
+
+      renderWithQueryClientAndRouter(
+        <ComponentImageRepositoryVisibility component={mockComponent} />,
+      );
+
+      // Verify useImageRepository was called with actual namespace/name
+      expect(useImageRepositoryMock).toHaveBeenCalledWith(
+        mockComponent.metadata.namespace,
+        mockComponent.metadata.name,
+        false,
+      );
+    });
+  });
+});

--- a/src/components/Components/ComponentDetails/tabs/__tests__/EditImageRepositoryVisibilityModal.spec.tsx
+++ b/src/components/Components/ComponentDetails/tabs/__tests__/EditImageRepositoryVisibilityModal.spec.tsx
@@ -1,0 +1,228 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  mockImageRepositoryWithoutVisibility,
+  mockPrivateImageRepository,
+  mockPublicImageRepository,
+} from '~/__data__/image-repository-data';
+import { updateImageRepositoryVisibility } from '~/utils/component-utils';
+import { renderWithQueryClientAndRouter } from '~/utils/test-utils';
+import { EditImageRepositoryVisibilityModal } from '../EditImageRepositoryVisibilityModal';
+
+jest.mock('~/utils/component-utils', () => ({
+  updateImageRepositoryVisibility: jest.fn(),
+}));
+
+const updateImageRepositoryVisibilityMock = updateImageRepositoryVisibility as jest.Mock;
+
+describe('EditImageRepositoryVisibilityModal', () => {
+  const onCloseMock = jest.fn();
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    updateImageRepositoryVisibilityMock.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the modal with switch off for public repository', () => {
+    renderWithQueryClientAndRouter(
+      <EditImageRepositoryVisibilityModal
+        imageRepository={mockPublicImageRepository}
+        onClose={onCloseMock}
+      />,
+    );
+
+    expect(screen.getByText('Should the image produced be private?')).toBeInTheDocument();
+    const switchElement = screen.getByTestId('visibility-switch');
+    expect(switchElement).toBeInTheDocument();
+    expect(switchElement).not.toBeChecked();
+  });
+
+  it('should render the modal with switch on for private repository', () => {
+    renderWithQueryClientAndRouter(
+      <EditImageRepositoryVisibilityModal
+        imageRepository={mockPrivateImageRepository}
+        onClose={onCloseMock}
+      />,
+    );
+
+    const switchElement = screen.getByTestId('visibility-switch');
+    expect(switchElement).toBeChecked();
+  });
+
+  it('should disable save button when no changes are made', () => {
+    renderWithQueryClientAndRouter(
+      <EditImageRepositoryVisibilityModal
+        imageRepository={mockPublicImageRepository}
+        onClose={onCloseMock}
+      />,
+    );
+
+    const saveButton = screen.getByTestId('save-visibility-button');
+    expect(saveButton).toBeDisabled();
+  });
+
+  it('should enable save button when switch is toggled', async () => {
+    renderWithQueryClientAndRouter(
+      <EditImageRepositoryVisibilityModal
+        imageRepository={mockPrivateImageRepository}
+        onClose={onCloseMock}
+      />,
+    );
+
+    const switchElement = screen.getByTestId('visibility-switch');
+    await user.click(switchElement);
+
+    const saveButton = screen.getByTestId('save-visibility-button');
+    expect(saveButton).not.toBeDisabled();
+  });
+
+  it('should call updateImageRepositoryVisibility with true when changing to private', async () => {
+    renderWithQueryClientAndRouter(
+      <EditImageRepositoryVisibilityModal
+        imageRepository={mockPublicImageRepository}
+        onClose={onCloseMock}
+      />,
+    );
+
+    const switchElement = screen.getByTestId('visibility-switch');
+    await user.click(switchElement);
+
+    const saveButton = screen.getByTestId('save-visibility-button');
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(updateImageRepositoryVisibilityMock).toHaveBeenCalledWith(
+        mockPublicImageRepository,
+        true,
+      );
+    });
+  });
+
+  it('should call updateImageRepositoryVisibility with false when changing to public', async () => {
+    renderWithQueryClientAndRouter(
+      <EditImageRepositoryVisibilityModal
+        imageRepository={mockPrivateImageRepository}
+        onClose={onCloseMock}
+      />,
+    );
+
+    const switchElement = screen.getByTestId('visibility-switch');
+    await user.click(switchElement);
+
+    const saveButton = screen.getByTestId('save-visibility-button');
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(updateImageRepositoryVisibilityMock).toHaveBeenCalledWith(
+        mockPrivateImageRepository,
+        false,
+      );
+    });
+  });
+
+  it('should close modal with submitClicked true on successful save', async () => {
+    renderWithQueryClientAndRouter(
+      <EditImageRepositoryVisibilityModal
+        imageRepository={mockPublicImageRepository}
+        onClose={onCloseMock}
+      />,
+    );
+
+    const switchElement = screen.getByTestId('visibility-switch');
+    await user.click(switchElement);
+
+    const saveButton = screen.getByTestId('save-visibility-button');
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(onCloseMock).toHaveBeenCalledWith(null, { submitClicked: true });
+    });
+  });
+
+  it('should show error message when update fails', async () => {
+    const errorMessage = 'Failed to update visibility';
+    updateImageRepositoryVisibilityMock.mockRejectedValueOnce(new Error(errorMessage));
+
+    renderWithQueryClientAndRouter(
+      <EditImageRepositoryVisibilityModal
+        imageRepository={mockPublicImageRepository}
+        onClose={onCloseMock}
+      />,
+    );
+
+    const switchElement = screen.getByTestId('visibility-switch');
+    await user.click(switchElement);
+
+    const saveButton = screen.getByTestId('save-visibility-button');
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error-alert')).toBeInTheDocument();
+      expect(screen.getByText(errorMessage)).toBeInTheDocument();
+    });
+
+    expect(onCloseMock).not.toHaveBeenCalled();
+  });
+
+  it('should close modal with submitClicked false when cancel is clicked', async () => {
+    renderWithQueryClientAndRouter(
+      <EditImageRepositoryVisibilityModal
+        imageRepository={mockPublicImageRepository}
+        onClose={onCloseMock}
+      />,
+    );
+
+    const cancelButton = screen.getByTestId('cancel-visibility-button');
+    await user.click(cancelButton);
+
+    expect(onCloseMock).toHaveBeenCalledWith(null, { submitClicked: false });
+  });
+
+  it('should default to private visibility when visibility is not set', () => {
+    renderWithQueryClientAndRouter(
+      <EditImageRepositoryVisibilityModal
+        imageRepository={mockImageRepositoryWithoutVisibility}
+        onClose={onCloseMock}
+      />,
+    );
+
+    const switchElement = screen.getByTestId('visibility-switch');
+    expect(switchElement).toBeChecked(); // Should default to private (ON)
+  });
+
+  it('should enable save button when visibility is not set (initial configuration)', () => {
+    renderWithQueryClientAndRouter(
+      <EditImageRepositoryVisibilityModal
+        imageRepository={mockImageRepositoryWithoutVisibility}
+        onClose={onCloseMock}
+      />,
+    );
+
+    const saveButton = screen.getByTestId('save-visibility-button');
+    expect(saveButton).not.toBeDisabled(); // Should be enabled for initial setup
+  });
+
+  it('should allow saving default private value when visibility is not set', async () => {
+    renderWithQueryClientAndRouter(
+      <EditImageRepositoryVisibilityModal
+        imageRepository={mockImageRepositoryWithoutVisibility}
+        onClose={onCloseMock}
+      />,
+    );
+
+    // Don't toggle switch - use default private value
+    const saveButton = screen.getByTestId('save-visibility-button');
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(updateImageRepositoryVisibilityMock).toHaveBeenCalledWith(
+        mockImageRepositoryWithoutVisibility,
+        true, // Should save as private (default)
+      );
+    });
+  });
+});

--- a/src/components/ImportForm/GitImportForm.tsx
+++ b/src/components/ImportForm/GitImportForm.tsx
@@ -33,7 +33,7 @@ export const GitImportForm: React.FC<{ applicationName: string }> = ({ applicati
     componentName: '',
     gitProviderAnnotation: '',
     gitURLAnnotation: '',
-    isPrivateRepo: false,
+    isPrivateRepo: true,
     source: {
       git: {
         url: '',

--- a/src/feature-flags/conditions.ts
+++ b/src/feature-flags/conditions.ts
@@ -2,6 +2,7 @@ const CONDITIONS = {
   KUBEARCHIVE: 'isKubearchiveEnabled',
   KITESERVICE: 'isKiteServiceEnabled',
   STAGING: 'isStagingCluster',
+  IMAGE_CONTROLLER: 'isImageControllerEnabled',
 } as const;
 
 export type ConditionState = Partial<Record<ConditionKey, boolean>>;

--- a/src/hooks/__tests__/useImageRepository.spec.ts
+++ b/src/hooks/__tests__/useImageRepository.spec.ts
@@ -1,0 +1,108 @@
+import { renderHook } from '@testing-library/react-hooks';
+import {
+  mockPrivateImageRepository,
+  mockPublicImageRepository,
+} from '~/__data__/image-repository-data';
+import { createK8sWatchResourceMock } from '~/utils/test-utils';
+import { useImageRepository } from '../useImageRepository';
+
+const useK8sWatchResourceMock = createK8sWatchResourceMock();
+
+describe('useImageRepository', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return empty array when call is inflight', () => {
+    useK8sWatchResourceMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: undefined,
+    });
+
+    const { result } = renderHook(() => useImageRepository('test-ns', 'test-component', false));
+    const [imageRepository, loaded, error] = result.current;
+
+    expect(imageRepository).toBeNull();
+    expect(loaded).toBe(false);
+    expect(error).toBeUndefined();
+  });
+
+  it('should return image repository when loaded', () => {
+    useK8sWatchResourceMock.mockReturnValue({
+      data: mockPublicImageRepository,
+      isLoading: false,
+      error: undefined,
+    });
+
+    const { result } = renderHook(() => useImageRepository('test-ns', 'test-component', false));
+    const [imageRepository, loaded, error] = result.current;
+
+    expect(imageRepository).toEqual(mockPublicImageRepository);
+    expect(loaded).toBe(true);
+    expect(error).toBeUndefined();
+  });
+
+  it('should return error when request fails', () => {
+    const mockError = { code: 500, message: 'Internal server error' };
+    useK8sWatchResourceMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: mockError,
+    });
+
+    const { result } = renderHook(() => useImageRepository('test-ns', 'test-component', false));
+    const [imageRepository, loaded, error] = result.current;
+
+    expect(imageRepository).toBeNull();
+    expect(loaded).toBe(true);
+    expect(error).toEqual(mockError);
+  });
+
+  it('should return undefined resource when componentName is not provided', () => {
+    useK8sWatchResourceMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: undefined,
+    });
+
+    const { result } = renderHook(() => useImageRepository('test-ns', '', false));
+    const [imageRepository, loaded, error] = result.current;
+
+    expect(imageRepository).toBeNull();
+    expect(loaded).toBe(true);
+    expect(error).toBeUndefined();
+  });
+
+  it('should pass watch parameter correctly', () => {
+    useK8sWatchResourceMock.mockReturnValue({
+      data: mockPublicImageRepository,
+      isLoading: false,
+      error: undefined,
+    });
+
+    renderHook(() => useImageRepository('test-ns', 'test-component', true));
+
+    expect(useK8sWatchResourceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        watch: true,
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('should handle private image repository', () => {
+    useK8sWatchResourceMock.mockReturnValue({
+      data: mockPrivateImageRepository,
+      isLoading: false,
+      error: undefined,
+    });
+
+    const { result } = renderHook(() => useImageRepository('test-ns', 'test-component', false));
+    const [imageRepository, loaded, error] = result.current;
+
+    expect(imageRepository).toEqual(mockPrivateImageRepository);
+    expect(loaded).toBe(true);
+    expect(error).toBeUndefined();
+  });
+});

--- a/src/hooks/useImageRepository.ts
+++ b/src/hooks/useImageRepository.ts
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { useK8sWatchResource } from '~/k8s';
+import { ImageRepositoryGroupVersionKind, ImageRepositoryModel } from '~/models';
+import { ImageRepositoryKind } from '~/types';
+
+/**
+ * Hook to fetch and watch an ImageRepository resource for a component
+ * @param namespace - The namespace where the ImageRepository exists (or null to skip fetch)
+ * @param componentName - The component name (ImageRepository has the same name as the component, or null to skip fetch)
+ * @param watch - Whether to watch for updates (default: false)
+ * @returns [imageRepository, loaded, error]
+ */
+export const useImageRepository = (
+  namespace: string | null,
+  componentName: string | null,
+  watch?: boolean,
+): [ImageRepositoryKind | null, boolean, unknown] => {
+  const {
+    data: imageRepository,
+    isLoading,
+    error,
+  } = useK8sWatchResource<ImageRepositoryKind>(
+    namespace && componentName
+      ? {
+          groupVersionKind: ImageRepositoryGroupVersionKind,
+          namespace,
+          name: componentName,
+          watch,
+        }
+      : undefined,
+    ImageRepositoryModel,
+  );
+
+  return React.useMemo(() => {
+    return [imageRepository ?? null, !isLoading, error];
+  }, [imageRepository, isLoading, error]);
+};

--- a/src/image-controller/__tests__/conditional-checks.spec.ts
+++ b/src/image-controller/__tests__/conditional-checks.spec.ts
@@ -1,0 +1,101 @@
+import { getKonfluxPublicInfo } from '~/hooks/useKonfluxPublicInfo';
+import { checkIfImageControllerIsEnabled } from '../conditional-checks';
+
+jest.mock('~/hooks/useKonfluxPublicInfo', () => ({
+  getKonfluxPublicInfo: jest.fn(),
+}));
+
+const getKonfluxPublicInfoMock = getKonfluxPublicInfo as jest.Mock;
+
+describe('checkIfImageControllerIsEnabled', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return true when image controller is enabled', async () => {
+    getKonfluxPublicInfoMock.mockResolvedValue({
+      integrations: {
+        image_controller: {
+          enabled: true,
+        },
+      },
+    });
+
+    const result = await checkIfImageControllerIsEnabled();
+
+    expect(result).toBe(true);
+    expect(getKonfluxPublicInfoMock).toHaveBeenCalled();
+  });
+
+  it('should return false when image controller is disabled', async () => {
+    getKonfluxPublicInfoMock.mockResolvedValue({
+      integrations: {
+        image_controller: {
+          enabled: false,
+        },
+      },
+    });
+
+    const result = await checkIfImageControllerIsEnabled();
+
+    expect(result).toBe(false);
+    expect(getKonfluxPublicInfoMock).toHaveBeenCalled();
+  });
+
+  it('should return false when image controller config is missing', async () => {
+    getKonfluxPublicInfoMock.mockResolvedValue({
+      integrations: {},
+    });
+
+    const result = await checkIfImageControllerIsEnabled();
+
+    expect(result).toBe(false);
+    expect(getKonfluxPublicInfoMock).toHaveBeenCalled();
+  });
+
+  it('should return false when integrations config is missing', async () => {
+    getKonfluxPublicInfoMock.mockResolvedValue({});
+
+    const result = await checkIfImageControllerIsEnabled();
+
+    expect(result).toBe(false);
+    expect(getKonfluxPublicInfoMock).toHaveBeenCalled();
+  });
+
+  it('should return false when image_controller.enabled is undefined', async () => {
+    getKonfluxPublicInfoMock.mockResolvedValue({
+      integrations: {
+        image_controller: {},
+      },
+    });
+
+    const result = await checkIfImageControllerIsEnabled();
+
+    expect(result).toBe(false);
+    expect(getKonfluxPublicInfoMock).toHaveBeenCalled();
+  });
+
+  it('should return false when image_controller.enabled is null', async () => {
+    getKonfluxPublicInfoMock.mockResolvedValue({
+      integrations: {
+        image_controller: {
+          enabled: null,
+        },
+      },
+    });
+
+    const result = await checkIfImageControllerIsEnabled();
+
+    expect(result).toBe(false);
+    expect(getKonfluxPublicInfoMock).toHaveBeenCalled();
+  });
+
+  it('should return false when getKonfluxPublicInfo throws an error', async () => {
+    getKonfluxPublicInfoMock.mockRejectedValue(new Error('Failed to fetch config'));
+
+    const result = await checkIfImageControllerIsEnabled();
+
+    expect(result).toBe(false);
+    expect(getKonfluxPublicInfoMock).toHaveBeenCalled();
+  });
+});

--- a/src/image-controller/conditional-checks.ts
+++ b/src/image-controller/conditional-checks.ts
@@ -1,0 +1,16 @@
+import { createConditionsHook } from '~/feature-flags/hooks';
+import { ensureConditionIsOn } from '~/feature-flags/utils';
+import { getKonfluxPublicInfo } from '~/hooks/useKonfluxPublicInfo';
+
+export const checkIfImageControllerIsEnabled = async () => {
+  try {
+    const info = await getKonfluxPublicInfo();
+    return info.integrations?.image_controller?.enabled ?? false;
+  } catch (error) {
+    return false;
+  }
+};
+
+export const useIsImageControllerEnabled = createConditionsHook(['isImageControllerEnabled']);
+
+export const isImageControllerEnabled = ensureConditionIsOn(['isImageControllerEnabled']);

--- a/src/k8s/query/fetch.ts
+++ b/src/k8s/query/fetch.ts
@@ -53,8 +53,10 @@ export const K8sQueryUpdateResource = <TResource extends K8sResourceCommon>(
   });
 };
 
-export const K8sQueryPatchResource = (requestInit: K8sResourcePatchOptions) => {
-  return k8sPatchResource(requestInit).finally(() => {
+export const K8sQueryPatchResource = <TResource extends K8sResourceCommon>(
+  requestInit: K8sResourcePatchOptions,
+) => {
+  return k8sPatchResource<K8sResourceCommon, TResource>(requestInit).finally(() => {
     !requestInit.queryOptions?.queryParams?.dryRun &&
       void queryClient.invalidateQueries({
         queryKey: createQueryKeys({

--- a/src/registers.ts
+++ b/src/registers.ts
@@ -1,11 +1,13 @@
 import { getKonfluxPublicInfo } from '~/hooks/useKonfluxPublicInfo';
 import { KonfluxInstanceEnvironments } from '~/types/konflux-public-info';
 import { registerCondition } from './feature-flags/conditions';
+import { checkIfImageControllerIsEnabled } from './image-controller/conditional-checks';
 import { checkIfKiteServiceIsEnabled } from './kite/conditional-checks';
 import { checkIfKubeArchiveIsEnabled } from './kubearchive/conditional-checks';
 
 registerCondition('isKubearchiveEnabled', checkIfKubeArchiveIsEnabled);
 registerCondition('isKiteServiceEnabled', checkIfKiteServiceIsEnabled);
+registerCondition('isImageControllerEnabled', checkIfImageControllerIsEnabled);
 
 registerCondition('isStagingCluster', async () => {
   try {


### PR DESCRIPTION
Assisted-by: Claude


## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added image repository visibility display in component details, showing whether repositories are public or private
- Added ability to edit image repository visibility settings with a dedicated modal interface
- Changed default image repository visibility to private

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->