### PR TITLE
fix(KFLUXUI-1156): show loading indicator while logs are being processed

### DIFF
--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.scss
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.scss
@@ -46,6 +46,11 @@
     right: 0;
     z-index: 1000;
   }
+
+  &__bullseye {
+    padding-top: var(--pf-v5-global--spacer--md);
+    padding-bottom: var(--pf-v5-global--spacer--md);
+  }
 }
 
 // Force light theme on the log content when user selects "Light theme" (e.g. when main app theme is dark)

--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
@@ -260,7 +260,7 @@ const LogViewer: React.FC<Props> = ({
               </FlexItem>
             </Flex>
             {isLoading && (
-              <Bullseye>
+              <Bullseye className="log-viewer__bullseye">
                 <Spinner size="lg" />
               </Bullseye>
             )}

--- a/src/shared/components/pipeline-run-logs/logs/Logs.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/Logs.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Base64 } from 'js-base64';
 import { useIsOnFeatureFlag } from '~/feature-flags/hooks';
 import { KUBEARCHIVE_PATH_PREFIX } from '~/kubearchive/const';
+import { useDebounceCallback } from '~/shared/hooks/useDebounceCallback';
 import { ResourceSource } from '~/types/k8s';
 import { commonFetchText } from '../../../../k8s';
 import { getK8sResourceURL, getWebsocketSubProtocolAndPathPrefix } from '../../../../k8s/k8s-utils';
@@ -186,10 +187,28 @@ const Logs: React.FC<LogsProps> = ({
     };
   }, [containers, resource, resName, resNamespace, appendLog, source, isKubearchiveEnabled]);
 
-  const formattedLogs = React.useMemo(
-    () => processLogs(logSources, containers),
-    [logSources, containers],
-  );
+  const [formattedLogs, setFormattedLogs] = React.useState('');
+  const [processingLogs, setProcessingLogs] = React.useState(false);
+  const containersRef = React.useRef(containers);
+  containersRef.current = containers;
+
+  const processAndSetLogs = useDebounceCallback(() => {
+    const result = processLogs(logSources, containersRef.current);
+    setFormattedLogs(result);
+    setProcessingLogs(false);
+  }, 300);
+
+  React.useEffect(() => {
+    if (Object.keys(logSources).length === 0) {
+      setFormattedLogs('');
+      return;
+    }
+
+    setProcessingLogs(true);
+    processAndSetLogs();
+
+    return () => processAndSetLogs.cancel();
+  }, [logSources, processAndSetLogs]);
 
   const allLogsTerminated = React.useMemo<boolean>(() => {
     if (containers.length === 0) return false;
@@ -222,7 +241,7 @@ const Logs: React.FC<LogsProps> = ({
       downloadAllLabel={downloadAllLabel}
       onDownloadAll={onDownloadAll}
       taskRun={taskRun}
-      isLoading={isLoading}
+      isLoading={isLoading || processingLogs}
       errorMessage={error ? t('An error occurred while retrieving the requested logs.') : null}
     />
   );

--- a/src/shared/components/pipeline-run-logs/logs/Logs.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/Logs.tsx
@@ -25,13 +25,7 @@ export const processLogs = (logSources: LogSources, containers: ContainerSpec[])
     const containerName = container.name;
     if (logSources[containerName]) {
       allLogs += `\n\n${containerName.toUpperCase()}\n`;
-
-      const indentedLogs = logSources[containerName]
-        ?.split('\n')
-        ?.map((line) => `  ${line}`)
-        ?.join('\n');
-
-      allLogs += indentedLogs;
+      allLogs += `  ${logSources[containerName].replace(/\n/g, '\n  ')}`;
     }
   }
   return allLogs.trim();

--- a/src/shared/components/pipeline-run-logs/logs/__tests__/Logs.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/__tests__/Logs.spec.tsx
@@ -17,6 +17,7 @@ jest.mock('../LogViewer', () => {
   return function MockLogViewer(props: {
     data: string;
     allowAutoScroll: boolean;
+    isLoading?: boolean;
     onScroll?: () => void;
   }) {
     mockLogViewer(props);
@@ -798,6 +799,76 @@ describe('Logs', () => {
         allowAutoScroll: true, // Should be true when no containers (empty array)
       }),
     );
+  });
+
+  describe('loading indicator while processing logs', () => {
+    it('should show loading while logs are being debounced', async () => {
+      jest.useFakeTimers();
+
+      const terminatedContainer: ContainerStatus = {
+        name: 'container1',
+        state: { terminated: { exitCode: 0 } },
+        ready: false,
+        restartCount: 0,
+        image: 'test-image',
+        imageID: 'test-image-id',
+      };
+
+      const resourceWithStatus: PodKind = {
+        ...mockResource,
+        status: {
+          phase: 'Succeeded',
+          containerStatuses: [terminatedContainer],
+        },
+      };
+
+      (containerToLogSourceStatus as jest.Mock).mockReturnValue('terminated');
+      (commonFetchText as jest.Mock).mockResolvedValue('some log output');
+
+      render(
+        <Logs
+          {...defaultProps}
+          resource={resourceWithStatus}
+          containers={[{ name: 'container1' }]}
+        />,
+      );
+
+      // After fetch resolves but before debounce fires, isLoading should be true
+      await act(async () => {
+        await Promise.resolve(); // let fetch resolve
+      });
+
+      expect(mockLogViewer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isLoading: true,
+        }),
+      );
+
+      // After debounce fires, isLoading should be false
+      act(() => {
+        jest.advanceTimersByTime(300);
+      });
+
+      expect(mockLogViewer).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          isLoading: false,
+          data: expect.stringContaining('some log output'),
+        }),
+      );
+
+      jest.useRealTimers();
+    });
+
+    it('should not show loading when there are no log sources', () => {
+      render(<Logs {...defaultProps} containers={[]} />);
+
+      expect(mockLogViewer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isLoading: false,
+          data: '',
+        }),
+      );
+    });
   });
 
   it('should handle containers that are not yet started', () => {


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->

Fixes https://redhat.atlassian.net/browse/KFLUXUI-1156

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In this PR we're updating the `Logs` component to track the processing logs state and pass it to `LogViewer`'s `isLoading` prop. 

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

https://github.com/user-attachments/assets/59623099-614d-4488-b761-a6d7746a298e

After:

https://github.com/user-attachments/assets/807f4906-a505-49d0-b458-6192b216ddf9

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

You can simply check logs from any PLRs, you'll notice that there'll be a loading spinner at the top while the logs are being loaded.

If you want to try to simulate "loading a huge log", you can add the following to `src/shared/components/pipeline-run-logs/logs/Logs.tsx`:

```tsx
  React.useEffect(() => {
    fetch('/mock-huge-log.log')
      .then((res) => res.text())
      .then((logData) => {
        // eslint-disable-next-line no-console
        console.log(
          `[MOCK] Loaded real log file: ${logData.length} chars, ~${logData.split('\n').length} lines`,
        );
        // Inject into only the first container (simulates one step with huge logs)
        if (containers.length > 0) {
          appendLog(containers[0].name, logData);
        }
      })
      // eslint-disable-next-line no-console
      .catch((err) => console.error('[MOCK] Failed to load mock log file:', err));
    // eslint-disable-next-line react-hooks/exhaustive-deps
  }, []);
```

You just need to create a file called `mock-huge-log.log` and put it inside the `public/` folder. This file will contain the huge log, so you can somehow foce it to be loaded in the LogViewer :)


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Loading indicator now reflects both external loading and internal log-processing, preventing stale or missing spinners during log formatting.

* **Style**
  * Adjusted spacing for the log viewer's loading display for improved visual alignment.

* **Tests**
  * Added tests verifying loading state during debounced log processing and when no log sources are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->