### PR TITLE
KFLUXUI-967 [User Access List View] exclude RoleBindings without subjects when filtering by username

### DIFF
--- a/src/components/UserAccess/UserAccessListView.tsx
+++ b/src/components/UserAccess/UserAccessListView.tsx
@@ -74,7 +74,7 @@ export const UserAccessListView: React.FC<React.PropsWithChildren<unknown>> = ()
     () =>
       roleBindings.filter(
         (rb) =>
-          !rb.subjects ||
+          (!usernameFilter && !rb.subjects) ||
           rb.subjects?.some((subject) =>
             subject.name.toLowerCase().includes(usernameFilter.toLowerCase()),
           ),

--- a/src/components/UserAccess/__tests__/UserAccessListView.spec.tsx
+++ b/src/components/UserAccess/__tests__/UserAccessListView.spec.tsx
@@ -141,4 +141,38 @@ describe('UserAccessListView', () => {
     expect(rows.length).toBe(2);
     expect(rows[1]).toHaveTextContent('-');
   });
+
+  it('should exclude role bindings with undefined subjects when filtering by username', async () => {
+    useRoleBindingsMock.mockReturnValue([
+      [
+        {
+          ...mockRoleBinding,
+          metadata: { ...mockRoleBinding.metadata, name: 'rb-no-subjects' },
+          subjects: undefined,
+        },
+        {
+          ...mockRoleBinding,
+          metadata: { ...mockRoleBinding.metadata, name: 'rb-user1' },
+          subjects: [{ kind: 'User', name: 'user1' }],
+        },
+      ],
+      true,
+    ]);
+
+    render(UserAccessList);
+
+    const filter = screen.getByPlaceholderText<HTMLInputElement>('Filter by username...');
+    act(() => {
+      fireEvent.change(filter, { target: { value: 'user1' } });
+      jest.advanceTimersByTime(700);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('rb-user1')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('user1')).toBeInTheDocument();
+
+    expect(screen.queryByText('rb-no-subjects')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/HAC-XXX -->

Fixes https://issues.redhat.com/browse/KFLUXUI-967

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When filtering by username in the User Access list view page, the list incorrectly includes `RoleBindings` with no subjects.

This PR fixes the behavior:

* exclude `RoleBindings` with no `subjects` when a username filter is applied
* only show `RoleBindings` whose `subject` name matches the filter

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

<img width="2434" height="904" alt="user-access-incorrect-filter-by-name" src="https://github.com/user-attachments/assets/f4d60c56-68bf-4863-b2c2-47d45b6d7c89" />

After:

![user-access-CORRECT-filter-by-name](https://github.com/user-attachments/assets/aa908f0d-8c26-4e10-95ed-2d7cee6afe3c)

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

* you need to have a RoleBinding with no subjects
* try searching for any username
* the RoleBindings with no subjects should not be displayed


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user access filtering to exclude entries without assigned subjects when searching by username. Previously, these entries were always displayed regardless of the search filter; now they are correctly excluded for more accurate results.

* **Tests**
  * Added test case verifying that entries without assigned subjects are properly excluded when filtering by username.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->