### PR TITLE
feat(KFLUXUI-1197): create text filtering util

### DIFF
--- a/src/utils/__tests__/text-filter-utils.spec.ts
+++ b/src/utils/__tests__/text-filter-utils.spec.ts
@@ -1,0 +1,217 @@
+import { textMatch, filterByText, TextFilterOptions } from '~/utils/text-filter-utils';
+
+describe('textMatch', () => {
+  describe('default options', () => {
+    it('should match a substring case-insensitively', () => {
+      expect(textMatch('Hello World', 'hello')).toBe(true);
+      expect(textMatch('Hello World', 'WORLD')).toBe(true);
+      expect(textMatch('Hello World', 'lo Wo')).toBe(true);
+    });
+
+    it('should return false when the substring is not present', () => {
+      expect(textMatch('Hello World', 'xyz')).toBe(false);
+    });
+
+    it('should trim the search term by default', () => {
+      expect(textMatch('Hello', '  hello  ')).toBe(true);
+    });
+
+    it('should match everything when the search term is empty', () => {
+      expect(textMatch('anything', '')).toBe(true);
+    });
+
+    it('should match everything when the search term is only whitespace (trimmed to empty)', () => {
+      expect(textMatch('anything', '   ')).toBe(true);
+    });
+  });
+
+  describe('non-string value handling', () => {
+    it('should coerce a number value to a string', () => {
+      expect(textMatch(42, '4')).toBe(true);
+      expect(textMatch(42, '42')).toBe(true);
+      expect(textMatch(42, '99')).toBe(false);
+    });
+
+    it('should handle null value gracefully', () => {
+      expect(textMatch(null, 'search')).toBe(false);
+      expect(textMatch(null, '')).toBe(true);
+    });
+
+    it('should handle undefined value gracefully', () => {
+      expect(textMatch(undefined, 'search')).toBe(false);
+      expect(textMatch(undefined, '')).toBe(true);
+    });
+
+    it('should coerce boolean values to strings', () => {
+      expect(textMatch(true, 'true')).toBe(true);
+      expect(textMatch(false, 'fal')).toBe(true);
+    });
+
+    it('should handle zero as a value', () => {
+      expect(textMatch(0, '0')).toBe(true);
+    });
+  });
+
+  describe('caseSensitive option', () => {
+    const opts: TextFilterOptions = { caseSensitive: true };
+
+    it('should match when case matches exactly', () => {
+      expect(textMatch('Hello World', 'Hello', opts)).toBe(true);
+    });
+
+    it('should not match when case differs', () => {
+      expect(textMatch('Hello World', 'hello', opts)).toBe(false);
+    });
+  });
+
+  describe('trim option', () => {
+    it('should not trim the search term when trim is disabled', () => {
+      // ' hello' (with leading space) is not a substring of 'hello world'
+      expect(textMatch('hello world', ' hello', { trim: false })).toBe(false);
+    });
+
+    it('should keep leading/trailing spaces significant when trim is disabled', () => {
+      expect(textMatch('  hello  ', '  hello  ', { trim: false })).toBe(true);
+    });
+  });
+
+  describe('fuzzy option (subsequence)', () => {
+    const opts: TextFilterOptions = { fuzzy: true };
+
+    it('should match when characters appear in order', () => {
+      expect(textMatch('Hello World', 'hwd', opts)).toBe(true);
+      expect(textMatch('component-build-pipeline', 'cbp', opts)).toBe(true);
+    });
+
+    it('should not match when characters are out of order', () => {
+      expect(textMatch('Hello World', 'dwh', opts)).toBe(false);
+    });
+
+    it('should still match contiguous substrings', () => {
+      expect(textMatch('Hello World', 'hello', opts)).toBe(true);
+    });
+
+    it('should handle fuzzy match with an empty search term', () => {
+      expect(textMatch('Hello', '', opts)).toBe(true);
+    });
+
+    it('should handle fuzzy match with single character', () => {
+      expect(textMatch('Hello', 'h', opts)).toBe(true);
+      expect(textMatch('Hello', 'z', opts)).toBe(false);
+    });
+
+    it('should not match when search term is longer than value', () => {
+      expect(textMatch('Hi', 'Hello', opts)).toBe(false);
+    });
+
+    it('should be case-insensitive by default', () => {
+      expect(textMatch('Hello World', 'HWD', opts)).toBe(true);
+    });
+
+    it('should respect caseSensitive with fuzzy', () => {
+      expect(textMatch('Hello World', 'HW', { fuzzy: true, caseSensitive: true })).toBe(true);
+      expect(textMatch('Hello World', 'hw', { fuzzy: true, caseSensitive: true })).toBe(false);
+    });
+  });
+
+  describe('combined options', () => {
+    it('should handle caseSensitive + trim disabled together', () => {
+      expect(textMatch('Hello', ' Hello', { caseSensitive: true, trim: false })).toBe(false);
+      expect(textMatch(' Hello', ' Hello', { caseSensitive: true, trim: false })).toBe(true);
+    });
+
+    it('should handle all options together', () => {
+      expect(
+        textMatch('Component Build Pipeline', '  cbp  ', {
+          caseSensitive: false,
+          trim: true,
+          fuzzy: true,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should match when value and search term are identical', () => {
+      expect(textMatch('exact', 'exact')).toBe(true);
+    });
+
+    it('should handle empty value with empty search term', () => {
+      expect(textMatch('', '')).toBe(true);
+    });
+
+    it('should handle empty value with non-empty search term', () => {
+      expect(textMatch('', 'search')).toBe(false);
+    });
+
+    it('should handle special regex characters in search term', () => {
+      expect(textMatch('price is $4.99', '$4.99')).toBe(true);
+      expect(textMatch('a (b) c', '(b)')).toBe(true);
+      expect(textMatch('foo[0]', '[0]')).toBe(true);
+    });
+
+    it('should handle unicode characters', () => {
+      expect(textMatch('café', 'café')).toBe(true);
+      expect(textMatch('日本語', '本')).toBe(true);
+    });
+  });
+});
+
+describe('filterByText', () => {
+  const items = [
+    { name: 'Alpha', id: 1 },
+    { name: 'Beta', id: 2 },
+    { name: 'Gamma', id: 3 },
+    { name: 'Delta', id: 4 },
+  ];
+
+  it('should filter items by substring match', () => {
+    const result = filterByText(items, 'eta', (item) => item.name);
+    expect(result).toEqual([{ name: 'Beta', id: 2 }]);
+  });
+
+  it('should return the original array reference for empty query', () => {
+    const result = filterByText(items, '', (item) => item.name);
+    expect(result).toBe(items);
+  });
+
+  it('should return the original array reference for whitespace-only query', () => {
+    const result = filterByText(items, '   ', (item) => item.name);
+    expect(result).toBe(items);
+  });
+
+  it('should return the original array reference for null/undefined query', () => {
+    expect(filterByText(items, null as unknown as string, (item) => item.name)).toBe(items);
+    expect(filterByText(items, undefined, (item) => item.name)).toBe(items);
+  });
+
+  it('should filter case-insensitively by default', () => {
+    const result = filterByText(items, 'ALPHA', (item) => item.name);
+    expect(result).toEqual([{ name: 'Alpha', id: 1 }]);
+  });
+
+  it('should support accessor converting a number to string', () => {
+    const result = filterByText(items, '2', (item) => String(item.id));
+    expect(result).toEqual([{ name: 'Beta', id: 2 }]);
+  });
+
+  it('should support fuzzy filtering', () => {
+    const result = filterByText(items, 'gma', (item) => item.name, { fuzzy: true });
+    expect(result).toEqual([{ name: 'Gamma', id: 3 }]);
+  });
+
+  it('should return an empty array when nothing matches', () => {
+    const result = filterByText(items, 'zzz', (item) => item.name);
+    expect(result).toEqual([]);
+  });
+
+  it('should handle an empty items array', () => {
+    const result = filterByText([], 'test', (item: { name: string }) => item.name);
+    expect(result).toEqual([]);
+  });
+
+  it('should pass options through to textMatch', () => {
+    const result = filterByText(items, 'alpha', (item) => item.name, { caseSensitive: true });
+    expect(result).toEqual([]);
+  });
+});

--- a/src/utils/text-filter-utils.ts
+++ b/src/utils/text-filter-utils.ts
@@ -1,0 +1,124 @@
+export type TextFilterOptions = {
+  caseSensitive?: boolean;
+  trim?: boolean;
+  /** Use subsequence (fuzzy) matching: all characters of the search term must
+   *  appear in order within the value, but not necessarily contiguously.
+   *  E.g. "cbp" matches "component-build-pipeline". Defaults to `false`. */
+  fuzzy?: boolean;
+};
+
+type Searchable = string | number | boolean | null | undefined;
+
+/**
+ * Safely coerces a primitive value to a string for text comparison.
+ */
+const toSearchableString = (value: Searchable): string => {
+  if (value === null) {
+    return '';
+  }
+
+  if (value === undefined) {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  return String(value);
+};
+
+/**
+ * Subsequence match: every character in `search` appears in `text` in order,
+ * but not necessarily contiguously. Both strings must already be in the
+ * desired case before calling this.
+ */
+const subsequenceMatch = (text: string, search: string): boolean => {
+  let si = 0;
+
+  for (let ti = 0; ti < text.length && si < search.length; ti++) {
+    if (text[ti] === search[si]) {
+      si++;
+    }
+  }
+
+  return si === search.length;
+};
+
+/**
+ * Checks whether a **value** matches a **search term** based on the provided options.
+ *
+ * Key behaviours:
+ * - Non-string values (numbers, booleans, `null`, `undefined`) are coerced to
+ *   a string before comparison, so calling code never has to worry about runtime
+ *   errors from e.g. `(42).toLowerCase()`.
+ * - An empty (or whitespace-only, when `trim` is enabled) search term matches
+ *   everything.
+ * - When `fuzzy` is true, uses subsequence matching: all characters of the
+ *   search term must appear in order within the value.
+ *
+ * @param value      - The value to search in.
+ * @param searchTerm - The term to look for.
+ * @param options    - Optional search configuration.
+ * @returns `true` when the value matches the search term.
+ *
+ * @example
+ * ```ts
+ * textMatch('Hello World', 'hello');                        // true  (case-insensitive)
+ * textMatch('Hello World', 'hello', { caseSensitive: true }); // false
+ * textMatch(42, '4');                                       // true  (number → "42")
+ * textMatch('Hello World', 'hwd', { fuzzy: true });         // true  (subsequence)
+ * textMatch(null, 'x');                                     // false
+ * textMatch('anything', '  ');                              // true  (empty after trim)
+ * ```
+ */
+export const textMatch = (
+  value: Searchable,
+  searchTerm: string,
+  options: TextFilterOptions = {},
+): boolean => {
+  const { caseSensitive = false, trim = true, fuzzy = false } = options;
+
+  let text = toSearchableString(value);
+
+  if (trim) {
+    searchTerm = searchTerm.trim();
+  }
+
+  if (!searchTerm) {
+    return true;
+  }
+
+  if (!text) {
+    return false;
+  }
+
+  if (!caseSensitive) {
+    text = text.toLowerCase();
+    searchTerm = searchTerm.toLowerCase();
+  }
+
+  return fuzzy ? subsequenceMatch(text, searchTerm) : text.includes(searchTerm);
+};
+
+/**
+ * Filters an array of items by matching a search term against a text field
+ * extracted via `accessor`. Returns the **original array reference** when the
+ * search term is empty so that `useMemo` consumers avoid unnecessary rerenders.
+ */
+export const filterByText = <T>(
+  items: T[],
+  searchTerm: string | undefined,
+  accessor: (item: T) => string,
+  options?: TextFilterOptions,
+): T[] => {
+  const { trim = true } = options ?? {};
+  const term = searchTerm ?? '';
+  const normalized = trim ? term.trim() : term;
+
+  if (!normalized) {
+    return items;
+  }
+
+  return items.filter((item) => textMatch(accessor(item), normalized, options));
+};


### PR DESCRIPTION
Assisted-by: Cursor


## Fixes 
[KFLUXUI-1197](https://redhat.atlassian.net/browse/KFLUXUI-1197)


## Description
Utility for consistent text filtering, with the ability to:
- trim whitespaces,
- case (in)sensitive
- subsequent search (`plr` -> `pipelinerun`) 

The current filtering will be replaced with this utility in a different PR for more clarity

## Type of change
<!-- Please delete options that are not relevant. -->

- [X] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


[KFLUXUI-1197]: https://redhat.atlassian.net/browse/KFLUXUI-1197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable text matching and list filtering: case-sensitive option, optional trimming of queries, and fuzzy (ordered-subsequence) matching. Filters return the original list when the query is empty and handle non-string values, Unicode, and literal special characters.

* **Tests**
  * Added comprehensive tests for defaults, option combinations, robustness with null/undefined/non-string inputs, empty queries/lists, and Unicode/special-character scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->