### PR TITLE
KFLUXUI-1050 [Secrets Page] fix "show more/less" labels logic

### DIFF
--- a/src/components/Secrets/SecretsListView/SecretLabels.tsx
+++ b/src/components/Secrets/SecretsListView/SecretLabels.tsx
@@ -22,7 +22,7 @@ export const SecretLabels = ({
   ) : (
     <>
       {labels.map((l, i) => {
-        if (expanded || i <= maxLabels) {
+        if (expanded || i < maxLabels) {
           return (
             <Label key={l} className="secret-label">
               {l}

--- a/src/components/Secrets/__tests___/SecretLabels.spec.tsx
+++ b/src/components/Secrets/__tests___/SecretLabels.spec.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import { SECRET_MAX_LABELS } from '~/consts/secrets';
 import { SecretLabels } from '../SecretsListView/SecretLabels';
 
 describe('SecretLabels', () => {
@@ -25,10 +26,23 @@ describe('SecretLabels', () => {
         handleToggle={() => {}}
       />,
     );
-    r.debug();
     expect(r.getByText('label1')).toBeInTheDocument();
     expect(r.getByText('label2')).toBeInTheDocument();
-    expect(r.queryByText('label5')).not.toBeInTheDocument();
+    expect(r.getByText('label3')).toBeInTheDocument();
+    expect(r.queryByText('label4')).not.toBeInTheDocument();
+    expect(r.getByText('Show more')).toBeInTheDocument();
+  });
+
+  it('should hide the label at maxLabels index when collapsed', () => {
+    const labels = Array.from({ length: SECRET_MAX_LABELS + 1 }, (_, i) => `label${i + 1}`);
+    const r = render(
+      <SecretLabels labels={labels} index={0} expanded={false} handleToggle={() => {}} />,
+    );
+
+    labels.slice(0, SECRET_MAX_LABELS).forEach((label) => {
+      expect(r.getByText(label)).toBeInTheDocument();
+    });
+    expect(r.queryByText(labels[SECRET_MAX_LABELS])).not.toBeInTheDocument();
     expect(r.getByText('Show more')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->

Fixes https://issues.redhat.com/browse/KFLUXUI-1050

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In this PR we're updating the `SecretLabels` component logic so that exactly the configured max number of labels is shown before the ‘Show more’ button (previously one extra label was shown).

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

https://github.com/user-attachments/assets/f0911890-3442-4aa7-a7fd-3f0f8ab91536

After:

https://github.com/user-attachments/assets/666bdef7-f072-4498-8f62-ea3e956f1f39

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

- navigate to Secrets page
- find a secret that has 4+ labels
- notice that the "show more/less" button behaves correctly
- :coffee:

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed label rendering in Secrets view to correctly truncate labels before displaying the "Show more" option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->