### PR TITLE
feat(KFLUXUI-1130): improve scroll accuracy and code organization

### DIFF
--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
@@ -271,6 +271,7 @@ const LogViewer: React.FC<Props> = ({
           <div ref={containerRef} className="log-viewer__content">
             {viewerHeight && (
               <VirtualizedLogViewer
+                key={taskRun?.metadata?.uid || 'default'}
                 data={processedData}
                 height={viewerHeight}
                 scrollToRow={scrolledRow}

--- a/src/shared/components/virtualized-log-viewer/VirtualizedLogContent.tsx
+++ b/src/shared/components/virtualized-log-viewer/VirtualizedLogContent.tsx
@@ -8,6 +8,13 @@ import { useResizeObserverFix } from './useResizeObserverFix';
 import { useSearchRegex } from './useSearchRegex';
 import { useTokenization } from './useTokenization';
 import { useVirtualizedScroll } from './useVirtualizedScroll';
+import {
+  VIRTUALIZATION_CONFIG,
+  getOverscanCount,
+  getSafetyMargin,
+  measureAverageCharWidth,
+  calculateCharsPerLine,
+} from './virtualization-utils';
 
 import './VirtualizedLogContent.scss';
 
@@ -35,7 +42,10 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
   currentSearchMatch,
 }) => {
   const parentRef = React.useRef<HTMLDivElement>(null);
-  const [itemSize, setItemSize] = React.useState(20);
+  const [itemSize, setItemSize] = React.useState(VIRTUALIZATION_CONFIG.FALLBACK_LINE_HEIGHT);
+  // Fallback values for when DOM measurement is unavailable (SSR, Canvas API failure, etc.)
+  const avgCharWidthRef = React.useRef(VIRTUALIZATION_CONFIG.FALLBACK_CHAR_WIDTH);
+  const charsPerLineRef = React.useRef(VIRTUALIZATION_CONFIG.FALLBACK_CHARS_PER_LINE);
 
   // Split data into lines
   const lines = React.useMemo(() => data.split('\n'), [data]);
@@ -65,12 +75,59 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
     }
   }, []);
 
+  // Measure average character width once on mount
+  // Uses Canvas API to get accurate font metrics for height estimation
+  React.useEffect(() => {
+    if (!parentRef.current) return;
+
+    const container = parentRef.current;
+
+    // Use RAF to ensure DOM elements are fully rendered
+    const rafId = requestAnimationFrame(() => {
+      const style = getComputedStyle(container);
+      const font = style.font || `${style.fontSize} ${style.fontFamily}`;
+
+      // Measure average character width
+      avgCharWidthRef.current = measureAverageCharWidth(font);
+
+      // Calculate how many characters fit per line
+      charsPerLineRef.current = calculateCharsPerLine(container, avgCharWidthRef.current);
+    });
+
+    return () => cancelAnimationFrame(rafId);
+  }, []);
+
+  // Conservative height estimation function
+  // Uses text length to estimate wrapped lines, with safety margin
+  // This is called by virtualizer for each row to estimate its height before rendering
+  const estimateRowHeight = React.useCallback(
+    (index: number): number => {
+      if (itemSize === 0) return VIRTUALIZATION_CONFIG.FALLBACK_LINE_HEIGHT;
+
+      const text = lines[index] || '';
+
+      // Use dynamically calculated charsPerLine based on actual font metrics
+      const charsPerLine = charsPerLineRef.current;
+      const estimatedLines = Math.max(1, Math.ceil(text.length / charsPerLine));
+
+      // Apply dynamic safety margin based on log size
+      const safetyMultiplier = getSafetyMargin(lines.length);
+
+      return Math.ceil(itemSize * estimatedLines * safetyMultiplier);
+    },
+    [itemSize, lines],
+  );
+
+  // Calculate overscan based on log size
+  // Larger overscan = more items pre-rendered = more accurate measurements
+  const overscanCount = React.useMemo(() => getOverscanCount(lines.length), [lines.length]);
+
   // Initialize virtualizer
   const virtualizer = useVirtualizer<HTMLDivElement, Element>({
     count: lines.length,
     getScrollElement: () => parentRef.current,
-    estimateSize: () => itemSize,
-    overscan: 10,
+    estimateSize: estimateRowHeight,
+    overscan: overscanCount,
   });
 
   // Handle scroll behavior (direction, programmatic scroll, scrollToRow)

--- a/src/shared/components/virtualized-log-viewer/__tests__/prism-log-language.spec.ts
+++ b/src/shared/components/virtualized-log-viewer/__tests__/prism-log-language.spec.ts
@@ -53,6 +53,29 @@ describe('Prism Log Language', () => {
       expect(timeToken).toBeDefined();
       expect(timeToken).toHaveProperty('content', '100ms');
     });
+    it('should tokenize relative time with "d" (days) unit', () => {
+      const tokens = Prism.tokenize('uptime: 2d', Prism.languages.log);
+
+      const timeToken = tokens.find((t) => typeof t !== 'string' && t.type === 'time');
+      expect(timeToken).toBeDefined();
+      expect(timeToken).toHaveProperty('content', '2d');
+    });
+
+    it('should tokenize composite relative time (e.g., 1h30m5s)', () => {
+      const tokens = Prism.tokenize('duration 1h30m5s', Prism.languages.log);
+
+      const timeToken = tokens.find((t) => typeof t !== 'string' && t.type === 'time');
+      expect(timeToken).toBeDefined();
+      expect(timeToken).toHaveProperty('content', '1h30m5s');
+    });
+
+    it('should tokenize composite time with decimals and spaces', () => {
+      const tokens = Prism.tokenize('delay 1.5s 200ms', Prism.languages.log);
+
+      const timeToken = tokens.find((t) => typeof t !== 'string' && t.type === 'time');
+      expect(timeToken).toBeDefined();
+      expect(timeToken).toHaveProperty('content', '1.5s 200ms');
+    });
   });
 
   describe('Log Levels', () => {

--- a/src/shared/components/virtualized-log-viewer/__tests__/virtualization-utils.spec.ts
+++ b/src/shared/components/virtualized-log-viewer/__tests__/virtualization-utils.spec.ts
@@ -1,0 +1,121 @@
+import {
+  VIRTUALIZATION_CONFIG,
+  getOverscanCount,
+  getSafetyMargin,
+  measureAverageCharWidth,
+  calculateCharsPerLine,
+} from '../virtualization-utils';
+
+describe('virtualization-utils', () => {
+  describe('VIRTUALIZATION_CONFIG', () => {
+    it('should have correct default values', () => {
+      expect(VIRTUALIZATION_CONFIG.FALLBACK_CHAR_WIDTH).toBe(8);
+      expect(VIRTUALIZATION_CONFIG.DEFAULT_OVERSCAN).toBe(50);
+    });
+  });
+
+  describe('getOverscanCount', () => {
+    it('should return lineCount for tiny logs', () => {
+      expect(getOverscanCount(50)).toBe(50);
+    });
+
+    it('should return DEFAULT_OVERSCAN for large logs', () => {
+      expect(getOverscanCount(500)).toBe(VIRTUALIZATION_CONFIG.DEFAULT_OVERSCAN);
+    });
+  });
+
+  describe('getSafetyMargin', () => {
+    it('should switch margin based on threshold', () => {
+      const threshold = VIRTUALIZATION_CONFIG.LARGE_LOG_THRESHOLD;
+      expect(getSafetyMargin(threshold)).toBe(VIRTUALIZATION_CONFIG.SAFETY_MARGIN_DEFAULT);
+      expect(getSafetyMargin(threshold + 1)).toBe(VIRTUALIZATION_CONFIG.SAFETY_MARGIN_LARGE);
+    });
+  });
+
+  describe('measureAverageCharWidth', () => {
+    let mockContext: Partial<CanvasRenderingContext2D>;
+
+    beforeEach(() => {
+      mockContext = {
+        font: '',
+        measureText: jest.fn().mockReturnValue({ width: 620 } as TextMetrics),
+      };
+
+      // Fixes unbound-method and unsafe-argument errors
+      jest
+        .spyOn(HTMLCanvasElement.prototype, 'getContext')
+        .mockReturnValue(mockContext as CanvasRenderingContext2D);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should measure average character width using Canvas API', () => {
+      const result = measureAverageCharWidth('12px Monaco');
+      expect(mockContext.font).toBe('12px Monaco');
+      expect(result).toBe(10);
+    });
+
+    it('should return fallback if getContext is not supported', () => {
+      jest.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
+      const result = measureAverageCharWidth('12px Monaco');
+      expect(result).toBe(VIRTUALIZATION_CONFIG.FALLBACK_CHAR_WIDTH);
+    });
+  });
+
+  describe('calculateCharsPerLine', () => {
+    let mockContainer: HTMLDivElement;
+    let mockGutter: HTMLDivElement;
+    let mockContent: HTMLDivElement;
+
+    const setWidth = (el: HTMLElement, prop: 'clientWidth' | 'offsetWidth', val: number): void => {
+      Object.defineProperty(el, prop, { configurable: true, value: val });
+    };
+
+    beforeEach(() => {
+      mockContainer = document.createElement('div');
+      mockGutter = document.createElement('div');
+      mockGutter.className = 'line-number__gutter';
+      mockContent = document.createElement('div');
+      mockContent.className = 'log-content__content-column';
+
+      mockContainer.appendChild(mockGutter);
+      mockContainer.appendChild(mockContent);
+
+      setWidth(mockContainer, 'clientWidth', 1000);
+      setWidth(mockGutter, 'offsetWidth', 60);
+
+      // Explicitly type the selector to avoid unsafe-argument errors
+      jest
+        .spyOn(mockContainer, 'querySelector')
+        .mockImplementation((selector: string): HTMLElement | null => {
+          if (selector === '.line-number__gutter') return mockGutter;
+          if (selector === '.log-content__content-column') return mockContent;
+          return null;
+        });
+
+      jest.spyOn(window, 'getComputedStyle').mockImplementation((el: Element) => {
+        if (el === mockContent) {
+          return { paddingLeft: '10px', paddingRight: '10px' } as CSSStyleDeclaration;
+        }
+        return {} as CSSStyleDeclaration;
+      });
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should calculate chars correctly (1000 - 60 - 20) / 8 = 115', () => {
+      const result = calculateCharsPerLine(mockContainer, 8);
+      expect(result).toBe(115);
+    });
+
+    it('should return fallback if calculation results in 0 or less', () => {
+      setWidth(mockContainer, 'clientWidth', 10);
+      const result = calculateCharsPerLine(mockContainer, 8);
+      expect(result).toBe(VIRTUALIZATION_CONFIG.FALLBACK_CHARS_PER_LINE);
+    });
+  });
+});

--- a/src/shared/components/virtualized-log-viewer/refractor-log.ts
+++ b/src/shared/components/virtualized-log-viewer/refractor-log.ts
@@ -212,7 +212,7 @@ export default function registerLogSyntax(PrismInstance: typeof Prism) {
 
     time: {
       pattern:
-        /\b\d{1,2}:\d{1,2}:\d{1,2}(?:[.,:]\d+)?(?:\s?[+-]\d{2}:?\d{2}|Z)?\b|\b\d+(?:\.\d+)?\s?(?:sec|ms|[smh])\b/i,
+        /\b\d{1,2}:\d{1,2}:\d{1,2}(?:[.,:]\d+)?(?:\s?[+-]\d{2}:?\d{2}|Z)?\b|\b(?:\d+(?:\.\d+)?(?:sec|ms|[smhd])\s?)+\b/i,
       alias: 'number',
     },
 

--- a/src/shared/components/virtualized-log-viewer/virtualization-utils.ts
+++ b/src/shared/components/virtualized-log-viewer/virtualization-utils.ts
@@ -1,0 +1,110 @@
+/**
+ * Configuration constants for virtualization behavior
+ */
+export const VIRTUALIZATION_CONFIG = {
+  // Fallback values when measurement or DOM access fails
+  FALLBACK_CHAR_WIDTH: 8, // Typical for monospace fonts (~8px)
+  FALLBACK_CHARS_PER_LINE: 70, // Assumes ~600px container width
+  FALLBACK_LINE_HEIGHT: 20, // Default single line height
+
+  // Height estimation safety margins
+  SAFETY_MARGIN_DEFAULT: 1.4, // 40% margin for logs ≤ 10k lines
+  SAFETY_MARGIN_LARGE: 3.0, // 200% margin for logs > 10k lines (handles heavy wrapping)
+  LARGE_LOG_THRESHOLD: 10000, // Threshold for large log detection
+
+  // Overscan (buffer) configuration by log size
+  TINY_LOG_LENGTH: 100, // Threshold for tiny logs (render all)
+  DEFAULT_OVERSCAN: 50, // Default buffer for non-tiny logs
+} as Record<string, number>;
+
+// Cache canvas instance to avoid repetitive DOM pressure and memory overhead
+let sharedCanvas: HTMLCanvasElement | null = null;
+
+/**
+ * Calculate appropriate overscan count based on log size.
+ * Larger overscan provides better scroll accuracy and prevents flickering.
+ */
+export function getOverscanCount(lineCount: number): number {
+  const safeLineCount = Math.max(0, lineCount);
+  if (safeLineCount < VIRTUALIZATION_CONFIG.TINY_LOG_LENGTH) {
+    return safeLineCount;
+  }
+  return VIRTUALIZATION_CONFIG.DEFAULT_OVERSCAN;
+}
+
+/**
+ * Get safety margin multiplier based on log size.
+ * Larger logs require more margin due to accumulated estimation errors from wrapping.
+ */
+export function getSafetyMargin(lineCount: number): number {
+  return lineCount > VIRTUALIZATION_CONFIG.LARGE_LOG_THRESHOLD
+    ? VIRTUALIZATION_CONFIG.SAFETY_MARGIN_LARGE
+    : VIRTUALIZATION_CONFIG.SAFETY_MARGIN_DEFAULT;
+}
+
+/**
+ * Measure average character width using the Canvas API.
+ * @param font - CSS font string (e.g., "12px Monaco")
+ * @returns Average character width in pixels
+ */
+export function measureAverageCharWidth(font: string): number {
+  try {
+    if (!sharedCanvas) {
+      sharedCanvas = document.createElement('canvas');
+    }
+    const context = sharedCanvas.getContext('2d');
+
+    if (!context) {
+      return VIRTUALIZATION_CONFIG.FALLBACK_CHAR_WIDTH;
+    }
+
+    context.font = font;
+
+    // Use a diverse sample string to improve measurement accuracy
+    const sampleText = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    const sampleWidth = context.measureText(sampleText).width;
+
+    return sampleWidth > 0
+      ? sampleWidth / sampleText.length
+      : VIRTUALIZATION_CONFIG.FALLBACK_CHAR_WIDTH;
+  } catch (error) {
+    // Catch potential DOM exceptions (e.g., canvas disabled in specific environments)
+    return VIRTUALIZATION_CONFIG.FALLBACK_CHAR_WIDTH;
+  }
+}
+
+/**
+ * Calculate how many characters fit per line in the content area.
+ * @param container - The scroll container element
+ * @param avgCharWidth - Average character width in pixels
+ * @returns Number of characters that fit per line (minimum 1)
+ */
+export function calculateCharsPerLine(container: HTMLElement, avgCharWidth: number): number {
+  if (!container) return VIRTUALIZATION_CONFIG.FALLBACK_CHARS_PER_LINE;
+
+  // 1. Calculate gutter (line numbers) width
+  let gutterWidth = 0;
+  const gutterElement = container.querySelector('.line-number__gutter');
+  if (gutterElement instanceof HTMLElement) {
+    gutterWidth = gutterElement.offsetWidth;
+  }
+
+  // 2. Determine base available width
+  let contentWidth = container.clientWidth - gutterWidth;
+
+  // 3. Subtract horizontal padding from the content column
+  const contentColumn = container.querySelector('.log-content__content-column');
+  if (contentColumn instanceof HTMLElement) {
+    const contentStyle = window.getComputedStyle(contentColumn);
+    const paddingLeft = parseFloat(contentStyle.paddingLeft) || 0;
+    const paddingRight = parseFloat(contentStyle.paddingRight) || 0;
+    contentWidth -= paddingLeft + paddingRight;
+  }
+
+  // 4. Calculate final count with safety fallback
+  const safeCharWidth = avgCharWidth > 0 ? avgCharWidth : VIRTUALIZATION_CONFIG.FALLBACK_CHAR_WIDTH;
+  const charsPerLine = Math.floor(Math.max(0, contentWidth) / safeCharWidth);
+
+  // Return calculated value or fallback, ensuring it is at least 1 to avoid division by zero later
+  return charsPerLine > 0 ? charsPerLine : VIRTUALIZATION_CONFIG.FALLBACK_CHARS_PER_LINE;
+}


### PR DESCRIPTION
## Fixes 
https://redhat.atlassian.net/browse/KFLUXUI-1130


## Description
PROBLEM:
- Chrome scrollbar dragging cannot reach bottom in one continuous motion (requires release and re-grab) for logs with 100+ lines
- Root cause: estimated scrollHeight too small, scrollbar "runs out of space" when mouse moves faster than scroll can keep up

SOLUTION:
Conservative height estimation with dynamic measurements
- Measure character width once using Canvas API (no hardcoded values)
- Dynamically calculate gutter width and padding from DOM
- Apply safety margin: 1.4x for ≤10k lines, 3.0x for >10k lines
- Smart overscan: full render for <100 lines, 50 overscan for larger logs

PERFORMANCE IMPACT:
✅ No performance degradation:
     - Character width measured only once on mount (using ref, not state)
     - Key prop only triggers reset on TaskRun switch (not on log growth)
     - Conservative estimation reduces re-measurement cycles
     - Smart overscan optimizes rendering based on log size

✅ Actually improved performance for large logs:
     - Better height estimation = fewer layout recalculations
     - Proper cache invalidation prevents visual bugs without extra overhead


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
- For chrome:
https://github.com/user-attachments/assets/ffa00d33-f108-4182-be2a-54cb85eba130
- For firefox:
https://github.com/user-attachments/assets/1f119095-bdd5-45bb-93ad-d2afc6dd780c


## How to test or reproduce?
1. go to https://localhost:8080/ns/wlin-tenant/applications/konflux-ui-test/pipelineruns/cara-konflux-ui-test-b1228-on-pull-request-v9gcw/ or any pipelines you could visit
2.review the task run logs in Chrome and use the scroll button in the log viewer to verify that you can reach the end of the log in a single action.

BTW, I have tested logs for 100+, 1000+, 10000+, it works well.
If you could find other length logs, it would be great to see how its behaves. Thank you a lot


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced log syntax highlighting to recognize multi-unit and day-based durations (e.g., "1h30m", "2d").
* **Bug Fixes**
  * Improved virtualized log viewer accuracy using font and viewport-aware height estimation.
  * Better performance and overscan handling for very large logs.
  * Fixed viewer remounting so logs reliably refresh when switching runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->