### PR TITLE
KFLUXUI-1053 [PLR details] update image proxy url logic

### DIFF
--- a/src/components/PipelineRun/PipelineRunDetailsView/tabs/__tests__/PipelineRunDetailsTab.spec.tsx
+++ b/src/components/PipelineRun/PipelineRunDetailsView/tabs/__tests__/PipelineRunDetailsTab.spec.tsx
@@ -471,7 +471,7 @@ describe('PipelineRunDetailsTab', () => {
       renderWithQueryClientAndRouter(<PipelineRunDetailsTab />);
 
       // Should fall back to original URL when proxy info is not available
-      expect(screen.getByText(konfluxImageUrl)).toBeInTheDocument();
+      expect(screen.getAllByText(konfluxImageUrl).length).toBeGreaterThan(0);
     });
 
     it('should handle image repository errors gracefully', () => {
@@ -482,7 +482,7 @@ describe('PipelineRunDetailsTab', () => {
       renderWithQueryClientAndRouter(<PipelineRunDetailsTab />);
 
       // Should fall back to original URL when image repository fails
-      expect(screen.getByText(konfluxImageUrl)).toBeInTheDocument();
+      expect(screen.getAllByText(konfluxImageUrl).length).toBeGreaterThan(0);
     });
 
     it('should wait for all data to load before rendering', () => {
@@ -516,7 +516,7 @@ describe('PipelineRunDetailsTab', () => {
       renderWithQueryClientAndRouter(<PipelineRunDetailsTab />);
 
       // User-owned repo should NOT use proxy URL even if private
-      expect(screen.getByText(userOwnedImageUrl)).toBeInTheDocument();
+      expect(screen.getAllByText(userOwnedImageUrl).length).toBeGreaterThan(0);
     });
 
     it('should not use proxy URL in params for user-owned private repositories', () => {
@@ -527,7 +527,7 @@ describe('PipelineRunDetailsTab', () => {
       renderWithQueryClientAndRouter(<PipelineRunDetailsTab />);
 
       // User-owned repo should NOT use proxy URL in params even if private
-      expect(screen.getByText(userOwnedImageUrl)).toBeInTheDocument();
+      expect(screen.getAllByText(userOwnedImageUrl).length).toBeGreaterThan(0);
     });
   });
 });


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->

Fixes https://issues.redhat.com/browse/KFLUXUI-1053

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In this PR we're updating the proxy url logic (in the PipelineRun Details page) to add a new result/param entry with the proxy url instead of replacing `IMAGE_URL` and `output-image` values directly.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

<img width="1917" height="975" alt="plr-details-proxy-image-url-ISSUE" src="https://github.com/user-attachments/assets/f87d7898-1cd9-43eb-986b-d3c25131d9bb" />

After:

<img width="1918" height="871" alt="plr-details-proxy-image-url-FIX" src="https://github.com/user-attachments/assets/a2df62f4-15f1-40fd-b71a-a5ef68479046" />


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

* open a PLR from a component that has "Image repository visibility" set as private
* scroll down the page and notice that Results list will have a new row `IMAGE_URL (via access proxy)` and Parameters list will have a new row `output-image (via access proxy)`
* :coffee:

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Proxy URL parameters: when a proxied URL differs, a proxied variant of the parameter is shown alongside the original (without mutating originals).
  * Rendering guards tightened so result and parameter sections display only when actual patched content exists, avoiding empty sections.
* **Tests**
  * Assertions updated to accept multiple matching renderings, ensuring tests remain robust to duplicated proxy variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->