### PR TITLE
KFLUXUI-933: [Snapshot Pipeline Runs] handle error when clicking in the actions menu

### DIFF
--- a/src/components/PipelineRun/PipelineRunListView/pipelinerun-actions.tsx
+++ b/src/components/PipelineRun/PipelineRunListView/pipelinerun-actions.tsx
@@ -257,17 +257,25 @@ export const useRerunActionLazy = (pipelineRun: PipelineRunKind): LazyActionHook
       let snapshot: Snapshot | null = null;
 
       if (runType === PipelineRunType.BUILD && isPushBuildType && componentName) {
-        component = await k8sQueryGetResource<ComponentKind>({
-          model: ComponentModel,
-          queryOptions: { ns: namespace, name: componentName },
-        });
+        try {
+          component = await k8sQueryGetResource<ComponentKind>({
+            model: ComponentModel,
+            queryOptions: { ns: namespace, name: componentName },
+          });
+        } catch {
+          component = null;
+        }
       }
 
       if (runType === PipelineRunType.TEST && snapshotName) {
-        snapshot = await k8sQueryGetResource<Snapshot>({
-          model: SnapshotModel,
-          queryOptions: { ns: namespace, name: snapshotName },
-        });
+        try {
+          snapshot = await k8sQueryGetResource<Snapshot>({
+            model: SnapshotModel,
+            queryOptions: { ns: namespace, name: snapshotName },
+          });
+        } catch {
+          snapshot = null;
+        }
       }
 
       return { component, snapshot };


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

Fixes https://issues.redhat.com/browse/KFLUXUI-933

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In this PR we're updating the logic in `pipelinerun-actions` to handle errors gracefully when fetching snapshot for TEST pipeline runs. So the action menu will render with appropriate disabled state.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

https://github.com/user-attachments/assets/1f1c596c-b912-4d71-ba55-0599af176e6b

After:

https://github.com/user-attachments/assets/2603cc4f-a57a-4009-a868-c977f0276821

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rerun actions now gracefully handle missing or inaccessible snapshot/component resources: the UI shows a disabled state with an explanatory tooltip for error or not-found cases and enables the action when the resource is available.

* **Tests**
  * Expanded test coverage for rerun behavior, including lazy-loading scenarios, error and 404 handling, and successful fetch paths to ensure consistent user-facing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->