### PR TITLE
KONFLUX-12360 - refactor(query/utils): add filter params to query key

### DIFF
--- a/src/k8s/query/__tests__/utils.spec.ts
+++ b/src/k8s/query/__tests__/utils.spec.ts
@@ -1,0 +1,128 @@
+import { createQueryKeys, hashQueryKeys } from '../utils';
+
+const minimalModel = {
+  apiGroup: 'tekton.dev',
+  apiVersion: 'v1',
+  kind: 'PipelineRun',
+  plural: 'pipelineruns',
+};
+
+describe('createQueryKeys', () => {
+  it('should return baseline key with model only (no queryOptions)', () => {
+    const key = createQueryKeys({ model: minimalModel });
+
+    expect(key).toEqual([
+      undefined,
+      {
+        group: 'tekton.dev',
+        version: 'v1',
+        kind: 'PipelineRun',
+      },
+    ]);
+  });
+
+  it('should include idKey when queryOptions.name is set', () => {
+    const key = createQueryKeys({
+      model: minimalModel,
+      queryOptions: { name: 'foo', queryParams: {} },
+    });
+
+    expect(key).toContainEqual({ metadata: { name: 'foo' } });
+    const idKeyEntry = key.find((x) => typeof x === 'object' && x !== null && 'metadata' in x);
+    expect(idKeyEntry).toEqual({ metadata: { name: 'foo' } });
+  });
+
+  it('should include selector when queryParams.labelSelector is set', () => {
+    const labelSelector = { matchLabels: { x: 'y' } };
+    const key = createQueryKeys({
+      model: minimalModel,
+      queryOptions: { ns: 'my-ns', queryParams: { labelSelector } },
+    });
+
+    expect(key).toContainEqual(labelSelector);
+  });
+
+  it('should include filterParams with only name in queryParams', () => {
+    const key = createQueryKeys({
+      model: minimalModel,
+      queryOptions: { ns: 'my-ns', queryParams: { name: 'bar' } },
+    });
+
+    expect(key).toContainEqual({ name: 'bar', creationTimestampAfter: undefined });
+  });
+
+  it('should include filterParams with only creationTimestampAfter in queryParams', () => {
+    const key = createQueryKeys({
+      model: minimalModel,
+      queryOptions: { ns: 'my-ns', queryParams: { creationTimestampAfter: '123' } },
+    });
+
+    expect(key).toContainEqual({ name: undefined, creationTimestampAfter: '123' });
+  });
+
+  it('should include filterParams with both name and creationTimestampAfter in queryParams', () => {
+    const key = createQueryKeys({
+      model: minimalModel,
+      queryOptions: {
+        ns: 'my-ns',
+        queryParams: { name: 'baz', creationTimestampAfter: '456' },
+      },
+    });
+
+    expect(key).toContainEqual({ name: 'baz', creationTimestampAfter: '456' });
+  });
+
+  it('should not add filterParams when queryParams has neither name nor creationTimestampAfter', () => {
+    const key = createQueryKeys({
+      model: minimalModel,
+      queryOptions: { ns: 'my-ns', queryParams: {} },
+    });
+
+    const hasFilterParamEntry = key.some(
+      (x) =>
+        typeof x === 'object' &&
+        x !== null &&
+        'name' in x &&
+        'creationTimestampAfter' in x &&
+        !('metadata' in x),
+    );
+    expect(hasFilterParamEntry).toBe(false);
+  });
+
+  it('should put prefix as first element when provided', () => {
+    const key = createQueryKeys({
+      model: minimalModel,
+      prefix: 'kubearchive',
+    });
+
+    expect(key[0]).toBe('kubearchive');
+  });
+});
+
+describe('hashQueryKeys', () => {
+  it('should produce different hashes for keys that differ only by filterParams', () => {
+    const keyA = createQueryKeys({
+      model: minimalModel,
+      queryOptions: { ns: 'ns', queryParams: { name: 'a' } },
+    });
+    const keyB = createQueryKeys({
+      model: minimalModel,
+      queryOptions: { ns: 'ns', queryParams: { name: 'b' } },
+    });
+
+    expect(hashQueryKeys(keyA)).not.toBe(hashQueryKeys(keyB));
+  });
+
+  it('should produce the same hash for keys with same filterParams', () => {
+    const keyA = createQueryKeys({
+      model: minimalModel,
+      queryOptions: { ns: 'ns', queryParams: { name: 'x', creationTimestampAfter: '123' } },
+    });
+    const keyB = createQueryKeys({
+      model: minimalModel,
+      queryOptions: { ns: 'ns', queryParams: { name: 'x', creationTimestampAfter: '123' } },
+    });
+
+    expect(hashQueryKeys(keyA)).toBe(hashQueryKeys(keyB));
+  });
+});

--- a/src/k8s/query/utils.ts
+++ b/src/k8s/query/utils.ts
@@ -23,6 +23,11 @@ export const createQueryKeys = ({
   const selector = queryOptions?.queryParams?.labelSelector
     ? [queryOptions?.queryParams?.labelSelector]
     : [];
+  const qp = queryOptions?.queryParams;
+  const filterParams =
+    qp?.name !== undefined || qp?.creationTimestampAfter !== undefined
+      ? [{ name: qp?.name, creationTimestampAfter: qp?.creationTimestampAfter }]
+      : [];
   return [
     ...(prefix ? [prefix] : []),
     queryOptions?.ns,
@@ -33,6 +38,7 @@ export const createQueryKeys = ({
     },
     ...idKey,
     ...selector,
+    ...filterParams,
   ];
 };
 


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->

Fixes https://issues.redhat.com/browse/KONFLUX-12360

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In this PR we're updating the `createQueryKeys` utility to add filter params to the query key.

Taking the example pointed out in the KONFLUX-12360 ticket, basically that's what was happening:

1. user opens Pipeline runs tab
2. they search for an "old" PLR. Old enough to not be fetched in the first pages
3. UI shows a 404 error
4. user reloads the page (with the PLR name in search params)
5. the PLR is found and displayed in the screen

The 404 occurred because the UI was reusing the cached “list all” result: the query key did not include the PLR name (and other filter params), so React Query returned the wrong cache entry instead of making a new request.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:
 
https://github.com/user-attachments/assets/fc744cea-a44c-44f7-8076-d8e799d361aa
 
After:

https://github.com/user-attachments/assets/3a0de3b9-9138-4724-be75-78599741abbd

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

- navigate to PLR list page
- search for a very old PLR (or simply a PLR that was not fetched in the first pipelineruns list pages)
- notice that the PLR now is found (fetched) and displayed in the UI
- :coffee:

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for query key utilities, covering baseline key generation, conditional inclusion of filter parameters, hash consistency, and prefix placement.

* **New Features**
  * Query keys now incorporate optional name and creation-timestamp filters, improving filtering precision and ensuring stable key hashing when filters match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->