### PR TITLE
chore(KFLUXUI-572): specify supported architecures in .yarnrc

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,3 +5,10 @@ enableGlobalCache: false
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.12.0.cjs
+
+supportedArchitectures:
+  os:
+    - linux
+  cpu:
+    - x64
+    - arm64


### PR DESCRIPTION
Assisted-by: Cursor


## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->


## Description
Push request Konflux pipelines we failing because they were unable to fetch dependencies when building for `arm64`

https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/konflux-ui-tenant/applications/konflux-ui/taskruns/konflux-ui-on-push-6k2vg-build-images-1/logs
```
[1/2] STEP 14/18: COPY webpack.prod.config.js webpack.prod.config.js
[1/2] STEP 15/18: COPY .swcrc .swcrc
[1/2] STEP 16/18: COPY aliases.config.js aliases.config.js
[1/2] STEP 17/18: RUN . /cachi2/cachi2.env &&     yarn install --immutable
➤ YN0000: · Yarn 4.12.0
➤ YN0000: ┌ Resolution step
➤ YN0000: └ Completed in 0s 412ms
➤ YN0000: ┌ Post-resolution validation
➤ YN0060: │ @types/react is listed by your project with version 18.3.27 (p11ac87), which doesn't satisfy what @testing-library/react-hooks and other dependencies request (but they have non-overlapping ranges!).
➤ YN0060: │ react is listed by your project with version 18.3.1 (pc94175), which doesn't satisfy what @testing-library/react-hooks and other dependencies request (but they have non-overlapping ranges!).
➤ YN0060: │ react-dom is listed by your project with version 18.3.1 (p93b928), which doesn't satisfy what @testing-library/react-hooks and other dependencies request (but they have non-overlapping ranges!).
➤ YN0002: │ konflux-ui@workspace:. doesn't provide i18next (pe9dd3c), requested by react-i18next.
➤ YN0002: │ konflux-ui@workspace:. doesn't provide postcss (pa219dc), requested by stylelint-config-recommended-scss.
➤ YN0086: │ Some peer dependencies are incorrectly met by your project; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code.
➤ YN0086: │ Some peer dependencies are incorrectly met by dependencies; run yarn explain peer-requirements for details.
➤ YN0000: └ Completed
➤ YN0000: ┌ Fetch step
➤ YN0001: │ RequestError: getaddrinfo ENOTFOUND registry.yarnpkg.com
    at ClientRequest.<anonymous> (/opt/app-root/src/.yarn/releases/yarn-4.12.0.cjs:146:14258)
    at Object.onceWrapper (node:events:639:26)
    at ClientRequest.emit (node:events:536:35)
    at c.emit (/opt/app-root/src/.yarn/releases/yarn-4.12.0.cjs:141:22975)
    at emitErrorEvent (node:_http_client:101:11)
    at TLSSocket.socketErrorListener (node:_http_client:504:5)
    at TLSSocket.emit (node:events:524:28)
    at emitErrorNT (node:internal/streams/destroy:169:8)
    at emitErrorCloseNT (node:internal/streams/destroy:128:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:120:26)
```
This was because the `prefetch-dependencies` step only fetched `x86_64` platform spefic dependencies.

I added supported architectures into `.yarnrc`, so all necessary dependencies are prefetched.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->