### PR TITLE
feat: limit rights to run a PR check to konflux-ui devs

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -40,17 +40,20 @@ jobs:
             exit 0
           fi
 
-          if gh api "/orgs/$ORG/members/$PR_AUTHOR"; then
-            echo "PR author is a member of $ORG GitHub organization, skipping further checks"
-            exit 0
-          fi
+          ALLOWED_USERS=("Katka92" "rrosatti" "janaki29" "sahil143" "testcara" "milantaky" "StanislavJochman" "JoaoPedroPP" "rakshett" "abhinandan13jan" "marcin-michal")
+          for author in "${ALLOWED_USERS[@]}"; do
+            if [[ "$author" == "$PR_AUTHOR" ]]; then
+              echo "PR author is in ALLOWED_USERS list. Running E2E tests."
+              exit 0
+            fi
+          done
 
           ERROR_SUMMARY=$(cat <<EOF
 
           ### ❌ Cannot run E2E tests - at least one of the following conditions must be met:
           * PR author is '$WHITELISTED_BOT_NAME'
           * PR has label '$REQUIRED_LABEL_NAME'
-          * PR author is a public member of '$ORG' GitHub organization
+          * PR author is a konflux-ui developer (listed in ALLOWED_USERS in this script)
           EOF
           )
           echo "$ERROR_SUMMARY" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Fixes 
https://issues.redhat.com/browse/KFLUXUI-1003

## Description
Limit users allowed to run PR check to konflux-ui developers.
I tested for my user in my fork https://github.com/Katka92/konflux-ui/actions/runs/21674136117/job/62489587297?pr=18. 

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): required fix for possible vulnerability

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->