### PR TITLE
KFLUXUI-1079 - [PipelineRunLogs] update getActiveTaskRun

### DIFF
--- a/src/shared/components/pipeline-run-logs/PipelineRunLogs.tsx
+++ b/src/shared/components/pipeline-run-logs/PipelineRunLogs.tsx
@@ -60,7 +60,11 @@ class PipelineRunLogs extends React.Component<PipelineRunLogsProps, PipelineRunL
 
   getActiveTaskRun = (taskRuns: TaskRunKind[], activeTask: string): string => {
     const activeTaskRun = activeTask
-      ? taskRuns.find((taskRun) => taskRun.metadata.name.endsWith(activeTask))
+      ? taskRuns.find(
+          (taskRun) =>
+            taskRun?.metadata?.labels?.[TektonResourceLabel.pipelineTask] === activeTask ||
+            taskRun?.metadata?.name?.endsWith(activeTask),
+        )
       : taskRuns.find((taskRun) => taskRunStatus(taskRun) === runStatus.Failed) ||
         taskRuns[taskRuns.length - 1];
 


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->

Fixes https://issues.redhat.com/browse/KFLUXUI-1079

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In this PR we're updating the `getActiveTaskRun` function logic to fallback to the pipeline task label when trying to find active task run.

This fixes the issue reported in the ticket because there are some cases in which a TaskRun `metadata.name` is different from its `tekton.dev/pipelineTask` label, which would cause the `getActiveTaskRun` function to not find the task run.

Using the example pointed out in the ticket:

https://localhost:8080/ns/wlin-tenant/applications/test-new/pipelineruns/test-component-custom-cadbb-on-pull-request-q7rwc/logs?task=ecosystem-cert-preflight-checks

If you check the network requests, you'll notice that the above TaskRun `metadata.name` is `"test-component-custom-cadbb-on-5b106e02593440f41c83a7a96d65552d"`, while its `tekton.dev/pipelineTask` label is `"ecosystem-cert-preflight-checks"`.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

https://github.com/user-attachments/assets/cf95be11-6570-4e12-b1b5-0cd0602bd237

After:

https://github.com/user-attachments/assets/03b7351d-d877-44b8-9c0c-03c90906e019

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

- you can check Cara's example from the ticket (https://localhost:8080/ns/wlin-tenant/applications/test-new/pipelineruns/test-component-custom-cadbb-on-pull-request-q7rwc/logs?task=ecosystem-cert-preflight-checks)
- when opening the link above, it should navigate/focus on the `ecosystem-cert-preflight-checks` TaskRun
- :coffee:

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task-run selection in pipeline logs: the chosen task is now matched by either its name or its associated task label, ensuring the correct logs are shown; fallback (failed or last run) remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->