### PR TITLE
feat(pipeline): add new minimal build pipeline

### DIFF
--- a/src/hooks/useBuildPipelineConfig.ts
+++ b/src/hooks/useBuildPipelineConfig.ts
@@ -46,6 +46,12 @@ export const PIPELINE_DATA = {
         'quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta@sha256:9002db310cd002ddc7ccf94e08f8cd9b02c1bdd5dce36b59173fbc6cd4799f97',
     },
     {
+      name: 'docker-build-oci-ta-min',
+      bundle:
+	'quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta-min@sha256:3b35c91fb1f69976586f01a859531c0e77651f678023f33a8ac27a6b256f08be',
+
+    },
+    {
       name: 'docker-build-multi-platform-oci-ta',
       bundle:
         'quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:269480b2037478c1c8509c5f562b65f0b7f4e8675d5fda68b6bf3d28357962d7',


### PR DESCRIPTION
docker-build-oci-ta-min pipeline is a variant of docker-build-oci-ta pipeline with minimal resource requirements.


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature


<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new pipeline option "docker-build-oci-ta-min" for building Docker container images, now available for use in your workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->