### PR TITLE
fix(KONFLUX-12890): SCM secret created via UI doesn't have required labels and annotations

### DIFF
--- a/src/utils/__tests__/create-utils.spec.ts
+++ b/src/utils/__tests__/create-utils.spec.ts
@@ -13,6 +13,7 @@ import { k8sCreateResource, k8sUpdateResource } from '../../k8s/k8s-fetch';
 import { SecretModel } from '../../models';
 import { ApplicationModel } from '../../models/application';
 import { ComponentModel } from '../../models/component';
+import { ImportSecret, SecretLabels, SecretTypeDropdownLabel, SourceSecretType } from '../../types';
 import { queueInstance } from '../async-queue';
 import {
   createApplication,
@@ -20,6 +21,7 @@ import {
   sanitizeName,
   getSecretObject,
   addSecretWithLinkingComponents,
+  createSecretWithLinkingComponents,
 } from '../create-utils';
 import { SecretForComponentOption } from '../secrets/secret-utils';
 import { linkSecretToServiceAccounts } from '../service-account/service-account-utils';
@@ -375,6 +377,102 @@ describe('create-utils addSecretWithLinkingComponents', () => {
     expect(createResourceMock).toHaveBeenCalled();
     expect(enqueueSpy).toHaveBeenCalled();
     expect(enqueueSpy).toHaveBeenCalledWith(expect.any(Function));
+  });
+});
+
+describe('create-utils createSecretWithLinkingComponents', () => {
+  const baseImportSecret: ImportSecret = {
+    secretName: 'my-import-secret',
+    type: SecretTypeDropdownLabel.opaque,
+    opaque: { keyValues: [{ key: 'token', value: 'abc123' }] },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    createResourceMock.mockResolvedValue({
+      metadata: { name: 'my-import-secret' },
+    });
+  });
+
+  it('should create a secret with source labels and annotations when host and repo are set', async () => {
+    const secret: ImportSecret = {
+      ...baseImportSecret,
+      type: SecretTypeDropdownLabel.source,
+      source: {
+        authType: SourceSecretType.basic,
+        host: 'github.com',
+        repo: 'org/repo',
+        username: 'user',
+        password: 'pass',
+      },
+    };
+
+    await createSecretWithLinkingComponents(secret, 'my-component', 'test-ns', false);
+
+    expect(createResourceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resource: expect.objectContaining({
+          metadata: expect.objectContaining({
+            labels: expect.objectContaining({
+              [SecretLabels.CREDENTIAL_LABEL]: SecretLabels.CREDENTIAL_VALUE,
+              [SecretLabels.HOST_LABEL]: 'github.com',
+            }),
+            annotations: expect.objectContaining({
+              [SecretLabels.REPO_ANNOTATION]: 'org/repo',
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('should create a secret without labels or annotations when source is not set', async () => {
+    await createSecretWithLinkingComponents(baseImportSecret, 'my-component', 'test-ns', false);
+
+    expect(createResourceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resource: expect.objectContaining({
+          metadata: expect.objectContaining({
+            labels: {},
+            annotations: null,
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('should add common secret label when secretForComponentOption is all', async () => {
+    const secret: ImportSecret = {
+      ...baseImportSecret,
+      secretForComponentOption: SecretForComponentOption.all,
+    };
+
+    await createSecretWithLinkingComponents(secret, 'my-component', 'test-ns', false);
+
+    expect(createResourceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resource: expect.objectContaining({
+          metadata: expect.objectContaining({
+            labels: expect.objectContaining({
+              [SecretLabels.COMMON_SECRET_LABEL]: 'true',
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('should not enqueue linking task on dry run', async () => {
+    await createSecretWithLinkingComponents(baseImportSecret, 'my-component', 'test-ns', true);
+
+    expect(createResourceMock).toHaveBeenCalled();
+    expect(enqueueSpy).not.toHaveBeenCalled();
+  });
+
+  it('should enqueue linking task when componentName is provided', async () => {
+    await createSecretWithLinkingComponents(baseImportSecret, 'my-component', 'test-ns', false);
+
+    expect(enqueueSpy).toHaveBeenCalled();
   });
 });
 

--- a/src/utils/__tests__/create-utils.spec.ts
+++ b/src/utils/__tests__/create-utils.spec.ts
@@ -433,7 +433,7 @@ describe('create-utils createSecretWithLinkingComponents', () => {
       expect.objectContaining({
         resource: expect.objectContaining({
           metadata: expect.objectContaining({
-            labels: {},
+            labels: null,
             annotations: null,
           }),
         }),

--- a/src/utils/create-utils.ts
+++ b/src/utils/create-utils.ts
@@ -514,9 +514,7 @@ export const createSecretWithLinkingComponents = async (
 ) => {
   const secretResource = getSecretObject(secret, namespace);
 
-  const labels = {
-    secret: getLabelsForSecret(secret),
-  };
+  const labels = getLabelsForSecret(secret);
 
   const annotations = getAnnotationForSecret(secret);
 
@@ -524,9 +522,7 @@ export const createSecretWithLinkingComponents = async (
     ...secretResource,
     metadata: {
       ...secretResource.metadata,
-      labels: {
-        ...labels?.secret,
-      },
+      labels,
       annotations,
     },
   };

--- a/src/utils/create-utils.ts
+++ b/src/utils/create-utils.ts
@@ -514,9 +514,26 @@ export const createSecretWithLinkingComponents = async (
 ) => {
   const secretResource = getSecretObject(secret, namespace);
 
+  const labels = {
+    secret: getLabelsForSecret(secret),
+  };
+
+  const annotations = getAnnotationForSecret(secret);
+
+  const k8sSecretResource = {
+    ...secretResource,
+    metadata: {
+      ...secretResource.metadata,
+      labels: {
+        ...labels?.secret,
+      },
+      annotations,
+    },
+  };
+
   const createdSecret = await K8sQueryCreateResource({
     model: SecretModel,
-    resource: secretResource,
+    resource: k8sSecretResource,
     queryOptions: { ns: namespace, ...(dryRun && { queryParams: { dryRun: 'All' } }) },
   });
 

--- a/src/utils/secrets/secret-utils.ts
+++ b/src/utils/secrets/secret-utils.ts
@@ -20,6 +20,8 @@ import {
   SecretTypeDropdownLabel,
   SourceSecretType,
   BuildTimeSecret,
+  Source,
+  KeyValueEntry,
 } from '../../types';
 
 export { SecretForComponentOption };
@@ -185,7 +187,13 @@ export const getTargetLabelsForRemoteSecret = (
   return labels;
 };
 
-export const getLabelsForSecret = (values: AddSecretFormValues): { [key: string]: string } => {
+type SecretLabelInput = {
+  source?: Source;
+  labels?: KeyValueEntry[];
+  secretForComponentOption?: null | SecretForComponentOption;
+};
+
+export const getLabelsForSecret = (values: SecretLabelInput): { [key: string]: string } => {
   const addCommonSecretLabel = values?.secretForComponentOption === SecretForComponentOption.all;
 
   if (
@@ -219,7 +227,7 @@ export const getLabelsForSecret = (values: AddSecretFormValues): { [key: string]
   return labels;
 };
 
-export const getAnnotationForSecret = (values: AddSecretFormValues): { [key: string]: string } => {
+export const getAnnotationForSecret = (values: SecretLabelInput): { [key: string]: string } => {
   if (!values.source?.repo) {
     // get scm annotation for repository
     return null;


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->

Fixes https://redhat.atlassian.net/browse/KONFLUX-12890

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The `createSecretWithLinkingComponents` util function was missing adding `label` and `annotations` to the secret resource that was being created. In this PR we're fixing it by applying the same logic already used in `addSecretWithLinkingComponents`.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

https://github.com/user-attachments/assets/a8a2a84e-cf9f-411f-b693-9bbb46004778

After:

https://github.com/user-attachments/assets/10b85c5d-0cbc-4295-9067-e9a67294b151

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

- navigate to "Create a Component" page
- fill in the necessary info and click on "Add secret" button
- choose "Source secret" type
- choose Basic authentication
- fill in the rest of the form with whatever info you want
- (I'd suggest to open your browser's dev tool and look out for the api requests/responses)
- once the component and secret is created, notice that the `Secret` has the proper `labels` and `annotations`
- :coffee:

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Secrets created with source info now include correct metadata labels and repository annotations; metadata is omitted when no source is provided.
  * Secrets targeted to all components now include the common secret label.
  * Dry-run mode prevents linking/enqueue operations.

* **Tests**
  * Added tests covering secret creation, metadata behavior, and linking/enqueue control flow.

* **Chores**
  * Refined input handling for secret label and annotation generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->