### PR TITLE
fix(KFLUXUI-976): public image url should can be selected

### DIFF
--- a/src/components/Components/ComponentDetails/tabs/ComponentDetails.tsx
+++ b/src/components/Components/ComponentDetails/tabs/ComponentDetails.tsx
@@ -138,7 +138,6 @@ const ComponentDetails: React.FC<React.PropsWithChildren<ComponentDetailsProps>>
                   imageUrl={componentImageURL}
                   namespace={component.metadata.namespace}
                   componentName={component.metadata.name}
-                  isHighlightable
                 />
               </DescriptionListDescription>
             </DescriptionListGroup>

--- a/src/shared/components/image-display/ImageUrlDisplay.tsx
+++ b/src/shared/components/image-display/ImageUrlDisplay.tsx
@@ -13,8 +13,6 @@ export interface ImageUrlDisplayProps {
   namespace: string;
   /** Component name */
   componentName: string;
-  /** Whether the external link should be selectable as highlighted text */
-  isHighlightable?: boolean;
 }
 
 /**
@@ -37,7 +35,6 @@ export const ImageUrlDisplay: React.FC<ImageUrlDisplayProps> = ({
   imageUrl,
   namespace,
   componentName,
-  isHighlightable = false,
 }) => {
   const [urlInfo, proxyLoaded, proxyError] = useImageProxy();
   const [imageRepository, imageRepoLoaded, imageRepoError] = useImageRepository(
@@ -73,7 +70,9 @@ export const ImageUrlDisplay: React.FC<ImageUrlDisplayProps> = ({
     <ExternalLink
       href={getContainerImageLink(imageUrl)}
       text={imageUrl}
-      isHighlightable={isHighlightable}
+      /** by default patternfly button disable text selection on Button component
+     this enables it on <a /> tag */
+      style={{ userSelect: 'auto' }}
     />
   );
 };

--- a/src/shared/components/image-display/__tests__/ImageUrlDisplay.spec.tsx
+++ b/src/shared/components/image-display/__tests__/ImageUrlDisplay.spec.tsx
@@ -188,7 +188,7 @@ describe('ImageUrlDisplay', () => {
     expect(mockUseImageRepository).toHaveBeenCalledWith(testNamespace, testComponentName, false);
   });
 
-  it('should apply isHighlightable prop', () => {
+  it('should ensure the image link can be selected', () => {
     mockUseImageRepository.mockReturnValue([mockPublicImageRepository, true, null]);
 
     renderWithQueryClient(
@@ -196,12 +196,13 @@ describe('ImageUrlDisplay', () => {
         imageUrl={testImageUrl}
         namespace={testNamespace}
         componentName={testComponentName}
-        isHighlightable={true}
       />,
     );
 
     const link = screen.getByRole('link');
     expect(link).toBeInTheDocument();
-    // ExternalLink component applies specific styling when isHighlightable is true
+    expect(link).toHaveStyle({
+      userSelect: 'auto',
+    });
   });
 });


### PR DESCRIPTION
Assisted-by: Claude


## Fixes 
[KFLUXUI-976](https://issues.redhat.com/browse/KFLUXUI-976)


## Description
The public image url should be selected. 


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<img width="813" height="385" alt="image" src="https://github.com/user-attachments/assets/b3634d71-e93f-4078-9139-1cac6c516c6b" />


## How to test or reproduce?
1. Open the component overview page
2. select the public image url 
it can be selected well.

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Image links now behave consistently as selectable/highlightable; previous per-component toggle was removed.
* **Tests**
  * Tests updated to verify image links are selectable (user can select/copy link text).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->