### PR TITLE
fix(KFLUXUI-1099): only show attestation on finished pipeline runs

### DIFF
--- a/src/components/PipelineRun/PipelineRunListView/PipelineRunListRow.tsx
+++ b/src/components/PipelineRun/PipelineRunListView/PipelineRunListRow.tsx
@@ -3,36 +3,34 @@ import { Link } from 'react-router-dom';
 import { Popover, Skeleton, Tooltip } from '@patternfly/react-core';
 import { ClipboardCheckIcon } from '@patternfly/react-icons/dist/esm/icons/clipboard-check-icon';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
-import { PipelineRunColumnKeys } from '../../../consts/pipeline';
-import { PipelineRunLabel, PipelineRunType, runStatus } from '../../../consts/pipelinerun';
-import { useIsOnFeatureFlag } from '../../../feature-flags/hooks';
-import { useKarchScanResults } from '../../../hooks/useScanResults';
+import { StatusIconWithText } from '~/components/StatusIcon/StatusIcon';
+import { PipelineRunColumnKeys } from '~/consts/pipeline';
+import { PipelineRunLabel, PipelineRunType, UNFINISHED_PLR_STATUSES } from '~/consts/pipelinerun';
+import { useIsOnFeatureFlag } from '~/feature-flags/hooks';
+import { useKarchScanResults } from '~/hooks/useScanResults';
 import {
   PIPELINE_RUNS_DETAILS_PATH,
   COMPONENT_DETAILS_PATH,
   SNAPSHOT_DETAILS_PATH,
-} from '../../../routes/paths';
-import ActionMenu from '../../../shared/components/action-menu/ActionMenu';
-import { RowFunctionArgs, TableData } from '../../../shared/components/table';
-import { Timestamp } from '../../../shared/components/timestamp/Timestamp';
-import { TriggerColumnData } from '../../../shared/components/trigger-column-data/trigger-column-data';
-import { useNamespace } from '../../../shared/providers/Namespace';
-import { PipelineRunKind, TaskRunKind } from '../../../types';
-import { ReleaseKind, ReleasePlanKind } from '../../../types/coreBuildService';
-import { createCommitObjectFromPLR } from '../../../utils/commits-utils';
+} from '~/routes/paths';
+import ActionMenu from '~/shared/components/action-menu/ActionMenu';
+import { RowFunctionArgs, TableData } from '~/shared/components/table';
+import { Timestamp } from '~/shared/components/timestamp/Timestamp';
+import { TriggerColumnData } from '~/shared/components/trigger-column-data/trigger-column-data';
+import { useNamespace } from '~/shared/providers/Namespace';
+import { PipelineRunKind, TaskRunKind } from '~/types';
+import { ReleaseKind, ReleasePlanKind } from '~/types/coreBuildService';
+import { createCommitObjectFromPLR } from '~/utils/commits-utils';
 import {
   calculateDuration,
   getPipelineRunStatusResults,
   pipelineRunStatus,
   taskTestResultStatus,
-} from '../../../utils/pipeline-utils';
-import { ScanResults } from '../../../utils/scan/scan-utils';
-import { StatusIconWithText } from '../../StatusIcon/StatusIcon';
+} from '~/utils/pipeline-utils';
+import { ScanResults } from '~/utils/scan/scan-utils';
 import { usePipelinerunActionsLazy } from './pipelinerun-actions';
 import { pipelineRunTableColumnClasses, getDynamicColumnClasses } from './PipelineRunListHeader';
 import { ScanStatus } from './ScanStatus';
-
-const UNSCANNED_PLR_STATUSES = [runStatus.Pending, runStatus.Running, runStatus.Idle];
 
 type PipelineRunListRowProps = RowFunctionArgs<
   PipelineRunKind,
@@ -117,7 +115,7 @@ const usePipelineRunScanResults = (
 const shouldShowScanResults = (pipelineRun: PipelineRunKind): boolean => {
   return (
     pipelineRun.metadata.labels?.[PipelineRunLabel.PIPELINE_TYPE] === PipelineRunType.BUILD &&
-    !UNSCANNED_PLR_STATUSES.includes(pipelineRunStatus(pipelineRun)) &&
+    !UNFINISHED_PLR_STATUSES.includes(pipelineRunStatus(pipelineRun)) &&
     pipelineRun.status?.completionTime !== undefined
   );
 };
@@ -134,6 +132,7 @@ const PipelineRunAttestation = ({ pipelineRun }: { pipelineRun: PipelineRunKind 
       }
     >
       <AttestationIcon
+        data-test={hasAttestation ? 'attestation-signed' : 'attestation-unsigned'}
         color={
           hasAttestation
             ? 'var(--pf-v5-global--success-color--100)'
@@ -169,6 +168,7 @@ const BasePipelineRunListRow: React.FC<React.PropsWithChildren<BasePipelineRunLi
   );
 
   const status = pipelineRunStatus(obj);
+  const isFinished = !UNFINISHED_PLR_STATUSES.includes(status);
   const [actions, onOpen] = usePipelinerunActionsLazy(obj);
   if (!obj.metadata?.labels) {
     obj.metadata.labels = {};
@@ -199,7 +199,7 @@ const BasePipelineRunListRow: React.FC<React.PropsWithChildren<BasePipelineRunLi
           })}${queryString}`}
           title={obj.metadata?.name}
         >
-          <PipelineRunAttestation pipelineRun={obj} />
+          {isFinished && <PipelineRunAttestation pipelineRun={obj} />}
           {obj.metadata?.name}
         </Link>
       </TableData>
@@ -358,6 +358,7 @@ const DynamicPipelineRunListRow: React.FC<
   );
 
   const status = pipelineRunStatus(obj);
+  const isFinished = !UNFINISHED_PLR_STATUSES.includes(status);
   const [actions, onOpen] = usePipelinerunActionsLazy(obj);
   if (!obj.metadata?.labels) {
     obj.metadata.labels = {};
@@ -389,7 +390,7 @@ const DynamicPipelineRunListRow: React.FC<
             })}${queryString}`}
             title={obj.metadata?.name}
           >
-            <PipelineRunAttestation pipelineRun={obj} />
+            {isFinished && <PipelineRunAttestation pipelineRun={obj} />}
             {obj.metadata?.name}
           </Link>
         </TableData>

--- a/src/components/PipelineRun/PipelineRunListView/__tests__/PipelineRunListRow.spec.tsx
+++ b/src/components/PipelineRun/PipelineRunListView/__tests__/PipelineRunListRow.spec.tsx
@@ -1,7 +1,11 @@
 import { fireEvent, render, waitFor } from '@testing-library/react';
+import { PipelineRunColumnKeys } from '~/consts/pipeline';
 import { DataState, testPipelineRuns } from '../../../../__data__/pipelinerun-data';
 import { createK8sWatchResourceMock } from '../../../../utils/test-utils';
-import { PipelineRunListRowWithVulnerabilities } from '../PipelineRunListRow';
+import {
+  PipelineRunListRowWithColumns,
+  PipelineRunListRowWithVulnerabilities,
+} from '../PipelineRunListRow';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -130,5 +134,73 @@ describe('Pipeline run Row', () => {
       row.getByText('Stop');
       row.getByText('Cancel');
     });
+  });
+
+  it('should show no attestation when pipeline run is running', () => {
+    const runningPlr = testPipelineRuns[DataState.RUNNING];
+    const plrName = runningPlr.metadata.name;
+
+    const row = render(
+      <PipelineRunListRowWithColumns
+        obj={runningPlr}
+        customData={{
+          fetchedPipelineRuns: [plrName],
+          vulnerabilities: [{ [plrName]: {} }] as any,
+        }}
+        columns={['name']}
+        visibleColumns={new Set<PipelineRunColumnKeys>(['name'])}
+      />,
+    );
+
+    expect(row.queryByTestId('attestation-signed')).toBeNull();
+    expect(row.queryByTestId('attestation-unsigned')).toBeNull();
+  });
+
+  it('should show signed attestation when chains signed annotation is true', () => {
+    const succeededPlr = testPipelineRuns[DataState.SUCCEEDED];
+    const signedPlr = {
+      ...succeededPlr,
+      metadata: {
+        ...succeededPlr.metadata,
+        annotations: {
+          ...succeededPlr.metadata.annotations,
+          'chains.tekton.dev/signed': 'true',
+        },
+      },
+    };
+    const plrName = signedPlr.metadata.name;
+
+    const row = render(
+      <PipelineRunListRowWithColumns
+        obj={signedPlr}
+        customData={{
+          fetchedPipelineRuns: [plrName],
+          vulnerabilities: [{ [plrName]: {} }] as any,
+        }}
+        columns={['name']}
+        visibleColumns={new Set<PipelineRunColumnKeys>(['name'])}
+      />,
+    );
+
+    expect(row.getByTestId('attestation-signed')).toBeDefined();
+  });
+
+  it('should show warning attestation when pipeline run is not signed', () => {
+    const succeededPlr = testPipelineRuns[DataState.SUCCEEDED];
+    const plrName = succeededPlr.metadata.name;
+
+    const row = render(
+      <PipelineRunListRowWithColumns
+        obj={succeededPlr}
+        customData={{
+          fetchedPipelineRuns: [plrName],
+          vulnerabilities: [{ [plrName]: {} }] as any,
+        }}
+        columns={['name']}
+        visibleColumns={new Set<PipelineRunColumnKeys>(['name'])}
+      />,
+    );
+
+    expect(row.getByTestId('attestation-unsigned')).toBeDefined();
   });
 });

--- a/src/consts/pipelinerun.ts
+++ b/src/consts/pipelinerun.ts
@@ -115,3 +115,10 @@ export enum SucceedConditionReason {
   ExceededResourceQuota = 'ExceededResourceQuota',
   ConditionCheckFailed = 'ConditionCheckFailed',
 }
+
+export const UNFINISHED_PLR_STATUSES = [
+  runStatus.Pending,
+  runStatus.Running,
+  runStatus.Idle,
+  runStatus.Cancelling,
+];


### PR DESCRIPTION
Assisted-by: Cursor


## Fixes
[KFLUXUI-1099](https://issues.redhat.com/browse/KFLUXUI-1099)


## Description
Running PLRs are erroneously showing a "Pipeline run is not signed" warning. The issue stems from the warning being conditional purely on the `chains.tekton.dev/signed` annotation not being true, failing to account for runs that are currently executing and haven't been signed yet.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [X] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review
Before:
<img width="1017" height="154" alt="image" src="https://github.com/user-attachments/assets/1d249bf6-bb50-497a-82da-768d67c0d2a9" />

After:
<img width="1017" height="154" alt="image" src="https://github.com/user-attachments/assets/93b8465c-c5ad-45e7-aaf4-e18a34f38dce" />



## How to test or reproduce?
Check any running pipeline run



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a column-aware pipeline run row component enabling column visibility control in list views.

* **Bug Fixes**
  * Attestation information now displays only for completed pipeline runs, preventing display during in-progress runs.

* **Tests**
  * Added tests covering attestation display across run states and the new column-aware rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->