### PR TITLE
KFLUXUI-1153 - Fix: "PLR Graph displays task failures during archival transition"

### DIFF
--- a/src/hooks/useTaskRunsV2.ts
+++ b/src/hooks/useTaskRunsV2.ts
@@ -248,7 +248,10 @@ export const useTaskRunsForPipelineRuns = (
       selector,
       watch,
     },
-    { staleTime: Infinity, enabled: !!(namespace && pipelineRunName) },
+    {
+      enabled: !!(namespace && pipelineRunName),
+      staleTime: (query) => (query?.state?.data?.pages?.flat()?.length ? Infinity : 0),
+    },
   );
 
   const sortedTaskRuns = React.useMemo(() => sortTaskRunsByTime(taskRuns), [taskRuns]);


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->

Fixes https://redhat.atlassian.net/browse/KFLUXUI-1153

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In this PR we're fixing the PLR deails visualization showing every task as Failed (red) when a run moves from "in-cluster / etcd" to archived (Tekton Results / KubeArchive) while the page stays open.

After some investigation I noticed the following problem: 

- after the PLR is fetched/loaded from the archive, taskRuns could stay empty
- the `PipelineRunVisualization` component builds task status from TaskRuns; when the list is empty, appendStatus falls back to the overall PipelineRun status for every task, so a failed PLR makes all tasks look failed.
- root cause: `useTaskRunsForPipelineRuns` passed `staleTime: Infinity` into `useTaskRunsV2` for the Tekton Results / KubeArchive list queries
  - that empty result was cached as never stale, so when `TaskRuns` disappeared from the cluster watch, we did not refetch the archive side and the merged list stayed empty

~~So, I tried the following fix: removed `staleTime: Infinity` so archive `TaskRun` lists can become stale and refetch, allowing `TaskRuns` to populate after archive transition~~

updated fix: replace static `staleTime: Infinity` with a function -> non-empty results are cached forever (task runs don't change once completed), empty results expire immediately so they get refetched after the archive transition


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before (kubearchive call happens at 00:39):

https://github.com/user-attachments/assets/ff0e24e8-cbfa-4fcd-af19-4a4c4b084c08

After (kubearchive call happens at 00:39):

https://github.com/user-attachments/assets/12ac015d-9408-4715-8223-9c0b6ea86775

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

- trigger a new PipelineRun (preferably try to make one of its TaskRuns to fail)
- stay in the PLR details page
- wait until the archival happens
- with this PR, the TaskRuns will be refetched and the `PipelineRunVisualization` will show the correct info
- :coffee:

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Refactor**
  * Improved caching behavior for task-run queries: cache lifetime is now conditional based on whether previously fetched data exists, reducing stale data and improving responsiveness when navigating between pipelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->