### PR TITLE
feat(KFLUXUI-874): support url hash navigation for log viewer

### DIFF
--- a/src/shared/components/virtualized-log-viewer/LineNumberGutter.tsx
+++ b/src/shared/components/virtualized-log-viewer/LineNumberGutter.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Flex } from '@patternfly/react-core';
+import type { VirtualItem } from '@tanstack/react-virtual';
+
+export interface LineNumberGutterProps {
+  /** Virtual items from the virtualizer */
+  virtualItems: VirtualItem[];
+  /** Height of each line in pixels */
+  itemSize: number;
+  /** Callback when a line number is clicked */
+  onLineClick: (lineNumber: number, event: React.MouseEvent) => void;
+  /** Function to check if a line is highlighted */
+  isLineHighlighted: (lineNumber: number) => boolean;
+}
+
+/**
+ * Line number gutter component for log viewer
+ *
+ * Displays clickable line numbers in a sticky left column.
+ * Supports single line and range selection via shift-click.
+ */
+export const LineNumberGutter: React.FC<LineNumberGutterProps> = ({
+  virtualItems,
+  itemSize,
+  onLineClick,
+  isLineHighlighted,
+}) => {
+  return (
+    <Flex className="log-viewer__gutter" direction={{ default: 'column' }}>
+      {virtualItems.map((virtualItem) => {
+        const lineNumber = virtualItem.index + 1;
+        const isHighlighted = isLineHighlighted(lineNumber);
+        return (
+          <div
+            key={`gutter-${virtualItem.key}`}
+            className={`log-viewer__gutter-cell ${isHighlighted ? 'log-viewer__gutter-cell--highlighted' : ''}`}
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              height: `${itemSize}px`,
+              transform: `translateY(${virtualItem.start}px)`,
+            }}
+          >
+            <a
+              href={`#L${lineNumber}`}
+              className="log-viewer__line-number"
+              aria-label={`Jump to line ${lineNumber}`}
+              onClick={(e) => {
+                e.preventDefault();
+                onLineClick(lineNumber, e);
+              }}
+              data-line-number={lineNumber}
+            >
+              {lineNumber}
+            </a>
+          </div>
+        );
+      })}
+    </Flex>
+  );
+};

--- a/src/shared/components/virtualized-log-viewer/VirtualizedLogContent.tsx
+++ b/src/shared/components/virtualized-log-viewer/VirtualizedLogContent.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
+import { LineNumberGutter } from './LineNumberGutter';
+import { useLineNumberNavigation } from './useLineNumberNavigation';
 import { useVirtualizedScroll } from './useVirtualizedScroll';
 
 export interface SearchedWord {
@@ -79,7 +81,7 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
   }, []);
 
   // Initialize virtualizer
-  const virtualizer = useVirtualizer({
+  const virtualizer = useVirtualizer<HTMLDivElement, Element>({
     count: lines.length,
     getScrollElement: () => parentRef.current,
     estimateSize: () => itemSize,
@@ -93,7 +95,7 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
     onScroll,
   });
 
-  // Render a single line with search highlighting
+  // Render a single line with search highlighting (line numbers are in the gutter)
   const renderLine = (line: string, index: number) => {
     // Preserve empty lines by using a non-breaking space
     // This ensures empty lines maintain their height and are visible
@@ -131,6 +133,43 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
     );
   };
 
+  // Use line number navigation hook
+  const { highlightedLines, handleLineClick, isLineHighlighted } = useLineNumberNavigation();
+
+  // Scroll to highlighted lines when hash changes or on initial load
+  React.useEffect(() => {
+    if (highlightedLines && highlightedLines.start > 0 && lines.length > 0) {
+      // Scroll to the start of the highlighted range
+      // Convert 1-based line number to 0-based index
+      const targetIndex = highlightedLines.start - 1;
+
+      // If target line is out of range, scroll to the last line instead
+      // This provides better UX by showing the user where the log ends
+      const scrollIndex = targetIndex < lines.length ? targetIndex : lines.length - 1;
+
+      // Wait for next frame to ensure virtualizer is ready after state updates
+      let rafId2: number;
+
+      const rafId1 = requestAnimationFrame(() => {
+        rafId2 = requestAnimationFrame(() => {
+          virtualizer.scrollToIndex(scrollIndex, {
+            align: 'center',
+            behavior: 'smooth',
+          });
+        });
+      });
+
+      // Cleanup: cancel pending animation frames on unmount or dependency change
+      return () => {
+        cancelAnimationFrame(rafId1);
+        cancelAnimationFrame(rafId2);
+      };
+    }
+    // Depend on both highlightedLines and lines.length to handle initial data load
+    // virtualizer reference is stable from useVirtualizer
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [highlightedLines, lines.length]);
+
   const virtualItems = virtualizer.getVirtualItems();
 
   return (
@@ -144,10 +183,10 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
         <span className="pf-v5-c-log-viewer__text">M</span>
       </div>
 
-      {/* Scrollable container */}
+      {/* Scrollable container with gutter */}
       <div
         ref={parentRef}
-        className="pf-v5-c-log-viewer__list"
+        className="pf-v5-c-log-viewer__list log-viewer__with-gutter"
         style={{
           height: `${height}px`,
           width: typeof width === 'number' ? `${width}px` : width,
@@ -160,29 +199,42 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
             height: `${virtualizer.getTotalSize()}px`,
             width: '100%',
             position: 'relative',
+            display: 'flex',
           }}
         >
-          {/* Visible items */}
-          {virtualItems.map((virtualItem) => {
-            const line = lines[virtualItem.index];
-            return (
-              <div
-                key={virtualItem.key}
-                data-index={virtualItem.index}
-                ref={virtualizer.measureElement}
-                className="pf-v5-c-log-viewer__list-item"
-                style={{
-                  position: 'absolute',
-                  top: 0,
-                  left: 0,
-                  width: '100%',
-                  transform: `translateY(${virtualItem.start}px)`,
-                }}
-              >
-                {renderLine(line, virtualItem.index)}
-              </div>
-            );
-          })}
+          {/* Line number gutter */}
+          <LineNumberGutter
+            virtualItems={virtualItems}
+            itemSize={itemSize}
+            onLineClick={handleLineClick}
+            isLineHighlighted={isLineHighlighted}
+          />
+
+          {/* Log content */}
+          <div className="log-viewer__content-column">
+            {virtualItems.map((virtualItem) => {
+              const line = lines[virtualItem.index];
+              const lineNumber: number = virtualItem.index + 1;
+              const isHighlighted = isLineHighlighted(lineNumber);
+              return (
+                <div
+                  key={virtualItem.key}
+                  data-index={virtualItem.index}
+                  ref={virtualizer.measureElement}
+                  className={`pf-v5-c-log-viewer__list-item ${isHighlighted ? 'log-viewer__line--highlighted' : ''}`}
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    width: '100%',
+                    transform: `translateY(${virtualItem.start}px)`,
+                  }}
+                >
+                  {renderLine(line, lineNumber - 1)}
+                </div>
+              );
+            })}
+          </div>
         </div>
       </div>
     </>

--- a/src/shared/components/virtualized-log-viewer/VirtualizedLogViewer.scss
+++ b/src/shared/components/virtualized-log-viewer/VirtualizedLogViewer.scss
@@ -3,5 +3,79 @@
 
 .pf-v5-c-log-viewer__text {
   white-space: pre-wrap; // Allow long lines to wrap while preserving spaces and line breaks
-  word-break: break-word; // Break long words/URLs to prevent horizontal overflow
+}
+
+// Line number gutter styles (GitHub-inspired)
+// Using specific selector to override PatternFly's default display
+.pf-v5-c-log-viewer__list.log-viewer__with-gutter {
+  display: flex;
+}
+
+.log-viewer__gutter {
+  position: sticky;
+  left: 0;
+  width: var(--pf-v5-global--spacer--3xl);
+  flex-shrink: 0;
+  background-color: var(--pf-v5-global--BackgroundColor--200);
+  border-right: var(--pf-v5-global--BorderWidth--sm) solid var(--pf-v5-global--BorderColor--100);
+  user-select: none;
+  overflow: hidden;
+}
+
+.pf-m-dark .log-viewer__gutter {
+  background-color: var(--pf-v5-global--BackgroundColor--dark-100);
+  border-right-color: var(--pf-v5-global--BorderColor--dark-100);
+}
+
+.log-viewer__gutter-cell {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding-right: var(--pf-v5-global--spacer--sm);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.log-viewer__gutter-cell--highlighted {
+  background-color: var(--pf-v5-global--palette--gold-100);
+}
+
+.pf-m-dark .log-viewer__gutter-cell--highlighted {
+  background-color: var(--pf-v5-global--palette--gold-400);
+}
+
+.log-viewer__line-number {
+  font-family: var(--pf-v5-global--FontFamily--monospace);
+  font-size: var(--pf-v5-global--FontSize--sm);
+  color: var(--pf-v5-global--Color--200);
+  text-decoration: none;
+  cursor: pointer;
+
+  &:hover {
+    color: var(--pf-v5-global--Color--100);
+    text-decoration: underline;
+  }
+}
+
+.pf-m-dark .log-viewer__line-number {
+  color: var(--pf-v5-global--Color--dark-200);
+
+  &:hover {
+    color: var(--pf-v5-global--palette--white-300);
+    text-decoration: underline;
+  }
+}
+
+.log-viewer__content-column {
+  flex: 1;
+  min-width: 0;
+  position: relative;
+}
+
+.log-viewer__line--highlighted {
+  background-color: var(--pf-v5-global--palette--gold-50);
+}
+
+.pf-m-dark .log-viewer__line--highlighted {
+  background-color: var(--pf-v5-global--palette--gold-700);
 }

--- a/src/shared/components/virtualized-log-viewer/__tests__/LineNumberGutter.spec.tsx
+++ b/src/shared/components/virtualized-log-viewer/__tests__/LineNumberGutter.spec.tsx
@@ -1,0 +1,306 @@
+import type { VirtualItem } from '@tanstack/react-virtual';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { LineNumberGutter } from '../LineNumberGutter';
+
+describe('LineNumberGutter', () => {
+  const createMockVirtualItem = (index: number, start: number): VirtualItem => ({
+    index,
+    start,
+    end: start + 20,
+    size: 20,
+    key: `item-${index}`,
+    lane: 0,
+  });
+
+  const mockVirtualItems: VirtualItem[] = [
+    createMockVirtualItem(0, 0),
+    createMockVirtualItem(1, 20),
+    createMockVirtualItem(2, 40),
+  ];
+
+  const defaultProps = {
+    virtualItems: mockVirtualItems,
+    itemSize: 20,
+    onLineClick: jest.fn(),
+    isLineHighlighted: jest.fn(() => false),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('should render gutter container', () => {
+      const { container } = render(<LineNumberGutter {...defaultProps} />);
+      const gutter = container.querySelector('.log-viewer__gutter');
+
+      expect(gutter).toBeInTheDocument();
+    });
+
+    it('should render line numbers for all virtual items', () => {
+      render(<LineNumberGutter {...defaultProps} />);
+
+      expect(screen.getByText('1')).toBeInTheDocument();
+      expect(screen.getByText('2')).toBeInTheDocument();
+      expect(screen.getByText('3')).toBeInTheDocument();
+    });
+
+    it('should render correct line numbers (1-indexed)', () => {
+      const items = [
+        createMockVirtualItem(5, 100), // Line 6
+        createMockVirtualItem(10, 200), // Line 11
+      ];
+
+      render(<LineNumberGutter {...defaultProps} virtualItems={items} />);
+
+      expect(screen.getByText('6')).toBeInTheDocument();
+      expect(screen.getByText('11')).toBeInTheDocument();
+    });
+
+    it('should render line numbers as links', () => {
+      render(<LineNumberGutter {...defaultProps} />);
+
+      const link = screen.getByText('1').closest('a');
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute('href', '#L1');
+    });
+
+    it('should add aria-label to line number links', () => {
+      render(<LineNumberGutter {...defaultProps} />);
+
+      const link = screen.getByText('1').closest('a');
+      expect(link).toHaveAttribute('aria-label', 'Jump to line 1');
+    });
+
+    it('should add data-line-number attribute', () => {
+      render(<LineNumberGutter {...defaultProps} />);
+
+      const link = screen.getByText('1').closest('a');
+      expect(link).toHaveAttribute('data-line-number', '1');
+    });
+  });
+
+  describe('Styling and Positioning', () => {
+    it('should apply correct CSS classes to gutter cells', () => {
+      const { container } = render(<LineNumberGutter {...defaultProps} />);
+      const cells = container.querySelectorAll('.log-viewer__gutter-cell');
+
+      expect(cells.length).toBe(3);
+      cells.forEach((cell) => {
+        expect(cell).toHaveClass('log-viewer__gutter-cell');
+      });
+    });
+
+    it('should apply correct positioning styles', () => {
+      const { container } = render(<LineNumberGutter {...defaultProps} itemSize={25} />);
+      const firstCell = container.querySelector('.log-viewer__gutter-cell');
+
+      expect(firstCell).toHaveStyle({
+        position: 'absolute',
+        top: '0',
+        left: '0',
+        height: '25px',
+      });
+    });
+
+    it('should apply transform based on virtual item start position', () => {
+      const { container } = render(<LineNumberGutter {...defaultProps} />);
+      const cells = container.querySelectorAll('.log-viewer__gutter-cell');
+
+      expect(cells[0]).toHaveStyle({ transform: 'translateY(0px)' });
+      expect(cells[1]).toHaveStyle({ transform: 'translateY(20px)' });
+      expect(cells[2]).toHaveStyle({ transform: 'translateY(40px)' });
+    });
+
+    it('should render correct number of gutter cells', () => {
+      const { container } = render(<LineNumberGutter {...defaultProps} />);
+      const cells = container.querySelectorAll('.log-viewer__gutter-cell');
+
+      // Should render one cell per virtual item
+      expect(cells.length).toBe(3);
+    });
+  });
+
+  describe('Highlighting', () => {
+    it('should add highlighted class when line is highlighted', () => {
+      const isLineHighlighted = jest.fn((lineNumber: number) => lineNumber === 2);
+      const { container } = render(
+        <LineNumberGutter {...defaultProps} isLineHighlighted={isLineHighlighted} />,
+      );
+
+      const cells = container.querySelectorAll('.log-viewer__gutter-cell');
+      expect(cells[0]).not.toHaveClass('log-viewer__gutter-cell--highlighted');
+      expect(cells[1]).toHaveClass('log-viewer__gutter-cell--highlighted');
+      expect(cells[2]).not.toHaveClass('log-viewer__gutter-cell--highlighted');
+    });
+
+    it('should call isLineHighlighted with correct line numbers', () => {
+      const isLineHighlighted = jest.fn(() => false);
+      render(<LineNumberGutter {...defaultProps} isLineHighlighted={isLineHighlighted} />);
+
+      expect(isLineHighlighted).toHaveBeenCalledWith(1);
+      expect(isLineHighlighted).toHaveBeenCalledWith(2);
+      expect(isLineHighlighted).toHaveBeenCalledWith(3);
+    });
+
+    it('should highlight multiple lines in a range', () => {
+      const isLineHighlighted = jest.fn((lineNumber: number) => lineNumber >= 1 && lineNumber <= 3);
+      const { container } = render(
+        <LineNumberGutter {...defaultProps} isLineHighlighted={isLineHighlighted} />,
+      );
+
+      const cells = container.querySelectorAll('.log-viewer__gutter-cell--highlighted');
+      expect(cells.length).toBe(3);
+    });
+  });
+
+  describe('Click Handling', () => {
+    it('should call onLineClick when line number is clicked', () => {
+      const onLineClick = jest.fn();
+      render(<LineNumberGutter {...defaultProps} onLineClick={onLineClick} />);
+
+      const link = screen.getByText('1');
+      fireEvent.click(link);
+
+      expect(onLineClick).toHaveBeenCalledWith(1, expect.any(Object));
+    });
+
+    it('should prevent default link behavior on click', () => {
+      const onLineClick = jest.fn();
+      render(<LineNumberGutter {...defaultProps} onLineClick={onLineClick} />);
+
+      const link = screen.getByText('1');
+      const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+      const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+      link.dispatchEvent(event);
+
+      expect(preventDefaultSpy).toHaveBeenCalled();
+    });
+
+    it('should pass mouse event to onLineClick handler', () => {
+      const onLineClick = jest.fn();
+      render(<LineNumberGutter {...defaultProps} onLineClick={onLineClick} />);
+
+      const link = screen.getByText('2');
+      fireEvent.click(link, { shiftKey: true });
+
+      expect(onLineClick).toHaveBeenCalledWith(
+        2,
+        expect.objectContaining({
+          shiftKey: true,
+        }),
+      );
+    });
+
+    it('should handle clicks on different line numbers', () => {
+      const onLineClick = jest.fn();
+      render(<LineNumberGutter {...defaultProps} onLineClick={onLineClick} />);
+
+      fireEvent.click(screen.getByText('1'));
+      fireEvent.click(screen.getByText('2'));
+      fireEvent.click(screen.getByText('3'));
+
+      expect(onLineClick).toHaveBeenCalledTimes(3);
+      expect(onLineClick).toHaveBeenNthCalledWith(1, 1, expect.any(Object));
+      expect(onLineClick).toHaveBeenNthCalledWith(2, 2, expect.any(Object));
+      expect(onLineClick).toHaveBeenNthCalledWith(3, 3, expect.any(Object));
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle empty virtualItems array', () => {
+      const { container } = render(<LineNumberGutter {...defaultProps} virtualItems={[]} />);
+      const gutter = container.querySelector('.log-viewer__gutter');
+
+      expect(gutter).toBeInTheDocument();
+      expect(gutter?.children.length).toBe(0);
+    });
+
+    it('should handle single virtual item', () => {
+      const singleItem = [createMockVirtualItem(0, 0)];
+      render(<LineNumberGutter {...defaultProps} virtualItems={singleItem} />);
+
+      expect(screen.getByText('1')).toBeInTheDocument();
+      expect(screen.queryByText('2')).not.toBeInTheDocument();
+    });
+
+    it('should handle large line numbers', () => {
+      const largeItem = [createMockVirtualItem(9999, 0)];
+      render(<LineNumberGutter {...defaultProps} virtualItems={largeItem} />);
+
+      expect(screen.getByText('10000')).toBeInTheDocument();
+    });
+
+    it('should handle very small item sizes', () => {
+      const { container } = render(<LineNumberGutter {...defaultProps} itemSize={1} />);
+      const cell = container.querySelector('.log-viewer__gutter-cell');
+
+      expect(cell).toHaveStyle({ height: '1px' });
+    });
+
+    it('should handle very large item sizes', () => {
+      const { container } = render(<LineNumberGutter {...defaultProps} itemSize={100} />);
+      const cell = container.querySelector('.log-viewer__gutter-cell');
+
+      expect(cell).toHaveStyle({ height: '100px' });
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have accessible links with proper attributes', () => {
+      render(<LineNumberGutter {...defaultProps} />);
+
+      const links = screen.getAllByRole('link');
+      links.forEach((link, index) => {
+        const lineNumber = index + 1;
+        expect(link).toHaveAttribute('href', `#L${lineNumber}`);
+        expect(link).toHaveAttribute('aria-label', `Jump to line ${lineNumber}`);
+      });
+    });
+
+    it('should be keyboard navigable', () => {
+      render(<LineNumberGutter {...defaultProps} />);
+
+      const link = screen.getByText('1').closest('a');
+      expect(link).toHaveClass('log-viewer__line-number');
+
+      // Links should be focusable by default
+      link?.focus();
+      expect(document.activeElement).toBe(link);
+    });
+  });
+
+  describe('Integration with Virtual Scrolling', () => {
+    it('should handle non-contiguous virtual items', () => {
+      // Simulate virtualization where only items 0, 5, and 10 are visible
+      const nonContiguousItems = [
+        createMockVirtualItem(0, 0),
+        createMockVirtualItem(5, 100),
+        createMockVirtualItem(10, 200),
+      ];
+
+      render(<LineNumberGutter {...defaultProps} virtualItems={nonContiguousItems} />);
+
+      expect(screen.getByText('1')).toBeInTheDocument();
+      expect(screen.getByText('6')).toBeInTheDocument();
+      expect(screen.getByText('11')).toBeInTheDocument();
+    });
+
+    it('should apply correct transforms for non-sequential items', () => {
+      const items = [
+        createMockVirtualItem(0, 0),
+        createMockVirtualItem(5, 500), // Large gap
+        createMockVirtualItem(6, 520),
+      ];
+
+      const { container } = render(<LineNumberGutter {...defaultProps} virtualItems={items} />);
+      const cells = container.querySelectorAll('.log-viewer__gutter-cell');
+
+      expect(cells[0]).toHaveStyle({ transform: 'translateY(0px)' });
+      expect(cells[1]).toHaveStyle({ transform: 'translateY(500px)' });
+      expect(cells[2]).toHaveStyle({ transform: 'translateY(520px)' });
+    });
+  });
+});

--- a/src/shared/components/virtualized-log-viewer/__tests__/useLineNumberNavigation.spec.ts
+++ b/src/shared/components/virtualized-log-viewer/__tests__/useLineNumberNavigation.spec.ts
@@ -1,0 +1,436 @@
+import { renderHook, act } from '@testing-library/react';
+import { useLineNumberNavigation } from '../useLineNumberNavigation';
+
+// Helper function to create mock mouse event with shiftKey property
+const createMouseEvent = (shiftKey: boolean): React.MouseEvent => {
+  const event = new MouseEvent('click') as unknown as React.MouseEvent;
+  Object.defineProperty(event, 'shiftKey', { value: shiftKey, writable: false });
+  return event;
+};
+
+describe('useLineNumberNavigation', () => {
+  let originalHash: string;
+  let pushStateSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    // Save and reset hash
+    originalHash = window.location.hash;
+    window.location.hash = '';
+
+    // Reset history.state using replaceState
+    window.history.replaceState(null, '');
+
+    // Mock pushState using spyOn - preserve state parameter for internal navigation tracking
+    pushStateSpy = jest
+      .spyOn(window.history, 'pushState')
+      .mockImplementation((state, title, url) => {
+        // Actually update hash and state in test environment using replaceState
+        const newUrl = url && typeof url === 'string' && url.includes('#') ? url : '#';
+        window.history.replaceState(state, title || '', newUrl);
+        if (url && typeof url === 'string' && url.includes('#')) {
+          window.location.hash = url.split('#')[1];
+        }
+      });
+  });
+
+  afterEach(() => {
+    // Restore hash
+    window.location.hash = originalHash;
+
+    // Reset history.state using replaceState
+    window.history.replaceState(null, '');
+
+    // Restore pushState
+    pushStateSpy.mockRestore();
+  });
+
+  describe('Initial State', () => {
+    it('should initialize with no highlighted lines when no hash', () => {
+      const { result } = renderHook(() => useLineNumberNavigation());
+
+      expect(result.current.highlightedLines).toBeNull();
+      expect(result.current.firstSelectedLine).toBeNull();
+    });
+
+    it('should parse single line from hash on mount (#L123)', () => {
+      window.location.hash = '#L123';
+      const { result } = renderHook(() => useLineNumberNavigation());
+
+      expect(result.current.highlightedLines).toEqual({ start: 123, end: 123 });
+    });
+
+    it('should parse line range from hash on mount (#L10-L20)', () => {
+      window.location.hash = '#L10-L20';
+      const { result } = renderHook(() => useLineNumberNavigation());
+
+      expect(result.current.highlightedLines).toEqual({ start: 10, end: 20 });
+    });
+
+    it('should handle reversed range and normalize it (#L20-L10)', () => {
+      window.location.hash = '#L20-L10';
+      const { result } = renderHook(() => useLineNumberNavigation());
+
+      // Should normalize to ascending order
+      expect(result.current.highlightedLines).toEqual({ start: 10, end: 20 });
+    });
+
+    it('should ignore invalid hash formats', () => {
+      window.location.hash = '#invalid';
+      const { result } = renderHook(() => useLineNumberNavigation());
+
+      expect(result.current.highlightedLines).toBeNull();
+    });
+  });
+
+  describe('Single Line Selection', () => {
+    it('should select single line on click', () => {
+      const { result } = renderHook(() => useLineNumberNavigation());
+
+      act(() => {
+        result.current.handleLineClick(42, createMouseEvent(false));
+      });
+
+      expect(pushStateSpy).toHaveBeenCalledWith({ source: 'line-click' }, '', '#L42');
+      expect(result.current.highlightedLines).toEqual({ start: 42, end: 42 });
+      expect(result.current.firstSelectedLine).toBe(42);
+    });
+
+    it('should update firstSelectedLine for range selection', () => {
+      const { result } = renderHook(() => useLineNumberNavigation());
+
+      act(() => {
+        result.current.handleLineClick(10, createMouseEvent(false));
+      });
+
+      expect(result.current.firstSelectedLine).toBe(10);
+    });
+  });
+
+  describe('Range Selection with Shift-Click', () => {
+    it('should create range with shift-click', () => {
+      const { result } = renderHook(() => useLineNumberNavigation());
+
+      // First click to set anchor
+      act(() => {
+        result.current.handleLineClick(10, createMouseEvent(false));
+      });
+
+      // Shift-click to create range
+      act(() => {
+        result.current.handleLineClick(20, createMouseEvent(true));
+      });
+
+      expect(pushStateSpy).toHaveBeenLastCalledWith({ source: 'line-click' }, '', '#L10-L20');
+      expect(result.current.highlightedLines).toEqual({ start: 10, end: 20 });
+      expect(result.current.firstSelectedLine).toBeNull(); // Reset after range
+    });
+
+    it('should handle reversed shift-click range', () => {
+      const { result } = renderHook(() => useLineNumberNavigation());
+
+      // First click at line 20
+      act(() => {
+        result.current.handleLineClick(20, createMouseEvent(false));
+      });
+
+      // Shift-click at line 10 (earlier)
+      act(() => {
+        result.current.handleLineClick(10, createMouseEvent(true));
+      });
+
+      // Should normalize to ascending order
+      expect(pushStateSpy).toHaveBeenLastCalledWith({ source: 'line-click' }, '', '#L10-L20');
+      expect(result.current.highlightedLines).toEqual({ start: 10, end: 20 });
+    });
+
+    it('should ignore shift-click without first selection', () => {
+      const { result } = renderHook(() => useLineNumberNavigation());
+
+      act(() => {
+        result.current.handleLineClick(20, createMouseEvent(true));
+      });
+
+      // Should treat as single selection
+      expect(pushStateSpy).toHaveBeenCalledWith({ source: 'line-click' }, '', '#L20');
+      expect(result.current.highlightedLines).toEqual({ start: 20, end: 20 });
+    });
+
+    it('should reset firstSelectedLine after creating range', () => {
+      const { result } = renderHook(() => useLineNumberNavigation());
+
+      act(() => {
+        result.current.handleLineClick(10, createMouseEvent(false));
+      });
+
+      expect(result.current.firstSelectedLine).toBe(10);
+
+      act(() => {
+        result.current.handleLineClick(20, createMouseEvent(true));
+      });
+
+      expect(result.current.firstSelectedLine).toBeNull();
+    });
+  });
+
+  describe('isLineHighlighted', () => {
+    it('should return false when no lines highlighted', () => {
+      const { result } = renderHook(() => useLineNumberNavigation());
+
+      expect(result.current.isLineHighlighted(10)).toBe(false);
+    });
+
+    it('should return true for highlighted single line', () => {
+      window.location.hash = '#L42';
+      const { result } = renderHook(() => useLineNumberNavigation());
+
+      expect(result.current.isLineHighlighted(42)).toBe(true);
+      expect(result.current.isLineHighlighted(41)).toBe(false);
+      expect(result.current.isLineHighlighted(43)).toBe(false);
+    });
+
+    it('should return true for lines in highlighted range', () => {
+      window.location.hash = '#L10-L20';
+      const { result } = renderHook(() => useLineNumberNavigation());
+
+      expect(result.current.isLineHighlighted(9)).toBe(false);
+      expect(result.current.isLineHighlighted(10)).toBe(true);
+      expect(result.current.isLineHighlighted(15)).toBe(true);
+      expect(result.current.isLineHighlighted(20)).toBe(true);
+      expect(result.current.isLineHighlighted(21)).toBe(false);
+    });
+  });
+
+  describe('Hash Change Event', () => {
+    it('should update highlighted lines when hash changes', () => {
+      const { result } = renderHook(() => useLineNumberNavigation());
+
+      expect(result.current.highlightedLines).toBeNull();
+
+      // Simulate hash change
+      act(() => {
+        window.location.hash = '#L123';
+        window.dispatchEvent(new HashChangeEvent('hashchange'));
+      });
+
+      expect(result.current.highlightedLines).toEqual({ start: 123, end: 123 });
+    });
+
+    it('should reset firstSelectedLine on hash change', () => {
+      const { result } = renderHook(() => useLineNumberNavigation());
+
+      // Set first selected line
+      act(() => {
+        result.current.handleLineClick(10, createMouseEvent(false));
+      });
+
+      expect(result.current.firstSelectedLine).toBe(10);
+
+      // External hash change (without line-click state) should reset it
+      act(() => {
+        window.location.hash = '#L456';
+        window.history.replaceState(null, '', '#L456'); // No line-click state
+        window.dispatchEvent(new HashChangeEvent('hashchange'));
+      });
+
+      expect(result.current.firstSelectedLine).toBeNull();
+    });
+
+    it('should clear highlights when hash is removed', () => {
+      window.location.hash = '#L123';
+      const { result } = renderHook(() => useLineNumberNavigation());
+
+      expect(result.current.highlightedLines).toEqual({ start: 123, end: 123 });
+
+      act(() => {
+        window.location.hash = '';
+        window.dispatchEvent(new HashChangeEvent('hashchange'));
+      });
+
+      expect(result.current.highlightedLines).toBeNull();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle line number 1', () => {
+      const { result } = renderHook(() => useLineNumberNavigation());
+
+      act(() => {
+        result.current.handleLineClick(1, createMouseEvent(false));
+      });
+
+      expect(result.current.highlightedLines).toEqual({ start: 1, end: 1 });
+    });
+
+    it('should handle very large line numbers', () => {
+      const { result } = renderHook(() => useLineNumberNavigation());
+
+      act(() => {
+        result.current.handleLineClick(999999, createMouseEvent(false));
+      });
+
+      expect(result.current.highlightedLines).toEqual({ start: 999999, end: 999999 });
+    });
+
+    it('should handle single-line range (same start and end)', () => {
+      window.location.hash = '#L42-L42';
+      const { result } = renderHook(() => useLineNumberNavigation());
+
+      expect(result.current.highlightedLines).toEqual({ start: 42, end: 42 });
+      expect(result.current.isLineHighlighted(42)).toBe(true);
+      expect(result.current.isLineHighlighted(43)).toBe(false);
+    });
+  });
+
+  describe('Hash clearing when switching views', () => {
+    it('should clear highlighted lines when hash is removed without hashchange event', () => {
+      // Start with a hash
+      window.location.hash = '#L9-L14';
+      const { result, rerender } = renderHook(() => useLineNumberNavigation());
+
+      // Verify initial highlight
+      expect(result.current.highlightedLines).toEqual({ start: 9, end: 14 });
+      expect(result.current.isLineHighlighted(10)).toBe(true);
+
+      // Simulate switching to another log view where parent clears the hash directly
+      // (without triggering hashchange event)
+      window.location.hash = '';
+      window.history.replaceState(null, '', window.location.pathname);
+
+      // Force re-render to trigger useEffect
+      rerender();
+
+      // Highlighted lines should be cleared
+      expect(result.current.highlightedLines).toBeNull();
+      expect(result.current.isLineHighlighted(10)).toBe(false);
+    });
+
+    it('should update highlights when hash changes without hashchange event', () => {
+      // Start with a hash
+      window.location.hash = '#L5';
+      const { result, rerender } = renderHook(() => useLineNumberNavigation());
+
+      expect(result.current.highlightedLines).toEqual({ start: 5, end: 5 });
+
+      // Simulate parent changing the hash directly (update both hash and state)
+      window.location.hash = '#L20-L25';
+      window.history.replaceState(null, '', '#L20-L25');
+
+      // Force re-render to trigger useEffect
+      rerender();
+
+      // Should update to new highlight
+      expect(result.current.highlightedLines).toEqual({ start: 20, end: 25 });
+      expect(result.current.isLineHighlighted(22)).toBe(true);
+      expect(result.current.isLineHighlighted(5)).toBe(false);
+    });
+
+    it('should not re-render infinitely when hash does not change', () => {
+      window.location.hash = '#L10';
+      const { result, rerender } = renderHook(() => useLineNumberNavigation());
+
+      const initialHighlight = result.current.highlightedLines;
+      expect(initialHighlight).toEqual({ start: 10, end: 10 });
+
+      // Multiple re-renders without hash change
+      rerender();
+      rerender();
+      rerender();
+
+      // Should maintain the same reference (no unnecessary re-renders)
+      expect(result.current.highlightedLines).toEqual({ start: 10, end: 10 });
+    });
+
+    it('should preserve firstSelectedLine after single line click for shift-click range selection', () => {
+      window.location.hash = '';
+      const { result, rerender } = renderHook(() => useLineNumberNavigation());
+
+      // Click line 5 (without shift)
+      act(() => {
+        result.current.handleLineClick(5, createMouseEvent(false));
+      });
+
+      // After clicking, hash should be #L5 and firstSelectedLine should be 5
+      expect(window.location.hash).toBe('#L5');
+      expect(result.current.firstSelectedLine).toBe(5);
+      // Verify history.state was set to mark internal navigation
+      expect(window.history.state).toEqual({ source: 'line-click' });
+
+      // Simulate re-render (hash sync effect runs)
+      rerender();
+
+      // firstSelectedLine should STILL be 5 (not cleared by hash sync for internal clicks)
+      expect(result.current.firstSelectedLine).toBe(5);
+
+      // Now shift-click line 10 to create a range
+      act(() => {
+        result.current.handleLineClick(10, createMouseEvent(true));
+      });
+
+      // Should create range L5-L10
+      expect(window.location.hash).toBe('#L5-L10');
+      expect(result.current.highlightedLines).toEqual({ start: 5, end: 10 });
+      expect(result.current.isLineHighlighted(7)).toBe(true);
+      // Verify history.state was set for range selection too
+      expect(window.history.state).toEqual({ source: 'line-click' });
+    });
+  });
+
+  describe('Performance', () => {
+    it('should not cause excessive re-renders when hash does not change', () => {
+      window.location.hash = '#L10';
+      const { result, rerender } = renderHook(() => useLineNumberNavigation());
+
+      const initialHighlight = result.current.highlightedLines;
+      const initialIsHighlighted = result.current.isLineHighlighted;
+      const initialHandleClick = result.current.handleLineClick;
+
+      // Multiple re-renders without hash change
+      for (let i = 0; i < 10; i++) {
+        rerender();
+      }
+
+      // Function references should remain stable
+      expect(result.current.isLineHighlighted).toBe(initialIsHighlighted);
+      expect(result.current.handleLineClick).toBe(initialHandleClick);
+
+      // Highlighted lines should be the same (though may be a new object)
+      expect(result.current.highlightedLines).toEqual(initialHighlight);
+    });
+
+    it('should efficiently handle rapid hash changes', () => {
+      const { result } = renderHook(() => useLineNumberNavigation());
+
+      // Simulate rapid clicking
+      const start = performance.now();
+      act(() => {
+        for (let i = 1; i <= 100; i++) {
+          result.current.handleLineClick(i, createMouseEvent(false));
+        }
+      });
+      const duration = performance.now() - start;
+
+      // Should complete 100 clicks in reasonable time (< 100ms in test environment)
+      expect(duration).toBeLessThan(100);
+
+      // Final state should be correct
+      expect(result.current.highlightedLines).toEqual({ start: 100, end: 100 });
+      expect(result.current.firstSelectedLine).toBe(100);
+    });
+
+    it('should not re-parse hash on every render when unchanged', () => {
+      window.location.hash = '#L50-L60';
+
+      // Verify the state doesn't change unnecessarily
+      const { result, rerender } = renderHook(() => useLineNumberNavigation());
+
+      const initialHighlight = result.current.highlightedLines;
+
+      // Re-render multiple times
+      for (let i = 0; i < 5; i++) {
+        rerender();
+        // Highlighted lines object should be the same
+        expect(result.current.highlightedLines).toEqual(initialHighlight);
+      }
+    });
+  });
+});

--- a/src/shared/components/virtualized-log-viewer/index.ts
+++ b/src/shared/components/virtualized-log-viewer/index.ts
@@ -2,3 +2,10 @@ export { VirtualizedLogViewer } from './VirtualizedLogViewer';
 export type { VirtualizedLogViewerProps } from './VirtualizedLogViewer';
 export { VirtualizedLogContent } from './VirtualizedLogContent';
 export type { VirtualizedLogContentProps } from './VirtualizedLogContent';
+export { LineNumberGutter } from './LineNumberGutter';
+export type { LineNumberGutterProps } from './LineNumberGutter';
+export { useLineNumberNavigation } from './useLineNumberNavigation';
+export type {
+  UseLineNumberNavigationResult,
+  HighlightedLineRange,
+} from './useLineNumberNavigation';

--- a/src/shared/components/virtualized-log-viewer/useLineNumberNavigation.ts
+++ b/src/shared/components/virtualized-log-viewer/useLineNumberNavigation.ts
@@ -1,0 +1,136 @@
+import React from 'react';
+
+export interface HighlightedLineRange {
+  start: number;
+  end: number;
+}
+
+export interface UseLineNumberNavigationResult {
+  highlightedLines: HighlightedLineRange | null;
+  firstSelectedLine: number | null;
+  handleLineClick: (lineNumber: number, event: React.MouseEvent) => void;
+  isLineHighlighted: (lineNumber: number) => boolean;
+}
+
+/**
+ * Custom hook to manage line number navigation and highlighting
+ *
+ * Supports:
+ * - Single line selection (#L123)
+ * - Range selection with shift-click (#L10-L20)
+ * - URL hash parsing and updates
+ * - Highlight state management
+ */
+export const useLineNumberNavigation = (): UseLineNumberNavigationResult => {
+  // Track the first selected line for range selection
+  const [firstSelectedLine, setFirstSelectedLine] = React.useState<number | null>(null);
+
+  // Parse hash to get highlighted line(s)
+  // No need for useCallback - function has no dependencies and is only called from effects
+  const getHighlightedLines = (): HighlightedLineRange | null => {
+    const hash = window.location.hash;
+    const LINE_NUMBER_RANGE_REGEX = /^#L(\d+)-L(\d+)$/; // Match #L123-L456 (range)
+    const LINE_NUMBER_SINGLE_REGEX = /^#L(\d+)$/; // Match #L123 (single line)
+
+    const rangeMatch = hash.match(LINE_NUMBER_RANGE_REGEX);
+    if (rangeMatch) {
+      const start = parseInt(rangeMatch[1], 10);
+      const end = parseInt(rangeMatch[2], 10);
+      return { start: Math.min(start, end), end: Math.max(start, end) };
+    }
+
+    const singleMatch = hash.match(LINE_NUMBER_SINGLE_REGEX);
+    if (singleMatch) {
+      const line = parseInt(singleMatch[1], 10);
+      return { start: line, end: line };
+    }
+
+    return null;
+  };
+
+  // Use lazy initialization to avoid calling getHighlightedLines on every render
+  const [highlightedLines, setHighlightedLines] = React.useState(() => getHighlightedLines());
+
+  // Track the last hash to detect changes (including when hash is cleared)
+  const lastHashRef = React.useRef(window.location.hash);
+
+  // Effect to detect hash changes on every render (including changes without hashchange event)
+  // This runs frequently but the ref comparison prevents unnecessary state updates
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  React.useEffect(() => {
+    const currentHash = window.location.hash;
+
+    // Check if this was an internal navigation using history.state
+    const isInternalNavigation = window.history.state?.source === 'line-click';
+
+    // Only update if hash actually changed (ref comparison prevents infinite loops)
+    if (currentHash !== lastHashRef.current) {
+      lastHashRef.current = currentHash;
+      const newHighlight = getHighlightedLines();
+      setHighlightedLines(newHighlight);
+
+      // Reset firstSelectedLine if:
+      // 1. Hash was cleared (switching views), OR
+      // 2. This was NOT an internal navigation (external hash change or browser navigation)
+      if (!currentHash || !newHighlight || !isInternalNavigation) {
+        setFirstSelectedLine(null);
+      }
+    }
+  }); // No dependency array - runs on every render to detect hash changes without hashchange event
+
+  // Separate effect for hashchange event listener (browser back/forward)
+  React.useEffect(() => {
+    const handleHashChange = () => {
+      const newHash = window.location.hash;
+      lastHashRef.current = newHash;
+      const newHighlight = getHighlightedLines();
+      setHighlightedLines(newHighlight);
+
+      // Always reset firstSelectedLine on hashchange event (external navigation)
+      setFirstSelectedLine(null);
+    };
+
+    window.addEventListener('hashchange', handleHashChange);
+    return () => window.removeEventListener('hashchange', handleHashChange);
+  }, []); // Empty dependency array - listener only needs to be set up once
+
+  // Handle line number click for hash navigation
+  const handleLineClick = React.useCallback(
+    (lineNumber: number, event: React.MouseEvent) => {
+      if (event.shiftKey && firstSelectedLine !== null) {
+        // Shift-click: create range
+        const start = Math.min(firstSelectedLine, lineNumber);
+        const end = Math.max(firstSelectedLine, lineNumber);
+        const hash = `#L${start}-L${end}`;
+        // Use history.state to mark this as an internal navigation
+        window.history.pushState({ source: 'line-click' }, '', hash);
+        setHighlightedLines({ start, end });
+        setFirstSelectedLine(null); // Reset after creating range
+      } else {
+        // Normal click: select single line
+        const hash = `#L${lineNumber}`;
+        // Use history.state to mark this as an internal navigation
+        window.history.pushState({ source: 'line-click' }, '', hash);
+        setHighlightedLines({ start: lineNumber, end: lineNumber });
+        setFirstSelectedLine(lineNumber);
+      }
+    },
+    [firstSelectedLine],
+  );
+
+  // Check if a line is highlighted
+  const isLineHighlighted = React.useCallback(
+    (lineNumber: number): boolean => {
+      if (!highlightedLines) return false;
+      return lineNumber >= highlightedLines.start && lineNumber <= highlightedLines.end;
+    },
+    [highlightedLines],
+  );
+
+  return {
+    highlightedLines,
+    firstSelectedLine,
+    handleLineClick,
+    isLineHighlighted,
+  };
+};


### PR DESCRIPTION
## Fixes 
[KFLUXUI-874](https://issues.redhat.com/browse/KFLUXUI-874)

## Description
Add hash-based line navigation to virtualized log viewer, enabling users to share URLs with highlighted log lines.

Details:
- **URL Hash Navigation**: Support `#L10` (single line) and `#L10-L20` (range) formats
- **Interactive Line Selection**:
  - Click line number to select and update URL hash
  - Shift+click to create range selection
- **Visual Highlighting**: Selected lines highlighted with gold background
- **Synchronized Scrolling**: Line numbers stay perfectly aligned with content during scroll

Implementation:
- New `useLineNumberNavigations` hook manages hash state and user interactions
- New `LineNumberGutter` component renders clickable line numbers
- Enhanced `VirtualizedLogContent` to highlight selected lines
- Zero-delay scroll updates using `requestAnimationFrame`

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

https://github.com/user-attachments/assets/30aba13a-bb87-4038-a896-a20f48fcbeba


## How to test or reproduce?
1. lines are shown for log viewer
2. click lines then url would be changed accordingly
3. change url with lines then enter， the target lines would be  selected.
BTW, the url navigation is quite similar with github usages to share codes, so test with your experiences. 


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added line number gutter display alongside log content with GitHub-inspired styling
  * Line numbers are clickable for direct navigation via URL hash (#L123 format)
  * Shift-Click enables line range selection (#L10-L20 format)
  * Auto-scroll to highlighted lines when navigating by hash
  * Dark mode styling for line gutter and highlights

* **Tests**
  * Improved test stability with enhanced console filtering
  * Added comprehensive test coverage for new line navigation features
<!-- end of auto-generated comment: release notes by coderabbit.ai -->