### PR TITLE
fix(KFLUXUI-1032): do not remove app when periodic stage e2e test fail

### DIFF
--- a/e2e-tests/tests/basic-happy-path.spec.ts
+++ b/e2e-tests/tests/basic-happy-path.spec.ts
@@ -219,7 +219,7 @@ describe('Basic Happy Path', () => {
   describe('Delete the application via UI', () => {
     before(function () {
       // Skip deletion if any previous test has failed on stage - preserve app for debugging
-      if (hasTestFailed && Cypress.env('PERIODIC_RUN_STAGE') === 'true') {
+      if (hasTestFailed && Cypress.env('JOB_TYPE') === 'periodic-stage') {
         cy.log('⚠️ Skipping application deletion - previous tests failed');
         cy.log(`Application "${applicationName}" will be preserved for debugging`);
         this.skip();


### PR DESCRIPTION
Assisted-by: Cursor


## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->
[KFLUXUI-1032](https://issues.redhat.com/browse/KFLUXUI-1032)


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Do not remove konflux ui app when periodic e2e stage test fails. Currently we chekcing for `PERIODIC_RUN_STAGE` variable from cypress.config.ts but on the periodic stage test it is set the variable `JOB_TYPE` that we can use to check what kind of test is running.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->