### PR TITLE
fix(KFLUXUI-941): Assisted-by message support for MacOS

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -55,7 +55,7 @@ if [ "$is_authorized" -eq 1 ]; then
 
     elif [ "$os_name" == "Darwin" ]; then
       # macOS (Darwin) method: Uses lsof (List Open Files)
-      cwd=$(lsof -a -d cwd -p "$pid" 2>/dev/null | tail -n 1 | awk 'NF > 0 {print $NF}' || echo "")
+      cwd=$(lsof -a -d cwd -p "$pid" -F n 2>/dev/null | grep '^n' | sed 's/^n//' || echo "")
     fi
 
     if [[ -n "$cwd" && "$cwd" == "$REPO_ROOT"* ]]; then


### PR DESCRIPTION
Assisted-by: Cursor


## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->
https://issues.redhat.com/browse/KFLUXUI-941

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- MacOS doesn't use `/proc` filesystem used when checking for Cursor/Claude running process
- Added support for `lsof` which mac uses
- Fallback: if the commit message contains `claude|anthropic|Generated with.*Claude Code|Co-Authored-By: Claude|cursor|Co-Authored-By: cursor`, the commit is "signed" as well

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved cross‑platform process detection in the commit hook: now reliably detects working directories on Linux and macOS using OS‑appropriate methods, consolidating checks for more consistent behavior across environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->