### PR TITLE
chore(KFLUXUI-717): enhanced commits search

### DIFF
--- a/src/components/Activity/__tests__/ActivityTab.spec.tsx
+++ b/src/components/Activity/__tests__/ActivityTab.spec.tsx
@@ -32,6 +32,7 @@ jest.mock('~/feature-flags/hooks', () => ({
   useIsOnFeatureFlag: jest.fn(() => false),
   // Provide flags map for FeatureFlagIndicator which uses useFeatureFlags()
   useFeatureFlags: jest.fn(() => [{ 'pipelineruns-kubearchive': false }, jest.fn()]),
+  IfFeature: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
 }));
 jest.mock(
   '~/kubearchive/conditional-checks',

--- a/src/components/Activity/__tests__/ActivityTab.spec.tsx
+++ b/src/components/Activity/__tests__/ActivityTab.spec.tsx
@@ -18,15 +18,6 @@ jest.mock('react-router-dom', () => {
   };
 });
 
-jest.mock('../../../hooks/useTektonResults', () => ({
-  useTRTaskRuns: jest.fn(() => [
-    [],
-    true,
-    undefined,
-    jest.fn(),
-    { isFetchingNextPage: false, hasNextPage: false },
-  ]),
-}));
 jest.mock('../../../hooks/usePipelineRunsV2', () => ({
   usePipelineRunsV2: jest.fn(() => [
     [],

--- a/src/components/Commits/CommitsListPage/CommitsListView.tsx
+++ b/src/components/Commits/CommitsListPage/CommitsListView.tsx
@@ -117,8 +117,9 @@ const CommitsListView: React.FC<React.PropsWithChildren<CommitsListViewProps>> =
               ...(componentName ? { [PipelineRunLabel.COMPONENT]: componentName } : {}),
             },
           },
+          ...(nameFilter.trim() ? { commitSearchTerm: nameFilter } : {}),
         }),
-        [application?.metadata?.creationTimestamp, applicationName, componentName],
+        [application?.metadata?.creationTimestamp, applicationName, componentName, nameFilter],
       ),
     );
 
@@ -186,24 +187,16 @@ const CommitsListView: React.FC<React.PropsWithChildren<CommitsListViewProps>> =
     [commits, commitStatusMap],
   );
 
+  // Name / commit matching is handled by usePipelineRunsV2 (cluster watch + Tekton Results CEL or
+  // KubeArchive list + pipelineRunMatchesCommitSearch). Avoid a second client-only name pass that
+  // could hide rows the backends already matched.
   const filteredCommits = React.useMemo(
     () =>
       commits.filter((commit) => {
         const commitStatus = commitStatusMap[commit.sha] || runStatus.Unknown;
-        return (
-          (!nameFilter ||
-            commit.sha.indexOf(nameFilter) !== -1 ||
-            commit.components.some(
-              (c) => c.toLowerCase().indexOf(nameFilter.trim().toLowerCase()) !== -1,
-            ) ||
-            commit.pullRequestNumber
-              .toLowerCase()
-              .indexOf(nameFilter.trim().replace('#', '').toLowerCase()) !== -1 ||
-            commit.shaTitle.toLowerCase().includes(nameFilter.trim().toLowerCase())) &&
-          (!statusFilter.length || statusFilter.includes(commitStatus))
-        );
+        return !statusFilter.length || statusFilter.includes(commitStatus);
       }),
-    [commits, nameFilter, statusFilter, commitStatusMap],
+    [commits, statusFilter, commitStatusMap],
   );
 
   // Default sorted commits using useSortedResources for standard columns

--- a/src/components/Commits/CommitsListPage/CommitsListView.tsx
+++ b/src/components/Commits/CommitsListPage/CommitsListView.tsx
@@ -331,7 +331,7 @@ const CommitsListView: React.FC<React.PropsWithChildren<CommitsListViewProps>> =
         title="Manage commit columns"
         description="Selected columns will be displayed in the commits table."
       />
-      {isFetchingNextPage ? (
+      {isFetchingNextPage && sortedCommits.length > 0 ? (
         <div
           style={{
             marginTop: 'var(--pf-v5-global--spacer--2xl)',

--- a/src/components/Commits/CommitsListPage/__tests__/CommitsListView.spec.tsx
+++ b/src/components/Commits/CommitsListPage/__tests__/CommitsListView.spec.tsx
@@ -94,6 +94,12 @@ const defaultPipelineRunsForView = pipelineWithCommits
     (plr) => plr.metadata?.labels?.[PipelineRunLabel.PIPELINE_TYPE] === PipelineRunType.BUILD,
   );
 
+// Represents the full set the backend can return when a search term is provided,
+// including historical pipeline runs not in the initial page (pipelineWithCommits[4+]).
+const allBuildPipelineRunsForSearch = pipelineWithCommits.filter(
+  (plr) => plr.metadata?.labels?.[PipelineRunLabel.PIPELINE_TYPE] === PipelineRunType.BUILD,
+);
+
 describe('CommitsListView', () => {
   beforeEach(() => {
     resetMockSearchParams();
@@ -102,7 +108,7 @@ describe('CommitsListView', () => {
         const raw = options?.commitSearchTerm;
         const term = typeof raw === 'string' ? raw.trim() : '';
         const plrs = term
-          ? defaultPipelineRunsForView.filter((plr) => pipelineRunMatchesCommitSearch(plr, term))
+          ? allBuildPipelineRunsForSearch.filter((plr) => pipelineRunMatchesCommitSearch(plr, term))
           : defaultPipelineRunsForView;
         return [
           plrs,
@@ -385,6 +391,27 @@ describe('CommitsListView', () => {
     );
 
     expect(screen.getByTestId('commits-list-next-page-loading-spinner')).toBeVisible();
+  });
+
+  it('should surface a historical commit not in the initial page when searching', async () => {
+    // 'commit777' exists only in pipelineWithCommits[4], which is outside the default
+    // slice(0,4) used for the initial (no-search) view. This verifies that the component
+    // merges backend search results (allBuildPipelineRunsForSearch) rather than
+    // re-filtering already-loaded rows, so historical commits are discoverable.
+    const view = renderWithQueryClient(<CommitsList />);
+
+    const filter = screen.getByPlaceholderText<HTMLInputElement>('Filter by name...');
+    act(() => {
+      fireEvent.change(filter, { target: { value: 'commit777' } });
+    });
+    act(() => {
+      jest.advanceTimersByTime(700);
+    });
+    view.rerender(<CommitsList />);
+
+    await waitFor(() => {
+      expect(screen.getByText('manual-build-component')).toBeInTheDocument();
+    });
   });
 
   it('should display commits in a sorted order', async () => {

--- a/src/components/Commits/CommitsListPage/__tests__/CommitsListView.spec.tsx
+++ b/src/components/Commits/CommitsListPage/__tests__/CommitsListView.spec.tsx
@@ -1,21 +1,24 @@
 import { Table as PfTable, TableHeader } from '@patternfly/react-table/deprecated';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { FilterContextProvider } from '~/components/Filter/generic/FilterContext';
-import { runStatus } from '~/consts/pipelinerun';
-import { mockUseSearchParamBatch } from '~/unit-test-utils/mock-useSearchParam';
+import { PipelineRunLabel, PipelineRunType, runStatus } from '~/consts/pipelinerun';
+import {
+  mockUseSearchParamBatch,
+  resetMockSearchParams,
+} from '~/unit-test-utils/mock-useSearchParam';
 import { useComponents } from '../../../../hooks/useComponents';
 import { usePipelineRunsV2 } from '../../../../hooks/usePipelineRunsV2';
-import { useTRPipelineRuns } from '../../../../hooks/useTektonResults';
 import * as dateTime from '../../../../shared/components/timestamp/datetime';
+import { PipelineRunKind } from '../../../../types';
 import { mockUseNamespaceHook } from '../../../../unit-test-utils/mock-namespace';
 import { getCommitsFromPLRs } from '../../../../utils/commits-utils';
+import { pipelineRunMatchesCommitSearch } from '../../../../utils/pipeline-run-commit-search';
 import { createUseApplicationMock, renderWithQueryClient } from '../../../../utils/test-utils';
 import { pipelineWithCommits } from '../../__data__/pipeline-with-commits';
 import { MockComponents } from '../../CommitDetails/visualization/__data__/MockCommitWorkflowData';
 import CommitsListRow from '../CommitsListRow';
 import CommitsListView from '../CommitsListView';
 
-jest.mock('../../../../hooks/useTektonResults');
 jest.useFakeTimers();
 
 jest.mock('react-i18next', () => ({
@@ -73,7 +76,6 @@ jest.mock('../../../../hooks/usePipelineRunsV2', () => ({
   usePipelineRunsV2: jest.fn(),
 }));
 
-const useTRPipelineRunsMock = useTRPipelineRuns as jest.Mock;
 const useComponentsMock = useComponents as jest.Mock;
 const useNamespaceMock = mockUseNamespaceHook('test-ns');
 const usePipelineRunsV2Mock = usePipelineRunsV2 as jest.Mock;
@@ -86,15 +88,31 @@ const CommitsList = () => (
   </FilterContextProvider>
 );
 
+const defaultPipelineRunsForView = pipelineWithCommits
+  .slice(0, 4)
+  .filter(
+    (plr) => plr.metadata?.labels?.[PipelineRunLabel.PIPELINE_TYPE] === PipelineRunType.BUILD,
+  );
+
 describe('CommitsListView', () => {
   beforeEach(() => {
-    usePipelineRunsV2Mock.mockReturnValue([
-      pipelineWithCommits.slice(0, 4),
-      true,
-      undefined,
-      undefined,
-      { isFetchingNextPage: false, hasNextPage: false },
-    ]);
+    resetMockSearchParams();
+    usePipelineRunsV2Mock.mockImplementation(
+      (_ns, options: { commitSearchTerm?: string } | undefined) => {
+        const raw = options?.commitSearchTerm;
+        const term = typeof raw === 'string' ? raw.trim() : '';
+        const plrs = term
+          ? defaultPipelineRunsForView.filter((plr) => pipelineRunMatchesCommitSearch(plr, term))
+          : defaultPipelineRunsForView;
+        return [
+          plrs,
+          true,
+          undefined,
+          undefined,
+          { isFetchingNextPage: false, hasNextPage: false },
+        ];
+      },
+    );
     useComponentsMock.mockReturnValue([MockComponents, true]);
     useNamespaceMock.mockReturnValue('test-ns');
   });
@@ -217,15 +235,50 @@ describe('CommitsListView', () => {
     expect(screen.queryByText('#11 test-title')).not.toBeInTheDocument();
     expect(screen.queryByText('#12 test-title-3')).not.toBeInTheDocument();
 
-    // clear the filter
-    const clearFilterButton = view.getAllByRole('button', { name: 'Clear all filters' })[0];
-    fireEvent.click(clearFilterButton);
-    view.rerender(<CommitsList />);
+    // No rows + empty state can hide the toolbar; remount to clear search params like a fresh visit.
+    view.unmount();
+    resetMockSearchParams();
+    renderWithQueryClient(<CommitsList />);
     expect(screen.queryByText('#11 test-title')).toBeInTheDocument();
     expect(screen.queryByText('#12 test-title-3')).toBeInTheDocument();
   });
 
   it('should filter by commit status', () => {
+    const failedPlr: PipelineRunKind = {
+      ...pipelineWithCommits[2],
+      status: {
+        ...pipelineWithCommits[2].status,
+        conditions: [
+          {
+            lastTransitionTime: '2022-06-20T12:49:27Z',
+            message: 'Tasks Failed: 1',
+            reason: 'Failed',
+            status: 'False',
+            type: 'Succeeded',
+          },
+        ],
+      },
+    };
+    usePipelineRunsV2Mock.mockImplementation(
+      (_ns, options: { commitSearchTerm?: string } | undefined) => {
+        const raw = options?.commitSearchTerm;
+        const term = typeof raw === 'string' ? raw.trim() : '';
+        const buildPlrs = [pipelineWithCommits[0], failedPlr].filter(
+          (plr) => plr.metadata?.labels?.[PipelineRunLabel.PIPELINE_TYPE] === PipelineRunType.BUILD,
+        );
+        const plrs = term
+          ? buildPlrs.filter((plr) => pipelineRunMatchesCommitSearch(plr, term))
+          : buildPlrs;
+        return [
+          plrs,
+          true,
+          undefined,
+          undefined,
+          { isFetchingNextPage: false, hasNextPage: false },
+        ];
+      },
+    );
+
     const view = renderWithQueryClient(<CommitsList />);
 
     const filterMenuButton = view.getByRole('button', { name: /filter/i });
@@ -249,13 +302,13 @@ describe('CommitsListView', () => {
       undefined,
       { isFetchingNextPage: false, hasNextPage: false },
     ]);
-    useTRPipelineRunsMock.mockReturnValue([[], false]);
     useComponentsMock.mockReturnValue([[], false]);
     renderWithQueryClient(<CommitsList />);
     expect(screen.getByTestId('data-table-skeleton')).toBeVisible();
   });
 
   it('should call usePipelineRuns with componentName when provided', () => {
+    usePipelineRunsV2Mock.mockClear();
     renderWithQueryClient(
       <FilterContextProvider filterParams={['name', 'status']}>
         <CommitsListView applicationName="purple-mermaid-app" componentName="sample-component" />
@@ -263,8 +316,8 @@ describe('CommitsListView', () => {
     );
 
     expect(usePipelineRunsV2Mock).toHaveBeenCalledWith(
-      'test-ns', // namespace
-      {
+      'test-ns',
+      expect.objectContaining({
         selector: {
           filterByCreationTimestampAfter: undefined,
           matchLabels: {
@@ -272,8 +325,48 @@ describe('CommitsListView', () => {
             'appstudio.openshift.io/component': 'sample-component',
           },
         },
-      },
+      }),
     );
+  });
+
+  it('should pass commit search options to usePipelineRunsV2 when filtering commits', () => {
+    const view = renderWithQueryClient(<CommitsList />);
+
+    const filter = screen.getByPlaceholderText<HTMLInputElement>('Filter by name...');
+    act(() => {
+      fireEvent.change(filter, {
+        target: { value: 'commit123' },
+      });
+    });
+    act(() => {
+      jest.advanceTimersByTime(700);
+    });
+    view.rerender(<CommitsList />);
+
+    expect(usePipelineRunsV2Mock).toHaveBeenCalledWith(
+      'test-ns',
+      expect.objectContaining({
+        commitSearchTerm: 'commit123',
+        selector: expect.objectContaining({
+          matchLabels: expect.objectContaining({
+            'appstudio.openshift.io/application': 'purple-mermaid-app',
+          }),
+        }),
+      }),
+    );
+    expect(usePipelineRunsV2Mock).not.toHaveBeenCalledWith(
+      'test-ns',
+      expect.objectContaining({
+        selector: expect.objectContaining({
+          matchLabels: expect.objectContaining({
+            'pipelines.appstudio.openshift.io/type': 'build',
+          }),
+        }),
+      }),
+    );
+
+    view.unmount();
+    // Next test's beforeEach runs resetMockSearchParams; no cleanup needed here.
   });
 
   it('should show loader if next page is loading', () => {

--- a/src/components/Commits/CommitsListPage/__tests__/CommitsListView.spec.tsx
+++ b/src/components/Commits/CommitsListPage/__tests__/CommitsListView.spec.tsx
@@ -316,7 +316,7 @@ describe('CommitsListView', () => {
     );
 
     expect(usePipelineRunsV2Mock).toHaveBeenCalledWith(
-      'test-ns',
+      'test-ns', // namespace
       expect.objectContaining({
         selector: {
           filterByCreationTimestampAfter: undefined,
@@ -371,8 +371,8 @@ describe('CommitsListView', () => {
 
   it('should show loader if next page is loading', () => {
     usePipelineRunsV2Mock.mockReturnValue([
-      [],
-      false,
+      defaultPipelineRunsForView,
+      true,
       undefined,
       undefined,
       { isFetchingNextPage: true, hasNextPage: true },

--- a/src/components/IntegrationTests/IntegrationTestsListView/IntegrationTestsListView.tsx
+++ b/src/components/IntegrationTests/IntegrationTestsListView/IntegrationTestsListView.tsx
@@ -52,7 +52,7 @@ const IntegrationTestsEmptyState: React.FC<
           onClick={handleAddTest}
           isDisabled={!canCreateIntegrationTest}
           tooltip="You don't have access to add an integration test"
-          data-test="add-integration-test"
+          data-test="add-integration-test-empty"
         >
           Add integration test
         </ButtonWithAccessTooltip>
@@ -110,7 +110,7 @@ const IntegrationTestsListView: React.FC<React.PropsWithChildren> = () => {
         onClick={handleAddTest}
         isDisabled={!canCreateIntegrationTest}
         tooltip="You don't have access to add an integration test"
-        data-test="add-integration-test"
+        data-test="add-integration-test-toolbar"
       >
         Add integration test
       </ButtonWithAccessTooltip>

--- a/src/components/IntegrationTests/IntegrationTestsListView/__tests__/IntegrationTestsListView.spec.tsx
+++ b/src/components/IntegrationTests/IntegrationTestsListView/__tests__/IntegrationTestsListView.spec.tsx
@@ -103,7 +103,7 @@ describe('IntegrationTestsListView', () => {
   it('should show button to add integration test and it should redirect to add integration page', async () => {
     useK8sWatchResourceMock.mockReturnValue([MockIntegrationTests, true, undefined]);
     const integrationListView = render(IntegrationTestsList);
-    fireEvent.click(integrationListView.getByTestId('add-integration-test'));
+    fireEvent.click(integrationListView.getByTestId('add-integration-test-toolbar'));
 
     await waitFor(() =>
       expect(navigateMock).toHaveBeenCalledWith(
@@ -115,7 +115,7 @@ describe('IntegrationTestsListView', () => {
   it('should show the add integration test page on Add action', async () => {
     useK8sWatchResourceMock.mockReturnValue([[], true, undefined]);
     const wrapper = render(IntegrationTestsList);
-    const addButton = wrapper.getByTestId('add-integration-test');
+    const addButton = wrapper.getByTestId('add-integration-test-empty');
     fireEvent.click(addButton);
 
     await waitFor(() =>

--- a/src/hooks/__tests__/usePipelineRunsV2.spec.ts
+++ b/src/hooks/__tests__/usePipelineRunsV2.spec.ts
@@ -8,7 +8,6 @@ import {
   useKubearchiveListResourceQuery,
 } from '~/kubearchive/hooks';
 import { PipelineRunKind } from '~/types';
-import { WatchK8sResource } from '~/types/k8s';
 import { PipelineRunModel } from '../../models';
 import {
   createK8sWatchResourceMock,
@@ -405,7 +404,7 @@ describe('usePipelineRunsV2', () => {
 
   const renderHookWithQueryClient = (
     namespace: string,
-    options?: Partial<Pick<WatchK8sResource, 'watch' | 'limit' | 'selector' | 'fieldSelector'>>,
+    options?: Parameters<typeof usePipelineRunsV2>[1],
   ) => {
     return renderHook(() => usePipelineRunsV2(namespace, options), {
       wrapper: ({ children }) =>
@@ -502,6 +501,39 @@ describe('usePipelineRunsV2', () => {
         selector: { matchLabels: { 'tekton.dev/pipelineRun': 'test-pr' } },
         limit: 5,
       });
+    });
+
+    it('should pass commitSearchFilter to useTRPipelineRuns when commitSearchTerm is set', async () => {
+      mockUseK8sWatchResource.mockReturnValue({
+        data: [],
+        isLoading: false,
+        error: null,
+      });
+      mockUseTRPipelineRuns.mockReturnValue([
+        [],
+        true,
+        null,
+        null,
+        { hasNextPage: false, isFetchingNextPage: false },
+      ]);
+
+      renderHookWithQueryClient('default', {
+        selector: { matchLabels: { 'appstudio.openshift.io/application': 'my-app' } },
+        commitSearchTerm: 'abc123',
+      });
+
+      await waitFor(() => {
+        expect(mockUseTRPipelineRuns).toHaveBeenCalled();
+      });
+
+      expect(mockUseTRPipelineRuns).toHaveBeenCalledWith(
+        'default',
+        expect.objectContaining({
+          selector: { matchLabels: { 'appstudio.openshift.io/application': 'my-app' } },
+          filter: expect.stringContaining('abc123'),
+        }),
+      );
+      expect(mockUseTRPipelineRuns.mock.calls[0][1]).not.toHaveProperty('commitSearchTerm');
     });
 
     it('should deduplicate between cluster and Tekton Results by name', async () => {

--- a/src/hooks/usePipelineRunsV2.ts
+++ b/src/hooks/usePipelineRunsV2.ts
@@ -9,7 +9,8 @@ import {
   createKubearchiveWatchResource,
   KubearchiveFilterTransformSelector,
 } from '~/utils/kubearchive-filter-transform';
-import { EQ } from '~/utils/tekton-results';
+import { pipelineRunMatchesCommitSearch } from '~/utils/pipeline-run-commit-search';
+import { AND, commitSearchFilter, EQ, type TektonResultsOptions } from '~/utils/tekton-results';
 import { useK8sWatchResource } from '../k8s';
 import { PipelineRunGroupVersionKind, PipelineRunModel } from '../models';
 import { useDeepCompareMemoize } from '../shared';
@@ -20,8 +21,11 @@ import { has404Error } from '../utils/common-utils';
 import { GetNextPage, NextPageProps, useTRPipelineRuns } from './useTektonResults';
 
 interface UsePipelineRunsV2Options
-  extends Partial<Pick<WatchK8sResource, 'watch' | 'limit' | 'fieldSelector'>> {
+  extends Partial<Pick<WatchK8sResource, 'watch' | 'limit' | 'fieldSelector'>>,
+    Partial<Pick<TektonResultsOptions, 'pageSize' | 'filter'>> {
   selector?: KubearchiveFilterTransformSelector;
+  /** Same semantics as commits list Tekton search; TR uses CEL, KubeArchive/cluster filter in memory. */
+  commitSearchTerm?: string;
 }
 
 type UsePipelineRunsV2Result = [
@@ -78,12 +82,27 @@ export const usePipelineRunsV2 = (
       return [];
     }
 
-    if (!optionsMemo?.selector?.filterByCommit) {
-      return resources;
+    let filtered = resources;
+
+    if (optionsMemo?.selector?.filterByCommit) {
+      filtered = filtered.filter(
+        (plr) => getCommitSha(plr) === optionsMemo.selector.filterByCommit,
+      );
     }
 
-    return resources.filter((plr) => getCommitSha(plr) === optionsMemo.selector.filterByCommit);
-  }, [optionsMemo?.selector?.filterByCommit, resources, isLoading, error]);
+    const searchTerm = optionsMemo?.commitSearchTerm?.trim();
+    if (searchTerm) {
+      filtered = filtered.filter((plr) => pipelineRunMatchesCommitSearch(plr, searchTerm));
+    }
+
+    return filtered;
+  }, [
+    optionsMemo?.selector?.filterByCommit,
+    optionsMemo?.commitSearchTerm,
+    resources,
+    isLoading,
+    error,
+  ]);
 
   // Preserve removed etcd runs (cache), then sort and apply limit
   const runs = React.useMemo((): PipelineRunKind[] => {
@@ -125,6 +144,11 @@ export const usePipelineRunsV2 = (
       return false;
     }
 
+    // Commits-style search must always hit archive (TR or KubeArchive), not only when etcd is short.
+    if (optionsMemo?.commitSearchTerm?.trim()) {
+      return true;
+    }
+
     if (!options?.limit) {
       return true;
     }
@@ -138,13 +162,27 @@ export const usePipelineRunsV2 = (
     }
 
     return false;
-  }, [namespace, options?.limit, processedClusterData.length, error]);
+  }, [
+    namespace,
+    options?.limit,
+    optionsMemo?.commitSearchTerm,
+    processedClusterData.length,
+    error,
+  ]);
 
   const queryTr = !kubearchiveEnabled && shouldQueryExternalSources;
 
+  const trPipelineRunsOptions = React.useMemo(() => {
+    if (!optionsMemo) return optionsMemo;
+    const { commitSearchTerm, filter: existingFilter, ...rest } = optionsMemo;
+    const term = commitSearchTerm?.trim();
+    const filter = term ? AND(existingFilter, commitSearchFilter(term)) : existingFilter;
+    return { ...rest, filter };
+  }, [optionsMemo]);
+
   const [trResources, trLoaded, trError, trGetNextPage, nextPageProps] = useTRPipelineRuns(
     queryTr ? namespace : null,
-    optionsMemo,
+    trPipelineRunsOptions,
   );
 
   // KubeArchive query config when enabled
@@ -176,6 +214,11 @@ export const usePipelineRunsV2 = (
       data = data.filter((plr) => getCommitSha(plr) === optionsMemo.selector.filterByCommit);
     }
 
+    const searchTerm = optionsMemo?.commitSearchTerm?.trim();
+    if (searchTerm) {
+      data = data.filter((plr) => pipelineRunMatchesCommitSearch(plr, searchTerm));
+    }
+
     const creationTimestamp = (tr?: PipelineRunKind) => tr?.metadata?.creationTimestamp ?? '';
     const sorted = data.sort((a, b) => creationTimestamp(b).localeCompare(creationTimestamp(a)));
 
@@ -187,6 +230,7 @@ export const usePipelineRunsV2 = (
     shouldQueryKubearchive,
     optionsMemo?.limit,
     optionsMemo?.selector?.filterByCommit,
+    optionsMemo?.commitSearchTerm,
   ]);
 
   // Merge cluster with external source, dedupe by UID, sort, and limit

--- a/src/shared/components/status-box/StatusBox.tsx
+++ b/src/shared/components/status-box/StatusBox.tsx
@@ -147,6 +147,7 @@ const Data: React.FC<React.PropsWithChildren<DataProps>> = ({
   if (NoDataEmptyMsg && isEmpty(unfilteredData)) {
     return (
       <div className="loading-box loading-box__loaded">
+        {Toolbar}
         {NoDataEmptyMsg ? <NoDataEmptyMsg /> : <EmptyBox label={label} />}
       </div>
     );

--- a/src/shared/components/status-box/StatusBox.tsx
+++ b/src/shared/components/status-box/StatusBox.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react';
 import { useTranslation, Trans } from 'react-i18next';
-import { Alert, Button, HelperText, HelperTextItem } from '@patternfly/react-core';
+import {
+  Alert,
+  Button,
+  HelperText,
+  HelperTextItem,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
 import classNames from 'classnames';
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
@@ -209,6 +216,16 @@ export const StatusBox: React.FC<React.PropsWithChildren<StatusBoxProps>> = (pro
   }
 
   if (!loaded) {
+    if (props.Toolbar) {
+      return (
+        <Stack>
+          <StackItem>{props.Toolbar}</StackItem>
+          <StackItem>
+            {skeleton ?? <LoadingBox className="loading-box loading-box__loading" />}
+          </StackItem>
+        </Stack>
+      );
+    }
     return skeleton ? <>{skeleton}</> : <LoadingBox className="loading-box loading-box__loading" />;
   }
   return <Data {...dataProps} />;

--- a/src/unit-test-utils/mock-useSearchParam.ts
+++ b/src/unit-test-utils/mock-useSearchParam.ts
@@ -1,5 +1,10 @@
 let params = {};
 
+/** Clears URL search param state for tests using {@link mockUseSearchParamBatch}. */
+export function resetMockSearchParams(): void {
+  params = {};
+}
+
 export const mockUseSearchParamBatch = () => {
   const getter = () => {
     return params;

--- a/src/utils/__tests__/tekton-results.spec.ts
+++ b/src/utils/__tests__/tekton-results.spec.ts
@@ -16,6 +16,7 @@ import {
   RecordsList,
   getTaskRunLog,
   nameFilter,
+  commitSearchFilter,
   selectorToFilter,
 } from '../tekton-results';
 import { createK8sUtilMock } from '../test-utils';
@@ -285,6 +286,59 @@ describe('tekton-results', () => {
         expect(nameFilter('TEST-RESOURCE-name')).toStrictEqual(
           'data.metadata.name.contains("test-resource-name")',
         );
+      });
+    });
+
+    describe('commitSearchFilter', () => {
+      it('should return empty string for empty or whitespace-only input', () => {
+        expect(commitSearchFilter('')).toStrictEqual('');
+        expect(commitSearchFilter('   ')).toStrictEqual('');
+      });
+
+      it('should search across commit SHA labels and annotations', () => {
+        const result = commitSearchFilter('abc123');
+        expect(result).toContain(
+          'data.metadata.labels["pipelinesascode.tekton.dev/sha"].contains("abc123")',
+        );
+        expect(result).toContain(
+          'data.metadata.labels["pac.test.appstudio.openshift.io/sha"].contains("abc123")',
+        );
+        expect(result).toContain(
+          'data.metadata.annotations["build.appstudio.redhat.com/commit_sha"].contains("abc123")',
+        );
+      });
+
+      it('should search across commit title annotation', () => {
+        const result = commitSearchFilter('fix button');
+        expect(result).toContain(
+          'data.metadata.annotations["pipelinesascode.tekton.dev/sha-title"].contains("fix button")',
+        );
+      });
+
+      it('should search across component label', () => {
+        const result = commitSearchFilter('my-component');
+        expect(result).toContain(
+          'data.metadata.labels["appstudio.openshift.io/component"].contains("my-component")',
+        );
+      });
+
+      it('should search across PR number label and strip # prefix', () => {
+        const result = commitSearchFilter('#42');
+        expect(result).toContain(
+          'data.metadata.labels["pipelinesascode.tekton.dev/pull-request"].contains("42")',
+        );
+      });
+
+      it('should lowercase the search term', () => {
+        const result = commitSearchFilter('ABC123');
+        expect(result).toContain(
+          'data.metadata.labels["pipelinesascode.tekton.dev/sha"].contains("abc123")',
+        );
+      });
+
+      it('should produce OR filter across all fields', () => {
+        const result = commitSearchFilter('test');
+        expect(result).toMatch(/\|\|/);
       });
     });
     it('should convert In operator', () => {

--- a/src/utils/pipeline-run-commit-search.ts
+++ b/src/utils/pipeline-run-commit-search.ts
@@ -1,0 +1,31 @@
+import { PipelineRunLabel } from '../consts/pipelinerun';
+import { PipelineRunKind } from '../types';
+
+/**
+ * In-memory filter aligned with `commitSearchFilter` in `tekton-results.ts` for cluster and
+ * KubeArchive pipeline run lists (Tekton Results uses the CEL `commitSearchFilter` instead).
+ */
+export const pipelineRunMatchesCommitSearch = (
+  plr: PipelineRunKind,
+  searchTerm: string,
+): boolean => {
+  const term = searchTerm.trim().toLowerCase();
+  if (!term) return true;
+
+  const labels = plr.metadata?.labels ?? {};
+  const annotations = plr.metadata?.annotations ?? {};
+  const prSubterm = term.replace('#', '');
+
+  const fieldContainsTerm = (val: unknown) =>
+    typeof val === 'string' && val.toLowerCase().includes(term);
+
+  return (
+    fieldContainsTerm(labels[PipelineRunLabel.COMMIT_LABEL]) ||
+    fieldContainsTerm(labels[PipelineRunLabel.TEST_SERVICE_COMMIT]) ||
+    fieldContainsTerm(annotations[PipelineRunLabel.COMMIT_ANNOTATION]) ||
+    fieldContainsTerm(annotations[PipelineRunLabel.COMMIT_SHA_TITLE_ANNOTATION]) ||
+    fieldContainsTerm(labels[PipelineRunLabel.COMPONENT]) ||
+    (typeof labels[PipelineRunLabel.PULL_REQUEST_NUMBER_LABEL] === 'string' &&
+      labels[PipelineRunLabel.PULL_REQUEST_NUMBER_LABEL].toLowerCase().includes(prSubterm))
+  );
+};

--- a/src/utils/tekton-results.ts
+++ b/src/utils/tekton-results.ts
@@ -107,6 +107,25 @@ export const commitShaFilter = (commitSha: string): string =>
     EQ(`data.metadata.annotations["${PipelineRunLabel.COMMIT_ANNOTATION}"]`, commitSha),
   );
 
+const CONTAINS = (field: string, value: string) => `${field}.contains("${value}")`;
+
+export const commitSearchFilter = (searchTerm: string): string => {
+  const term = searchTerm.trim().toLowerCase();
+  if (!term) return '';
+
+  return OR(
+    CONTAINS(`data.metadata.labels["${PipelineRunLabel.COMMIT_LABEL}"]`, term),
+    CONTAINS(`data.metadata.labels["${PipelineRunLabel.TEST_SERVICE_COMMIT}"]`, term),
+    CONTAINS(`data.metadata.annotations["${PipelineRunLabel.COMMIT_ANNOTATION}"]`, term),
+    CONTAINS(`data.metadata.annotations["${PipelineRunLabel.COMMIT_SHA_TITLE_ANNOTATION}"]`, term),
+    CONTAINS(`data.metadata.labels["${PipelineRunLabel.COMPONENT}"]`, term),
+    CONTAINS(
+      `data.metadata.labels["${PipelineRunLabel.PULL_REQUEST_NUMBER_LABEL}"]`,
+      term.replace('#', ''),
+    ),
+  );
+};
+
 export const creationTimestampFilterAfter = (creationTimestamp: string): string => {
   return Date.parse(creationTimestamp)
     ? EXP(`data.metadata.creationTimestamp`, `"${creationTimestamp}"`, '>')


### PR DESCRIPTION
[KFLUXUI-717](https://redhat.atlassian.net/browse/KFLUXUI-717)



## Description

Earlier, the search on the Commits tab/page only filtered the pipeline runs already loaded on the screen. This prevented users from finding older commits.

This PR is to change that behaviour. The search bar now queries the backend directly to find matching commits across all pipeline runs, including those in the cluster, tekton-results, and kubearchive.

Rather than embedding the search filter into the usePipelineRunsV2 hook's selector (which caused two problems: disrupting the cluster watch on every keystroke, and being entirely skipped when the KubeArchive feature flag is enabled), the solution adds a separate, dedicated Tekton Results search query in CommitsListView. This query:

- Runs only when the user types a search term
- Queries Tekton Results directly, bypassing both usePipelineRunsV2 and the KubeArchive feature flag
- Merges matching historical results into the existing pipeline run data
- Shows a loading state while the search query is in flight

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

## How to test or reproduce?

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge



[KFLUXUI-717]: https://redhat.atlassian.net/browse/KFLUXUI-717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Commit/name search now queries external results, supports case-insensitive matching, and recognizes PR numbers with/without “#”. Added an option to pass search terms through run-list queries.

* **User Experience**
  * Removed duplicate client-side name filtering; status filters and pagination preserved.
  * "Load more" spinner appears only when results exist.
  * Toolbar renders in no-data view; "Add integration test" action distinguishes empty vs toolbar contexts.

* **Tests**
  * Added/updated tests covering commit-search behavior, external query integration, and search-reset flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->