### PR TITLE
feat(KFLUXUI-934): [e2e] re-enable vulnerability scanning tests

### DIFF
--- a/e2e-tests/tests/basic-happy-path.spec.ts
+++ b/e2e-tests/tests/basic-happy-path.spec.ts
@@ -165,28 +165,24 @@ describe('Basic Happy Path', () => {
       DetailsTab.waitForPLRAndDownloadAllLogs(false);
     });
 
-    // Skipping unstable test
-    it.skip('Verify vulnerabilities column exists in Pipeline runs table', () => {
+    it('Verify vulnerabilities column exists in Pipeline runs table', () => {
       Applications.clickBreadcrumbLink('Pipeline runs');
       PipelinerunsTabPage.verifyVulnerabilityColumn();
     });
 
-    // Skipping unstable test
-    it.skip('Verify vulnerability indicators are displayed for on-push pipeline run', () => {
+    it('Verify vulnerability indicators are displayed for on-push pipeline run', () => {
       PipelinerunsTabPage.verifyVulnerabilityIndicators(
         `${componentName}-on-push`,
         /(-|N\/A|Critical\d+High\d+Medium\d+Low\d+Unknown\d+)/,
       );
     });
 
-    // Skipping unstable test
-    it.skip('Verify vulnerability indicators for on-pull-request pipeline run', () => {
+    it('Verify vulnerability indicators for on-pull-request pipeline run', () => {
       // Test passed for a page that was not fully loaded, test this functionality to prove it works as expected
       PipelinerunsTabPage.verifyVulnerabilityCellVisibility(`${componentName}-on-pull-request`);
     });
 
-    // Skipping unstable test
-    it.skip('Verify vulnerability scan details when available', () => {
+    it('Verify vulnerability scan details when available', () => {
       PipelinerunsTabPage.verifyVulnerabilityScanDetails(`${componentName}-on-push`);
     });
   });

--- a/src/hooks/__tests__/useScanResults.spec.ts
+++ b/src/hooks/__tests__/useScanResults.spec.ts
@@ -155,7 +155,7 @@ describe('usePLRScanResults', () => {
       { isFetchingNextPage: false, hasNextPage: false },
     ]);
     const { result } = renderHook(() => usePLRScanResults(['test2']));
-    expect(result.current).toEqual([null, true, [], undefined]);
+    expect(result.current).toEqual([null, true, ['test2'], undefined]);
   });
 
   it('returns error if scan results API is failing', () => {
@@ -168,7 +168,7 @@ describe('usePLRScanResults', () => {
       { isFetchingNextPage: false, hasNextPage: false },
     ]);
     const { result } = renderHook(() => usePLRScanResults(['test2']));
-    expect(result.current).toEqual([null, true, [], badGatewayError]);
+    expect(result.current).toEqual([null, true, ['test2'], badGatewayError]);
   });
 
   it('returns scan results if taskrun is found', () => {

--- a/src/hooks/useScanResults.ts
+++ b/src/hooks/useScanResults.ts
@@ -191,10 +191,10 @@ export const usePLRScanResults = (
   pipelineRunNames: string[],
 ): [{ [key: string]: unknown }, boolean, string[], unknown] => {
   // Fetch directly from tekton-results because a task result is only present on completed tasks runs.
-  const cacheKey = React.useRef('');
-  React.useEffect(() => {
-    if (pipelineRunNames.length) cacheKey.current = pipelineRunNames.sort().join('|');
-  }, [pipelineRunNames]);
+  const cacheKey = React.useMemo(
+    () => (pipelineRunNames.length ? pipelineRunNames.sort().join('|') : ''),
+    [pipelineRunNames],
+  );
 
   const namespace = useNamespace();
   const kubearchiveEnabled = useIsOnFeatureFlag('taskruns-kubearchive');
@@ -235,10 +235,10 @@ export const usePLRScanResults = (
     return [
       scanResultsMap,
       loaded,
-      loaded && pipelineRunNames.sort().join('|') === cacheKey.current ? pipelineRunNames : [],
+      loaded && pipelineRunNames.sort().join('|') === cacheKey ? pipelineRunNames : [],
       error,
     ];
-  }, [loaded, pipelineRunNames, taskRuns, error]);
+  }, [loaded, pipelineRunNames, taskRuns, error, cacheKey]);
 };
 
 export const usePLRVulnerabilities = (

--- a/src/hooks/useTaskRunsV2.ts
+++ b/src/hooks/useTaskRunsV2.ts
@@ -248,7 +248,7 @@ export const useTaskRunsForPipelineRuns = (
       selector,
       watch,
     },
-    { staleTime: Infinity, enabled: !!(namespace && pipelineRunName) },
+    { enabled: !!(namespace && pipelineRunName) },
   );
 
   const sortedTaskRuns = React.useMemo(() => sortTaskRunsByTime(taskRuns), [taskRuns]);


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->

Fixes https://redhat.atlassian.net/browse/KFLUXUI-934

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR re-enables the vulnerability-related e2e tests that were previously skipped as unstable.

The tests were failing because the "Fixable vulnerabilities" column showed skeleton loaders indefinitely when navigating back to the Pipeline runs list. The `cacheKey` in `usePLRScanResults` was computed in a `useEffect` (after render) but read in a `useMemo` (during render), so on remount with cached data the comparison always failed and scan results never displayed.

The fix: compute `cacheKey` with `useMemo` instead so it's available in the same render cycle.

We're also removing the `staleTime: Infinity` from `useTaskRunsForPipelineRuns` to allow proper refetching. This change is being cherry-picked from another PR, so please review #784 first :)


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

![e2e-vulnerability-scan-ISSUE](https://github.com/user-attachments/assets/323c5d07-df87-4109-afdb-3d1dbad26187)

After:

![e2e-vulnerability-scan-FIX](https://github.com/user-attachments/assets/b8167c02-f58b-422a-8edf-8d0fd2f63db1)

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

- run e2e tests locally
- notice that the vulnerability-related tests are re-enabled again and passing
- :coffee:

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enabled previously skipped vulnerability verification tests for pipeline runs, validating vulnerability column, indicators, cell visibility, and scan detail display.
  * Adjusted test expectations for scan-result failure scenarios to include the requested pipeline run identifier.

* **Refactor**
  * Improved scan-results caching logic to make returned results more consistent and reliable.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konflux-ci/konflux-ui/pull/796)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->