### PR TITLE
KFLUXUI-932 refactor(e2e-tests/entrypoint): add --runner-ui flag

### DIFF
--- a/e2e-tests/entrypoint.sh
+++ b/e2e-tests/entrypoint.sh
@@ -14,7 +14,7 @@ else
   cd /tmp/e2e
 fi
 
-npx cypress run $args
+npx cypress run --runner-ui $args
 EXIT_CODE=$?
 echo "Tests exited with code $EXIT_CODE. Archiving artifacts."
 


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

Fixes https://issues.redhat.com/browse/KFLUXUI-932

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Add `--runner-ui` flag when running the 'cypress run' command. It will explicitly display the Cypress Runner UI in the recorded video.

Ref: https://docs.cypress.io/app/references/command-line#cypress-run-runner-ui

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

![cypress-video-command-log-ISSUE](https://github.com/user-attachments/assets/2d2be682-7476-42ac-9cc1-0a73b527bf6f)


After:

![cypress-video-command-log-FIX](https://github.com/user-attachments/assets/750e01fb-4df4-414e-a935-7047b9754e1b)


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

You can simply check the "PR Check Test" job's artifacts from one of your open PRs. Download the logs file and open the `basic-happy-path.spec.ts.mp4` file under the `videos` folder. You'll notice that the Command Log (left side bar) is not displayed.

Now, do the same for this PR's "PR Check Test" job's artifacts. The video should contain the Command Log ☕ 

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enabled the Cypress runner UI by default for end-to-end testing.
  * Improved memory handling for browser-based tests (reduces /dev/shm usage on Chromium).
  * Increased shared memory allocation for test containers to improve stability and reduce flaky failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->