### PR TITLE
fix(KFLUXUI-966): kubeArchive logs do not show error when logs are empty

### DIFF
--- a/src/shared/components/pipeline-run-logs/logs/Logs.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/Logs.tsx
@@ -140,6 +140,14 @@ const Logs: React.FC<LogsProps> = ({
           .then((res) => appendLog(name, res))
           .catch((err) => {
             if (err.name !== 'AbortError') {
+              // Gracefully handle empty logs (404) from kubearch, similar to how Tekton Results handles 404
+              // When logs don't exist, both kubearch and Tekton Results return 404
+              if (err?.code === 404) {
+                // Don't append any error message for missing logs - just leave it empty
+                // This matches the behavior of Tekton Results which returns empty logs for 404
+                return;
+              }
+
               appendLog(
                 name,
                 `\x1b[1;31mLOG FETCH ERROR${err instanceof Error ? `:\n${err.message}` : ''}\x1b[0m\n`,


### PR DESCRIPTION
Assisted-by: Claude


## Fixes 
[KFLUXUI-966](https://issues.redhat.com/browse/KFLUXUI-966)


## Description
KubeArchive logs show a red error message when logs are empty, while Tekton Results handles empty logs gracefully by showing nothing. We improve kubearch logs to keep consistence between them.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of missing logs: when logs cannot be retrieved, the interface now displays an empty log view instead of showing an error message, delivering a cleaner user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->