### PR TITLE
feat(KFLUXUI-1004): new component list page

### DIFF
--- a/src/components/ComponentList/ComponentList.tsx
+++ b/src/components/ComponentList/ComponentList.tsx
@@ -1,0 +1,115 @@
+import * as React from 'react';
+import { EmptyStateBody, Text, TextContent, TextVariants, Title } from '@patternfly/react-core';
+import { FilterContext } from '~/components/Filter/generic/FilterContext';
+import { BaseTextFilterToolbar } from '~/components/Filter/toolbars/BaseTextFIlterToolbar';
+import { FeatureFlagIndicator } from '~/feature-flags/FeatureFlagIndicator';
+import { useAllComponents } from '~/hooks/useComponents';
+import { Table, useDeepCompareMemoize } from '~/shared';
+import AppEmptyState from '~/shared/components/empty-state/AppEmptyState';
+import FilteredEmptyState from '~/shared/components/empty-state/FilteredEmptyState';
+import { useNamespace } from '~/shared/providers/Namespace/useNamespaceInfo';
+import { getErrorState } from '~/shared/utils/error-utils';
+import { ComponentKind } from '~/types';
+import emptyStateImgUrl from '../../assets/Components.svg';
+import { ButtonWithAccessTooltip } from '../ButtonWithAccessTooltip';
+import ComponentsListHeader from './ComponentListHeader';
+import ComponentsListRow from './ComponentListRow';
+
+const ComponentList: React.FC = () => {
+  const namespace = useNamespace();
+
+  const { filters: unparsedFilters, setFilters, onClearFilters } = React.useContext(FilterContext);
+  const filters = useDeepCompareMemoize({
+    name: unparsedFilters.name ? (unparsedFilters.name as string) : '',
+  });
+
+  const { name: nameFilter } = filters;
+
+  const [allComponents, allComponentsLoaded, allComponentsError] = useAllComponents(namespace);
+
+  const components = React.useMemo(
+    () => (!allComponentsLoaded || allComponentsError ? [] : allComponents),
+    [allComponentsLoaded, allComponentsError, allComponents],
+  );
+
+  const filteredComponents = React.useMemo(
+    () =>
+      components.filter((component) => {
+        return !nameFilter || component.metadata.name.indexOf(nameFilter) !== -1;
+      }),
+    [components, nameFilter],
+  );
+
+  const NoDataEmptyMessage = () => (
+    <AppEmptyState
+      className="component-list__empty-state"
+      emptyStateImg={emptyStateImgUrl}
+      title=""
+    >
+      <EmptyStateBody>
+        A component is an image built from source code in a repository.
+        <br />
+        To get started, add a component.
+      </EmptyStateBody>
+      <ButtonWithAccessTooltip variant="primary" tooltip="You don't have access to add a component">
+        Add component
+      </ButtonWithAccessTooltip>
+    </AppEmptyState>
+  );
+
+  const EmptyMessage = () => (
+    <FilteredEmptyState
+      onClearFilters={onClearFilters}
+      data-test="components-list-view__all-filtered"
+      className="component-list__empty-state"
+    />
+  );
+
+  const toolbar = (
+    <BaseTextFilterToolbar
+      text={nameFilter}
+      label="name"
+      setText={(name) => setFilters({ ...filters, name })}
+      onClearFilters={onClearFilters}
+      dataTest="component-list-toolbar"
+    />
+  );
+
+  if (allComponentsError) {
+    return getErrorState(allComponentsError, allComponentsLoaded, 'components');
+  }
+
+  return (
+    <>
+      <Title headingLevel="h3" className="pf-v5-u-mt-lg pf-v5-u-mb-sm pf-v5-u-pl-md">
+        Components
+        <span className="pf-v5-u-ml-sm">
+          <FeatureFlagIndicator flags={['components-page']} />
+        </span>
+      </Title>
+      <TextContent className="pf-v5-u-pl-md">
+        <Text component={TextVariants.p}>
+          A component is an image built from source code in a repository.
+        </Text>
+      </TextContent>
+      <Table
+        virtualize={false}
+        data={filteredComponents}
+        unfilteredData={components}
+        EmptyMsg={EmptyMessage}
+        NoDataEmptyMsg={NoDataEmptyMessage}
+        Toolbar={toolbar}
+        aria-label="Components List"
+        Header={ComponentsListHeader}
+        Row={ComponentsListRow}
+        loaded={allComponentsLoaded}
+        getRowProps={(obj: ComponentKind) => ({
+          id: `${obj.metadata.name}-component-list-item`,
+          'aria-label': obj.metadata.name,
+        })}
+      />
+    </>
+  );
+};
+
+export default ComponentList;

--- a/src/components/ComponentList/ComponentListHeader.tsx
+++ b/src/components/ComponentList/ComponentListHeader.tsx
@@ -1,0 +1,29 @@
+export const componentsTableColumnClasses = {
+  component: 'pf-m-width-30 wrap-column',
+  gitRepository: 'pf-m-width-30 wrap-column',
+  imageRegistry: 'pf-m-width-30 wrap-column',
+  componentVersions: 'pf-m-width-20',
+};
+
+const ComponentsListHeader = () => {
+  return [
+    {
+      title: 'Name',
+      props: { className: componentsTableColumnClasses.component },
+    },
+    {
+      title: 'Git Repository',
+      props: { className: componentsTableColumnClasses.gitRepository },
+    },
+    {
+      title: 'Image Registry',
+      props: { className: componentsTableColumnClasses.imageRegistry },
+    },
+    {
+      title: 'Component Versions',
+      props: { className: componentsTableColumnClasses.componentVersions },
+    },
+  ];
+};
+
+export default ComponentsListHeader;

--- a/src/components/ComponentList/ComponentListRow.tsx
+++ b/src/components/ComponentList/ComponentListRow.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { PacStatesForComponents } from '../../hooks/usePACStatesForComponents';
+import { COMPONENT_DETAILS_V2_PATH } from '../../routes/paths';
+import { RowFunctionArgs, TableData } from '../../shared';
+import { ImageUrlDisplay } from '../../shared/components/image-display';
+import { useNamespace } from '../../shared/providers/Namespace/useNamespaceInfo';
+import { ComponentKind, PipelineRunKind } from '../../types';
+import { getLastestImage } from '../../utils/component-utils';
+import GitRepoLink from '../GitLink/GitRepoLink';
+import { componentsTableColumnClasses } from './ComponentListHeader';
+
+type ComponentWithLatestBuildPipeline = ComponentKind & {
+  latestBuildPipelineRun?: PipelineRunKind;
+};
+
+const ComponentsListRow: React.FC<
+  RowFunctionArgs<ComponentWithLatestBuildPipeline, PacStatesForComponents>
+> = ({ obj: component }) => {
+  const namespace = useNamespace();
+  const name = component.metadata.name;
+  const latestImage = getLastestImage(component);
+  const versions = component.spec.source?.versions;
+  const versionsCount = versions?.length ?? 0;
+
+  return (
+    <>
+      <TableData className={componentsTableColumnClasses.component} data-test="component-list-item">
+        <Link
+          to={COMPONENT_DETAILS_V2_PATH.createPath({
+            workspaceName: namespace,
+            componentName: name,
+          })}
+        >
+          {name}
+        </Link>
+      </TableData>
+      <TableData className={componentsTableColumnClasses.gitRepository}>
+        {component.spec.source?.git && (
+          <GitRepoLink
+            url={component.spec.source?.git?.url}
+            revision={component.spec.source?.git?.revision}
+            context={component.spec.source?.git?.context}
+          />
+        )}
+      </TableData>
+      <TableData className={componentsTableColumnClasses.imageRegistry}>
+        {latestImage && (
+          <ImageUrlDisplay
+            imageUrl={latestImage}
+            namespace={component.metadata.namespace}
+            componentName={component.metadata.name}
+          />
+        )}
+      </TableData>
+      <TableData
+        className={componentsTableColumnClasses.componentVersions}
+        data-test="component-versions-count"
+      >
+        {versionsCount}
+      </TableData>
+    </>
+  );
+};
+
+export default ComponentsListRow;

--- a/src/components/ComponentList/ComponentsListView.tsx
+++ b/src/components/ComponentList/ComponentsListView.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { FilterContextProvider } from '~/components/Filter/generic/FilterContext';
+import ComponentList from './ComponentList';
+
+const ComponentsListView: React.FC = () => (
+  <FilterContextProvider filterParams={['name']}>
+    <ComponentList />
+  </FilterContextProvider>
+);
+
+export default ComponentsListView;

--- a/src/components/ComponentList/__tests__/ComponentList.spec.tsx
+++ b/src/components/ComponentList/__tests__/ComponentList.spec.tsx
@@ -1,0 +1,127 @@
+import { screen } from '@testing-library/react';
+import { FilterContextProvider } from '~/components/Filter/generic/FilterContext';
+import type { ComponentKind } from '~/types';
+import { mockUseNamespaceHook } from '~/unit-test-utils/mock-namespace';
+import { mockUseSearchParamBatch } from '~/unit-test-utils/mock-useSearchParam';
+import { renderWithQueryClientAndRouter } from '~/unit-test-utils/rendering-utils';
+import ComponentList from '../ComponentList';
+
+jest.mock('~/hooks/useComponents', () => ({
+  useAllComponents: jest.fn(),
+}));
+
+jest.mock('~/hooks/useSearchParam', () => ({
+  useSearchParamBatch: () => mockUseSearchParamBatch(),
+}));
+
+const useAllComponentsMock = jest.requireMock('~/hooks/useComponents')
+  .useAllComponents as jest.Mock;
+
+const createMockComponent = (name: string, namespace = 'test-ns'): ComponentKind =>
+  ({
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    kind: 'Component',
+    metadata: { name, namespace, uid: `uid-${name}` },
+    spec: {
+      application: 'test-app',
+      componentName: name,
+      source: { git: { url: 'https://example.com/repo', revision: 'main' } },
+    },
+  }) as ComponentKind;
+
+const renderComponentList = () =>
+  renderWithQueryClientAndRouter(
+    <FilterContextProvider filterParams={['name', 'status']}>
+      <ComponentList />
+    </FilterContextProvider>,
+  );
+
+describe('ComponentList', () => {
+  let useNamespaceMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useNamespaceMock = mockUseNamespaceHook('test-ns') as jest.Mock;
+    useAllComponentsMock.mockReturnValue([[], true, undefined]);
+  });
+
+  it('should render title and description', () => {
+    renderComponentList();
+    expect(screen.getByRole('heading', { level: 3, name: /Components/i })).toBeInTheDocument();
+    expect(
+      screen.getAllByText(/A component is an image built from source code in a repository/).length,
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should render the filter toolbar when components are present', () => {
+    const components = [createMockComponent('single-comp')];
+    useAllComponentsMock.mockReturnValue([components, true, undefined]);
+    renderComponentList();
+    expect(screen.getByTestId('component-list-toolbar')).toBeInTheDocument();
+  });
+
+  it('should show loading skeleton when components are not loaded', () => {
+    useAllComponentsMock.mockReturnValue([[], false, undefined]);
+    renderComponentList();
+    expect(screen.getByTestId('data-table-skeleton')).toBeInTheDocument();
+  });
+
+  it('should show error state when useAllComponents returns an error', () => {
+    useAllComponentsMock.mockReturnValue([[], true, { code: 403 }]);
+    renderComponentList();
+    expect(screen.getByText(/Unable to load components/i)).toBeInTheDocument();
+  });
+
+  it('should show empty state with Add component when no components exist', () => {
+    renderComponentList();
+    expect(screen.getByText(/To get started, add a component/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Add component/i })).toBeInTheDocument();
+  });
+
+  it('should render component rows when data is loaded', () => {
+    const components = [createMockComponent('comp-a'), createMockComponent('comp-b')];
+    useAllComponentsMock.mockReturnValue([components, true, undefined]);
+
+    renderComponentList();
+
+    expect(screen.getByText('comp-a')).toBeInTheDocument();
+    expect(screen.getByText('comp-b')).toBeInTheDocument();
+    expect(screen.getAllByTestId('component-list-item')).toHaveLength(2);
+  });
+
+  it('should call useAllComponents with current namespace', () => {
+    useNamespaceMock.mockReturnValue('my-namespace');
+    renderComponentList();
+    expect(useAllComponentsMock).toHaveBeenCalledWith('my-namespace');
+  });
+
+  it('should filter components by name when name filter is applied via context', async () => {
+    const components = [createMockComponent('nodejs-app'), createMockComponent('go-service')];
+    useAllComponentsMock.mockReturnValue([components, true, undefined]);
+    const setFiltersMock = jest.fn();
+    const onClearFiltersMock = jest.fn();
+    const { FilterContext: FilterContextObj } = await import(
+      '~/components/Filter/generic/FilterContext'
+    );
+    renderWithQueryClientAndRouter(
+      <FilterContextObj.Provider
+        value={{
+          filters: { name: 'nodejs', status: [] },
+          setFilters: setFiltersMock,
+          onClearFilters: onClearFiltersMock,
+        }}
+      >
+        <ComponentList />
+      </FilterContextObj.Provider>,
+    );
+    expect(screen.getByText('nodejs-app')).toBeInTheDocument();
+    expect(screen.queryByText('go-service')).not.toBeInTheDocument();
+  });
+
+  it('should render table when components are loaded', () => {
+    const components = [createMockComponent('one')];
+    useAllComponentsMock.mockReturnValue([components, true, undefined]);
+    renderComponentList();
+    expect(screen.getByText('one')).toBeInTheDocument();
+  });
+});

--- a/src/components/ComponentList/__tests__/ComponentListHeader.spec.tsx
+++ b/src/components/ComponentList/__tests__/ComponentListHeader.spec.tsx
@@ -1,0 +1,31 @@
+import ComponentsListHeader, { componentsTableColumnClasses } from '../ComponentListHeader';
+
+describe('ComponentListHeader', () => {
+  it('returns column definitions with expected titles', () => {
+    const headers = ComponentsListHeader();
+    expect(headers).toHaveLength(4);
+    expect(headers.map((h) => h.title)).toEqual([
+      'Name',
+      'Git Repository',
+      'Image Registry',
+      'Component Versions',
+    ]);
+  });
+
+  it('applies componentsTableColumnClasses to each column', () => {
+    const headers = ComponentsListHeader();
+    expect(headers[0].props.className).toBe(componentsTableColumnClasses.component);
+    expect(headers[1].props.className).toBe(componentsTableColumnClasses.gitRepository);
+    expect(headers[2].props.className).toBe(componentsTableColumnClasses.imageRegistry);
+    expect(headers[3].props.className).toBe(componentsTableColumnClasses.componentVersions);
+  });
+
+  it('exports componentsTableColumnClasses with expected keys', () => {
+    expect(componentsTableColumnClasses).toEqual({
+      component: 'pf-m-width-30 wrap-column',
+      gitRepository: 'pf-m-width-30 wrap-column',
+      imageRegistry: 'pf-m-width-30 wrap-column',
+      componentVersions: 'pf-m-width-20',
+    });
+  });
+});

--- a/src/components/ComponentList/__tests__/ComponentListRow.spec.tsx
+++ b/src/components/ComponentList/__tests__/ComponentListRow.spec.tsx
@@ -1,0 +1,128 @@
+import { screen } from '@testing-library/react';
+import { COMPONENT_DETAILS_V2_PATH } from '~/routes/paths';
+import type { ComponentKind } from '~/types';
+import { renderWithQueryClientAndRouter } from '~/unit-test-utils/rendering-utils';
+import ComponentsListRow from '../ComponentListRow';
+
+jest.mock('~/shared/providers/Namespace/useNamespaceInfo', () => ({
+  useNamespace: jest.fn(),
+}));
+
+jest.mock('~/components/Components/component-actions', () => ({
+  useComponentActions: () => [],
+}));
+
+const useNamespaceMock = jest.requireMock('~/shared/providers/Namespace/useNamespaceInfo')
+  .useNamespace as jest.Mock;
+
+const createMockComponent = (overrides: Partial<ComponentKind> = {}): ComponentKind =>
+  ({
+    apiVersion: 'appstudio.redhat.com/v1alpha1',
+    kind: 'Component',
+    metadata: { name: 'test-component', namespace: 'test-ns', uid: 'uid-1' },
+    spec: {
+      application: 'test-app',
+      componentName: 'test-component',
+      source: { git: { url: 'https://github.com/org/repo', revision: 'main' } },
+    },
+    ...overrides,
+  }) as ComponentKind;
+
+const renderRow = (component: ComponentKind) => {
+  const obj = { ...component };
+  return renderWithQueryClientAndRouter(
+    <table>
+      <tbody>
+        <tr>
+          <ComponentsListRow obj={obj} columns={[]} />
+        </tr>
+      </tbody>
+    </table>,
+  );
+};
+
+describe('ComponentListRow', () => {
+  beforeEach(() => {
+    useNamespaceMock.mockReturnValue('test-ns');
+  });
+
+  it('renders component name as link', () => {
+    renderRow(createMockComponent());
+    expect(screen.getByRole('link', { name: 'test-component' })).toBeInTheDocument();
+  });
+
+  it('links to component details page with correct path', () => {
+    renderRow(
+      createMockComponent({ metadata: { name: 'my-comp', namespace: 'test-ns', uid: '1' } }),
+    );
+    useNamespaceMock.mockReturnValue('test-ns');
+    const expectedPath = COMPONENT_DETAILS_V2_PATH.createPath({
+      workspaceName: 'test-ns',
+      componentName: 'my-comp',
+    });
+    expect(screen.getByRole('link', { name: 'my-comp' })).toHaveAttribute('href', expectedPath);
+  });
+
+  it('renders component versions count', () => {
+    renderRow(
+      createMockComponent({
+        spec: {
+          application: 'test-app',
+          componentName: 'test-component',
+          source: {
+            git: { url: 'https://github.com/org/repo', revision: 'main' },
+            versions: [
+              { name: 'v1', revision: 'main' },
+              { name: 'v2', revision: 'branch' },
+            ],
+          },
+        },
+      } as ComponentKind),
+    );
+    expect(screen.getByTestId('component-versions-count')).toHaveTextContent('2');
+  });
+
+  it('renders versions count 0 when source.versions is undefined', () => {
+    renderRow(createMockComponent());
+    expect(screen.getByTestId('component-versions-count')).toHaveTextContent('0');
+  });
+
+  it('renders GitRepoLink when spec.source.git is present', () => {
+    renderRow(
+      createMockComponent({
+        spec: {
+          application: 'test-app',
+          componentName: 'test-component',
+          source: {
+            git: {
+              url: 'https://github.com/org/repo',
+              revision: 'main',
+              context: './src',
+            },
+          },
+        },
+      } as ComponentKind),
+    );
+    const link = screen.getByRole('link', { name: /org\/repo/i });
+    expect(link).toBeInTheDocument();
+  });
+
+  it('does not render GitRepoLink when spec.source.git is absent', () => {
+    renderRow(
+      createMockComponent({
+        spec: {
+          application: 'test-app',
+          componentName: 'test-component',
+          source: {},
+        },
+      } as ComponentKind),
+    );
+    expect(screen.getAllByRole('link')).toHaveLength(1);
+    expect(screen.getByRole('link', { name: 'test-component' })).toBeInTheDocument();
+  });
+
+  it('renders row with data-test component-list-item', () => {
+    renderRow(createMockComponent());
+    expect(screen.getByTestId('component-list-item')).toBeInTheDocument();
+  });
+});

--- a/src/routes/page-routes/components-page.tsx
+++ b/src/routes/page-routes/components-page.tsx
@@ -1,5 +1,6 @@
 import { RouteErrorBoundry } from '@routes/RouteErrorBoundary';
 import { ComponentVersionsTab } from '~/components/ComponentsPage/tabs/ComponentVersionsTab';
+import { ensureFeatureFlagOnLoader } from '~/feature-flags/utils';
 import {
   ComponentDetailsTab,
   ComponentDetailsViewLayout,
@@ -10,11 +11,14 @@ import { COMPONENT_DETAILS_V2_PATH, COMPONENTS_PATH } from '../paths';
 const componentsPageRoutes = [
   {
     path: COMPONENTS_PATH.path,
-    lazy: async () => {
-      const { default: Component } = await import('~/components/ComponentsPage/ComponentsPage');
+    errorElement: <RouteErrorBoundry />,
+    async lazy() {
+      ensureFeatureFlagOnLoader('components-page');
+      const { default: Component } = await import(
+        '~/components/ComponentList/ComponentsListView' /* webpackChunkName: "components-list" */
+      );
       return { Component };
     },
-    errorElement: <RouteErrorBoundry />,
   },
   {
     path: COMPONENT_DETAILS_V2_PATH.path,

--- a/src/types/component.ts
+++ b/src/types/component.ts
@@ -12,6 +12,15 @@ export type ResourceRequirements = {
   };
 };
 
+export type ComponentSourceVersion = {
+  name: string;
+  revision: string;
+  context?: string;
+  dockerfileUri?: string;
+  'skip-builds'?: boolean;
+  'build-pipeline'?: Record<string, unknown>;
+};
+
 export type ComponentSource = {
   url?: string; // Will be required when we remove old component model
   /** @deprecated Will be removed when we remove old component model */
@@ -22,9 +31,9 @@ export type ComponentSource = {
     revision?: string;
     context?: string;
   };
-
+  versions?: ComponentSourceVersion[];
   dockerfileUri?: string;
-  versions?: ComponentVersion[]; // Will be required when we remove old component model
+
 };
 
 export type RepositorySettings = {


### PR DESCRIPTION
## Fixes 
[KFLUXUI-1004](https://issues.redhat.com/browse/KFLUXUI-1004)


## Description
New Component List Page


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<img width="1428" height="666" alt="image" src="https://github.com/user-attachments/assets/bfeaa477-4fcf-4c07-ab23-591e0fdd7d44" />

<img width="1435" height="573" alt="image" src="https://github.com/user-attachments/assets/208a9846-e55a-4fd1-a708-e2c92631f804" />



## How to test or reproduce?
1. Enable flag for new application/component model.
2. Components option will appear in the left menu section.
3. Clicking on it takes you to New Component List page.

or just go to route ns/{ns}/components

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Components page: filterable list, per-item details link, image preview, version counts, actions menu, and clear CTAs; route now surfaces the page directly and applies name filtering.

* **Style**
  * Added layout, column, actions and empty-state styling for the components list view.

* **Tests**
  * Added unit and integration tests covering list, header, rows, filters, empty/error states, and getting-started behavior.

* **Types**
  * Added support for component source version metadata (versions field).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[KFLUXUI-1004]: https://redhat.atlassian.net/browse/KFLUXUI-1004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ