### PR TITLE
chore(KFLUXUI-1197): replace manual text filtering with new util

### DIFF
--- a/src/components/Applications/ApplicationListView.tsx
+++ b/src/components/Applications/ApplicationListView.tsx
@@ -9,6 +9,7 @@ import {
 } from '@patternfly/react-core';
 import { SortByDirection } from '@patternfly/react-table';
 import { getErrorState } from '~/shared/utils/error-utils';
+import { textMatch } from '~/utils/text-filter-utils';
 import emptyStateImgUrl from '../../assets/Application.svg';
 import { useApplications } from '../../hooks/useApplications';
 import { useSortedResources } from '../../hooks/useSortedResources';
@@ -56,14 +57,13 @@ const ApplicationListView: React.FC<React.PropsWithChildren<unknown>> = () => {
   );
 
   const [applications, loaded, error] = useApplications(namespace);
-  const filteredApplications = React.useMemo(() => {
-    const lowerCaseNameFilter = nameFilter.toLowerCase();
-    return applications?.filter(
-      (app) =>
-        app.spec.displayName?.toLowerCase().includes(lowerCaseNameFilter) ??
-        app.metadata.name.includes(lowerCaseNameFilter),
-    );
-  }, [nameFilter, applications]);
+  const filteredApplications = React.useMemo(
+    () =>
+      applications?.filter((app) =>
+        textMatch(app.spec.displayName ?? app.metadata.name, nameFilter),
+      ),
+    [nameFilter, applications],
+  );
 
   const sortedApplications = useSortedResources(
     filteredApplications,

--- a/src/components/Commits/CommitsListPage/CommitsListView.tsx
+++ b/src/components/Commits/CommitsListPage/CommitsListView.tsx
@@ -7,6 +7,7 @@ import { BaseTextFilterToolbar } from '~/components/Filter/toolbars/BaseTextFIlt
 import { createFilterObj } from '~/components/Filter/utils/filter-utils';
 import ColumnManagement from '~/shared/components/table/ColumnManagement';
 import { getErrorState } from '~/shared/utils/error-utils';
+import { textMatch } from '~/utils/text-filter-utils';
 import { SESSION_STORAGE_KEYS } from '../../../consts/constants';
 import {
   PipelineRunLabel,
@@ -190,16 +191,13 @@ const CommitsListView: React.FC<React.PropsWithChildren<CommitsListViewProps>> =
     () =>
       commits.filter((commit) => {
         const commitStatus = commitStatusMap[commit.sha] || runStatus.Unknown;
+        const strippedFilter = nameFilter?.trim().replace('#', '');
         return (
           (!nameFilter ||
-            commit.sha.indexOf(nameFilter) !== -1 ||
-            commit.components.some(
-              (c) => c.toLowerCase().indexOf(nameFilter.trim().toLowerCase()) !== -1,
-            ) ||
-            commit.pullRequestNumber
-              .toLowerCase()
-              .indexOf(nameFilter.trim().replace('#', '').toLowerCase()) !== -1 ||
-            commit.shaTitle.toLowerCase().includes(nameFilter.trim().toLowerCase())) &&
+            textMatch(commit.sha, nameFilter) ||
+            commit.components.some((c) => textMatch(c, nameFilter)) ||
+            textMatch(commit.pullRequestNumber, strippedFilter) ||
+            textMatch(commit.shaTitle, nameFilter)) &&
           (!statusFilter.length || statusFilter.includes(commitStatus))
         );
       }),

--- a/src/components/Commits/CommitsListPage/CommitsListViewV2.tsx
+++ b/src/components/Commits/CommitsListPage/CommitsListViewV2.tsx
@@ -23,6 +23,7 @@ import { useNamespace } from '~/shared/providers/Namespace';
 import { getErrorState } from '~/shared/utils/error-utils';
 import { Commit, PipelineRunKind } from '~/types';
 import { getCommitsFromPLRs, getCommitSha, statuses } from '~/utils/commits-utils';
+import { textMatch } from '~/utils/text-filter-utils';
 import { getCommitStatusFromPipelineRuns } from '../commit-status';
 import CommitsEmptyStateV2 from '../CommitsEmptyStateV2';
 import {
@@ -167,16 +168,13 @@ const CommitsListViewV2: React.FC<React.PropsWithChildren<CommitsListViewPropsV2
     () =>
       commits.filter((commit) => {
         const commitStatus = commitStatusMap[commit.sha] || runStatus.Unknown;
+        const strippedFilter = nameFilter?.trim().replace('#', '');
         return (
           (!nameFilter ||
-            commit.sha.indexOf(nameFilter) !== -1 ||
-            commit.components.some(
-              (c) => c.toLowerCase().indexOf(nameFilter.trim().toLowerCase()) !== -1,
-            ) ||
-            commit.pullRequestNumber
-              .toLowerCase()
-              .indexOf(nameFilter.trim().replace('#', '').toLowerCase()) !== -1 ||
-            commit.shaTitle.toLowerCase().includes(nameFilter.trim().toLowerCase())) &&
+            textMatch(commit.sha, nameFilter) ||
+            commit.components.some((c) => textMatch(c, nameFilter)) ||
+            textMatch(commit.pullRequestNumber, strippedFilter) ||
+            textMatch(commit.shaTitle, nameFilter)) &&
           (!statusFilter.length || statusFilter.includes(commitStatus)) &&
           (!versionFilter.length || versionFilter.includes(commit.branch))
         );

--- a/src/components/ComponentList/ComponentList.tsx
+++ b/src/components/ComponentList/ComponentList.tsx
@@ -10,6 +10,7 @@ import FilteredEmptyState from '~/shared/components/empty-state/FilteredEmptySta
 import { useNamespace } from '~/shared/providers/Namespace/useNamespaceInfo';
 import { getErrorState } from '~/shared/utils/error-utils';
 import { ComponentKind } from '~/types';
+import { filterByText } from '~/utils/text-filter-utils';
 import emptyStateImgUrl from '../../assets/Components.svg';
 import { ButtonWithAccessTooltip } from '../ButtonWithAccessTooltip';
 import ComponentsListHeader from './ComponentListHeader';
@@ -33,10 +34,7 @@ const ComponentList: React.FC = () => {
   );
 
   const filteredComponents = React.useMemo(
-    () =>
-      components.filter((component) => {
-        return !nameFilter || component.metadata.name.indexOf(nameFilter) !== -1;
-      }),
+    () => filterByText(components, nameFilter, (c) => c.metadata.name),
     [components, nameFilter],
   );
 

--- a/src/components/ComponentVersion/ComponentVersionListView/ComponentVersionListView.tsx
+++ b/src/components/ComponentVersion/ComponentVersionListView/ComponentVersionListView.tsx
@@ -9,6 +9,7 @@ import FilteredEmptyState from '~/shared/components/empty-state/FilteredEmptySta
 import { useNamespace } from '~/shared/providers/Namespace';
 import { getErrorState } from '~/shared/utils/error-utils';
 import { ComponentVersion } from '~/types/component';
+import { filterByText } from '~/utils/text-filter-utils';
 import getVersionListHeader, { SortableHeaders } from './ComponentVersionListHeader';
 import { ComponentVersionListRow, VersionListRowCustomData } from './ComponentVersionListRow';
 
@@ -40,7 +41,7 @@ const ComponentVersionListView: React.FC<
   const versions = component?.spec?.source?.versions ?? EMPTY_VERSIONS;
 
   const filteredVersions = React.useMemo(
-    () => versions.filter((v) => v.name.toLowerCase().includes(nameFilter.trim().toLowerCase())),
+    () => filterByText(versions, nameFilter, (v) => v.name),
     [versions, nameFilter],
   );
 

--- a/src/components/Components/ComponentsListView/ComponentListView.tsx
+++ b/src/components/Components/ComponentsListView/ComponentListView.tsx
@@ -23,6 +23,7 @@ import { createFilterObj } from '~/components/Filter/utils/filter-utils';
 import { getErrorState } from '~/shared/utils/error-utils';
 import { statuses } from '~/utils/commits-utils';
 import { pipelineRunStatus } from '~/utils/pipeline-utils';
+import { textMatch } from '~/utils/text-filter-utils';
 import emptyStateImgUrl from '../../../assets/Components.svg';
 import pipelineImg from '../../../assets/Pipeline.svg';
 import { PipelineRunLabel } from '../../../consts/pipelinerun';
@@ -114,7 +115,7 @@ const ComponentListView: React.FC<React.PropsWithChildren<ComponentListViewProps
           : 'unknown';
 
         return (
-          (!nameFilter || component.metadata.name.indexOf(nameFilter) !== -1) &&
+          textMatch(component.metadata.name, nameFilter) &&
           (!statusFilter?.length || statusFilter.includes(capitalize(compStatus)))
         );
       }),

--- a/src/components/Components/LinkedSecretsListView/LinkedSecretsListView.tsx
+++ b/src/components/Components/LinkedSecretsListView/LinkedSecretsListView.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import {
-  TextContent,
-  Text,
-  TextVariants,
+  Bullseye,
   PageSection,
   PageSectionVariants,
-  Bullseye,
   Spinner,
+  Text,
+  TextContent,
+  TextVariants,
   EmptyStateBody,
   Button,
 } from '@patternfly/react-core';
 import { SortByDirection } from '@patternfly/react-table';
 import { getErrorState } from '~/shared/utils/error-utils';
+import { filterByText } from '~/utils/text-filter-utils';
 import emptyStateImgUrl from '../../../assets/secret.svg';
 import { useLinkedSecrets } from '../../../hooks/useLinkedSecrets';
 import { useSearchParam } from '../../../hooks/useSearchParam';
@@ -79,10 +80,7 @@ export const LinkedSecretsListView: React.FC = () => {
   );
 
   const filteredLinkedSecrets = React.useMemo(
-    () =>
-      sortedLinkedSecrets?.filter((linkedSecret) => {
-        return !nameFilter || linkedSecret.metadata.name.includes(nameFilter);
-      }),
+    () => filterByText(sortedLinkedSecrets ?? [], nameFilter, (s) => s.metadata.name),
     [sortedLinkedSecrets, nameFilter],
   );
 

--- a/src/components/Conforma/SecurityConformaTab.tsx
+++ b/src/components/Conforma/SecurityConformaTab.tsx
@@ -13,6 +13,7 @@ import { CONFORMA_POLICY_AVAILABLE_RULE_COLLECTIONS_URL } from '~/consts/documen
 import { useDeepCompareMemoize } from '~/shared';
 import { getErrorState } from '~/shared/utils/error-utils';
 import { CONFORMA_RESULT_STATUS, UIConformaData } from '~/types/conforma';
+import { textMatch } from '~/utils/text-filter-utils';
 import FilteredEmptyState from '../../shared/components/empty-state/FilteredEmptyState';
 import { FilterContext } from '../Filter/generic/FilterContext';
 import { MultiSelect } from '../Filter/generic/MultiSelect';
@@ -75,7 +76,7 @@ export const SecurityConformaTab: React.FC<
     return crLoaded && conformaResult
       ? conformaResult?.filter((rule: UIConformaData) => {
           return (
-            (!ruleFilter || rule.title.toLowerCase().indexOf(ruleFilter.toLowerCase()) !== -1) &&
+            textMatch(rule.title, ruleFilter) &&
             (!statusFilter.length || statusFilter.includes(rule.status)) &&
             (!componentFilter.length || componentFilter.includes(rule.component))
           );

--- a/src/components/Filter/utils/filter-utils.ts
+++ b/src/components/Filter/utils/filter-utils.ts
@@ -1,3 +1,4 @@
+import { textMatch } from '~/utils/text-filter-utils';
 import { PipelineRunLabel } from '../../../consts/pipelinerun';
 import { PipelineRunKind } from '../../../types';
 import { pipelineRunStatus } from '../../../utils/pipeline-utils';
@@ -21,9 +22,8 @@ export const filterPipelineRuns = (
       const runType = plr?.metadata.labels[PipelineRunLabel.PIPELINE_TYPE];
       return (
         (!name ||
-          plr.metadata.name.indexOf(name) >= 0 ||
-          plr.metadata.labels?.[PipelineRunLabel.COMPONENT]?.indexOf(name.trim().toLowerCase()) >=
-            0) &&
+          textMatch(plr.metadata.name, name) ||
+          textMatch(plr.metadata.labels?.[PipelineRunLabel.COMPONENT], name)) &&
         (!status.length || status.includes(pipelineRunStatus(plr))) &&
         (!type.length || type.includes(runType))
       );

--- a/src/components/Filter/utils/monitoredreleases-filter-utils.ts
+++ b/src/components/Filter/utils/monitoredreleases-filter-utils.ts
@@ -1,6 +1,7 @@
 import { PipelineRunLabel } from '~/consts/pipelinerun';
 import { getReleaseStatus } from '~/hooks/useReleaseStatus';
 import { MonitoredReleaseKind } from '~/types';
+import { textMatch } from '~/utils/text-filter-utils';
 
 export type MonitoredReleasesFilterState = {
   name: string;
@@ -50,7 +51,7 @@ export const filterMonitoredReleases = (
       (productVersion.includes('No product version') && !productVersionValue);
 
     return (
-      (!name || mr?.metadata?.name?.indexOf(name) >= 0) &&
+      textMatch(mr?.metadata?.name, name) &&
       (!status.length || status.includes(getReleaseStatus(mr))) &&
       applicationFilter &&
       (!releasePlan.length || releasePlan.includes(releasePlanName)) &&

--- a/src/components/Filter/utils/pipelineruns-filter-utils.ts
+++ b/src/components/Filter/utils/pipelineruns-filter-utils.ts
@@ -1,6 +1,7 @@
 import { PipelineRunLabel } from '~/consts/pipelinerun';
 import { PipelineRunKind } from '~/types';
 import { pipelineRunStatus } from '~/utils/pipeline-utils';
+import { textMatch } from '~/utils/text-filter-utils';
 
 export type PipelineRunsFilterState = {
   name: string;
@@ -21,11 +22,9 @@ export const filterPipelineRuns = (
     .filter((plr) => {
       const runType = plr?.metadata.labels[PipelineRunLabel.PIPELINE_TYPE];
       return (
-        (!name || plr.metadata.name.indexOf(name) >= 0) &&
+        textMatch(plr.metadata.name, name) &&
         (!componentName ||
-          plr.metadata.labels?.[PipelineRunLabel.COMPONENT]
-            ?.toLowerCase()
-            .indexOf(componentName.trim().toLowerCase()) >= 0) &&
+          textMatch(plr.metadata.labels?.[PipelineRunLabel.COMPONENT], componentName)) &&
         (!status.length || status.includes(pipelineRunStatus(plr))) &&
         (!type.length || type.includes(runType)) &&
         (!version?.length ||

--- a/src/components/IntegrationTests/ContextsField.tsx
+++ b/src/components/IntegrationTests/ContextsField.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { Bullseye, FormGroup, HelperText, Spinner } from '@patternfly/react-core';
 import { FieldArray, useField, FieldArrayRenderProps } from 'formik';
 import { getErrorState } from '~/shared/utils/error-utils';
+import { filterByText } from '~/utils/text-filter-utils';
 import { getFieldId } from '../../../src/shared/components/formik-fields/field-utils';
 import { useComponents } from '../../hooks/useComponents';
 import { useNamespace } from '../../shared/providers/Namespace';
@@ -42,9 +43,7 @@ const ContextsField: React.FC<IntegrationTestContextProps> = ({ heading, fieldNa
   // This holds the contexts that are filtered using the user input value.
   const filteredContexts = React.useMemo(() => {
     if (inputValue) {
-      const filtered = allContexts.filter((ctx) =>
-        ctx.name.toLowerCase().includes(inputValue.toLowerCase()),
-      );
+      const filtered = filterByText(allContexts, inputValue, (ctx) => ctx.name);
       return filtered.length
         ? filtered
         : [{ name: 'No results found', description: 'Please try another value.', selected: false }];

--- a/src/components/IntegrationTests/IntegrationTestsListView/IntegrationTestsListView.tsx
+++ b/src/components/IntegrationTests/IntegrationTestsListView/IntegrationTestsListView.tsx
@@ -12,6 +12,7 @@ import {
 import { FilterContext } from '~/components/Filter/generic/FilterContext';
 import { BaseTextFilterToolbar } from '~/components/Filter/toolbars/BaseTextFIlterToolbar';
 import { getErrorState } from '~/shared/utils/error-utils';
+import { filterByText } from '~/utils/text-filter-utils';
 import emptyStateImgUrl from '../../../assets/Integration-test.svg';
 import { useIntegrationTestScenarios } from '../../../hooks/useIntegrationTestScenarios';
 import { IntegrationTestScenarioModel } from '../../../models';
@@ -79,10 +80,7 @@ const IntegrationTestsListView: React.FC<React.PropsWithChildren> = () => {
   const { name: nameFilter } = filters;
 
   const filteredIntegrationTests = React.useMemo(
-    () =>
-      nameFilter
-        ? integrationTests.filter((test) => test.metadata.name.indexOf(nameFilter) !== -1)
-        : integrationTests,
+    () => filterByText(integrationTests, nameFilter, (t) => t.metadata.name),
     [nameFilter, integrationTests],
   );
 

--- a/src/components/Issues/IssuesListView/IssueListView.tsx
+++ b/src/components/Issues/IssuesListView/IssueListView.tsx
@@ -15,6 +15,7 @@ import AppEmptyState from '~/shared/components/empty-state/AppEmptyState';
 import FilteredEmptyState from '~/shared/components/empty-state/FilteredEmptyState';
 import { useNamespace } from '~/shared/providers/Namespace';
 import { getErrorState } from '~/shared/utils/error-utils';
+import { textMatch } from '~/utils/text-filter-utils';
 import { IssuesTableHeader, SortableIssuesHeaders } from './IssuesListHeader';
 import IssuesListRow from './IssuesListRow';
 
@@ -70,12 +71,11 @@ const IssueListView = () => {
   const filteredIssues = React.useMemo(
     () =>
       issues.filter((issue) => {
-        const matchesName =
-          !nameFilter || issue.title.toLowerCase().includes(nameFilter.toLowerCase());
-        const matchesStatus = !statusFilter?.length || statusFilter.includes(issue.state);
-        const matchesSeverity = !severityFilter?.length || severityFilter.includes(issue.severity);
-
-        return matchesName && matchesStatus && matchesSeverity;
+        return (
+          textMatch(issue.title, nameFilter) &&
+          (!statusFilter?.length || statusFilter.includes(issue.state)) &&
+          (!severityFilter?.length || severityFilter.includes(issue.severity))
+        );
       }),
     [issues, statusFilter, severityFilter, nameFilter],
   );

--- a/src/components/NamespaceList/NamespaceListView.tsx
+++ b/src/components/NamespaceList/NamespaceListView.tsx
@@ -12,6 +12,7 @@ import { QuestionCircleIcon } from '@patternfly/react-icons/dist/js/icons/questi
 import { GETTING_ACCESS_INTERNAL } from '~/consts/documentation';
 import { useInstanceVisibility } from '~/hooks/useUIInstance';
 import { KonfluxInstanceVisibility } from '~/types/konflux-public-info';
+import { filterByText } from '~/utils/text-filter-utils';
 import emptyStateImgUrl from '../../assets/namespace.svg';
 import { ExternalLink, Table, useDeepCompareMemoize } from '../../shared';
 import AppEmptyState from '../../shared/components/empty-state/AppEmptyState';
@@ -54,10 +55,10 @@ const NamespaceListView: React.FC<React.PropsWithChildren<unknown>> = () => {
   const { name: nameFilter } = filters;
 
   namespaces?.sort((app1, app2) => app1.metadata.name.localeCompare(app2.metadata.name));
-  const filteredNamespaces = React.useMemo(() => {
-    const lowerCaseNameFilter = nameFilter.toLowerCase();
-    return namespaces?.filter((app) => app.metadata.name.includes(lowerCaseNameFilter));
-  }, [nameFilter, namespaces]);
+  const filteredNamespaces = React.useMemo(
+    () => filterByText(namespaces ?? [], nameFilter, (ns) => ns.metadata.name),
+    [nameFilter, namespaces],
+  );
 
   if (!loaded) {
     return (

--- a/src/components/ReleaseService/ReleasePlan/ReleasePlanListView.tsx
+++ b/src/components/ReleaseService/ReleasePlan/ReleasePlanListView.tsx
@@ -5,6 +5,7 @@ import { BaseTextFilterToolbar } from '~/components/Filter/toolbars/BaseTextFIlt
 import { useApplications } from '~/hooks/useApplications';
 import { useLocalStorage } from '~/shared/hooks/useLocalStorage';
 import { getErrorState } from '~/shared/utils/error-utils';
+import { filterByText } from '~/utils/text-filter-utils';
 import { FULL_APPLICATION_TITLE } from '../../../consts/labels';
 import {
   RELEASE_PLAN_COLUMNS_DEFINITIONS,
@@ -61,7 +62,7 @@ const ReleasePlanListView: React.FC<React.PropsWithChildren<unknown>> = () => {
   }, [releasePlansLoaded, appLoaded, releasePlans, applications]);
 
   const filteredReleasePlans = React.useMemo(
-    () => releasePlanWithApplicationData.filter((r) => r.metadata.name.indexOf(nameFilter) !== -1),
+    () => filterByText(releasePlanWithApplicationData, nameFilter, (r) => r.metadata.name),
     [releasePlanWithApplicationData, nameFilter],
   );
 

--- a/src/components/ReleaseService/ReleasePlan/TriggerRelease/AddIssueSection/AddIssueSection.tsx
+++ b/src/components/ReleaseService/ReleasePlan/TriggerRelease/AddIssueSection/AddIssueSection.tsx
@@ -12,6 +12,7 @@ import { FieldArray, useField } from 'formik';
 import { FilterContext } from '~/components/Filter/generic/FilterContext';
 import { BaseTextFilterToolbar } from '~/components/Filter/toolbars/BaseTextFIlterToolbar';
 import { useDeepCompareMemoize } from '~/shared';
+import { textMatch } from '~/utils/text-filter-utils';
 import FilteredEmptyState from '../../../../../shared/components/empty-state/FilteredEmptyState';
 import { AddIssueModal, IssueType } from './AddIssueModal';
 import './AddIssueSection.scss';
@@ -44,7 +45,7 @@ export const AddIssueSection: React.FC<React.PropsWithChildren<AddIssueSectionPr
       issues && Array.isArray(issues)
         ? issues?.filter((bug) => {
             const key = isBug ? (bug as BugObject).id : (bug as CVEObject).key;
-            return !nameFilter || key?.toLowerCase().indexOf(nameFilter.toLowerCase()) >= 0;
+            return textMatch(key, nameFilter);
           })
         : [],
     [issues, nameFilter, isBug],

--- a/src/components/ReleaseService/ReleasePlanAdmission/ReleasePlanAdmissionListView.tsx
+++ b/src/components/ReleaseService/ReleasePlanAdmission/ReleasePlanAdmissionListView.tsx
@@ -3,6 +3,7 @@ import { Bullseye, PageSection, PageSectionVariants, Spinner } from '@patternfly
 import { FilterContext, FilterContextProvider } from '~/components/Filter/generic/FilterContext';
 import { BaseTextFilterToolbar } from '~/components/Filter/toolbars/BaseTextFIlterToolbar';
 import { getErrorState } from '~/shared/utils/error-utils';
+import { filterByText } from '~/utils/text-filter-utils';
 import { FULL_APPLICATION_TITLE } from '../../../consts/labels';
 import { useDocumentTitle } from '../../../hooks/useDocumentTitle';
 import { useReleasePlanAdmissions } from '../../../hooks/useReleasePlanAdmissions';
@@ -26,10 +27,7 @@ const ReleasePlanAdmissionListView: React.FC<React.PropsWithChildren<unknown>> =
   const { name: nameFilter } = filters;
 
   const filteredReleasePlanAdmission = React.useMemo(
-    () =>
-      releasePlanAdmissions
-        ? releasePlanAdmissions.filter((r) => r.metadata.name.indexOf(nameFilter) !== -1)
-        : [],
+    () => filterByText(releasePlanAdmissions ?? [], nameFilter, (r) => r.metadata.name),
     [releasePlanAdmissions, nameFilter],
   );
 

--- a/src/components/Releases/ReleaseArtifactsTab/index.tsx
+++ b/src/components/Releases/ReleaseArtifactsTab/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useParams } from 'react-router-dom';
 import { Bullseye, debounce, Spinner, Stack, StackItem, Title } from '@patternfly/react-core';
 import { SortByDirection } from '@patternfly/react-table';
+import { filterByText } from '~/utils/text-filter-utils';
 import { useRelease } from '../../../hooks/useReleases';
 import { useSearchParam } from '../../../hooks/useSearchParam';
 import { useSortedResources } from '../../../hooks/useSortedResources';
@@ -64,12 +65,10 @@ const ReleaseArtifactsTab: React.FC = () => {
     setNameFilter(n);
   }, 600);
 
-  const filteredArtifactsImages = React.useMemo(() => {
-    const lowerCaseNameFilter = nameFilter.toLowerCase();
-    return sortedArtifactsImages?.filter((image) =>
-      image.name?.toLowerCase().includes(lowerCaseNameFilter),
-    );
-  }, [nameFilter, sortedArtifactsImages]);
+  const filteredArtifactsImages = React.useMemo(
+    () => filterByText(sortedArtifactsImages ?? [], nameFilter, (image) => image.name),
+    [nameFilter, sortedArtifactsImages],
+  );
 
   if (!releaseLoaded) {
     return (

--- a/src/components/Releases/ReleasePipelineRunTab.tsx
+++ b/src/components/Releases/ReleasePipelineRunTab.tsx
@@ -17,6 +17,7 @@ import {
   getTenantCollectorProcessingFromRelease,
   getTenantProcessingFromRelease,
 } from '~/utils/release-utils';
+import { filterByText } from '~/utils/text-filter-utils';
 import { SESSION_STORAGE_KEYS } from '../../consts/constants';
 import { useVisibleColumns } from '../../hooks/useVisibleColumns';
 import ReleasePipelineListHeader from './ReleasePipelineList/ReleasePipelineListHeader';
@@ -130,11 +131,11 @@ const ReleasePipelineRunTab: React.FC = () => {
     ),
   ].filter(Boolean);
 
-  const filteredRuns = filters?.name
-    ? allRuns.filter((run) =>
-        run.pipelineRun.toLowerCase().includes((filters.name as string).toLowerCase()),
-      )
-    : allRuns;
+  const filteredRuns = filterByText(
+    allRuns,
+    filters?.name ? (filters.name as string) : '',
+    (run) => run.pipelineRun,
+  );
 
   const EmptyMessage = () => <FilteredEmptyState onClearFilters={onClearFilters} />;
 

--- a/src/components/Releases/ReleasesListView.tsx
+++ b/src/components/Releases/ReleasesListView.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useParams } from 'react-router-dom';
 import { PageSection, PageSectionVariants, Title, Spinner, Bullseye } from '@patternfly/react-core';
 import { SortByDirection } from '@patternfly/react-table';
+import { textMatch } from '~/utils/text-filter-utils';
 import { SESSION_STORAGE_KEYS } from '../../consts/constants';
 import { PipelineRunLabel } from '../../consts/pipelinerun';
 import {
@@ -92,14 +93,17 @@ const ReleasesListView: React.FC = () => {
   const { [filterType]: searchFilter } = filters;
 
   const filteredReleases = React.useMemo(() => {
-    if (isLoading && !releases.length) return [];
+    if (isLoading && !releases.length) {
+      return [];
+    }
+
     switch (filterType) {
       case FilterTypes.name:
-        return releases.filter((r) => r.metadata.name.indexOf(searchFilter) !== -1);
+        return releases.filter((r) => textMatch(r.metadata.name, searchFilter));
       case FilterTypes.releasePlan:
-        return releases.filter((r) => r.spec.releasePlan.indexOf(searchFilter) !== -1);
+        return releases.filter((r) => textMatch(r.spec.releasePlan, searchFilter));
       case FilterTypes.releaseSnapshot:
-        return releases.filter((r) => r.spec.snapshot.indexOf(searchFilter) !== -1);
+        return releases.filter((r) => textMatch(r.spec.snapshot, searchFilter));
       default:
         return releases;
     }

--- a/src/components/Secrets/SecretsListView/SecretsListView.tsx
+++ b/src/components/Secrets/SecretsListView/SecretsListView.tsx
@@ -6,6 +6,7 @@ import { FilterContext } from '~/components/Filter/generic/FilterContext';
 import { BaseTextFilterToolbar } from '~/components/Filter/toolbars/BaseTextFIlterToolbar';
 import { useDeepCompareMemoize } from '~/shared';
 import { getErrorState } from '~/shared/utils/error-utils';
+import { filterByText } from '~/utils/text-filter-utils';
 import secretEmptyStateIcon from '../../../assets/secret.svg';
 import { useSecrets } from '../../../hooks/useSecrets';
 import { SecretModel } from '../../../models';
@@ -27,10 +28,10 @@ const SecretsListView: React.FC = () => {
   const { name: nameFilter } = filters;
   const [canCreateRemoteSecret] = useAccessReviewForModel(SecretModel, 'create');
 
-  const filteredRemoteSecrets = React.useMemo(() => {
-    // apply name filter
-    return nameFilter ? secrets.filter((s) => s.metadata.name.indexOf(nameFilter) !== -1) : secrets;
-  }, [secrets, nameFilter]);
+  const filteredRemoteSecrets = React.useMemo(
+    () => filterByText(secrets, nameFilter, (s) => s.metadata.name),
+    [secrets, nameFilter],
+  );
 
   const createSecretButton = React.useMemo(() => {
     return (

--- a/src/components/SnapshotDetails/tabs/SnapshotComponentsList.tsx
+++ b/src/components/SnapshotDetails/tabs/SnapshotComponentsList.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { PageSection, PageSectionVariants, Text, Title } from '@patternfly/react-core';
 import { FilterContext } from '~/components/Filter/generic/FilterContext';
 import { BaseTextFilterToolbar } from '~/components/Filter/toolbars/BaseTextFIlterToolbar';
+import { filterByText } from '~/utils/text-filter-utils';
 import { Table, useDeepCompareMemoize } from '../../../shared';
 import FilteredEmptyState from '../../../shared/components/empty-state/FilteredEmptyState';
 import { ComponentKind } from '../../../types';
@@ -25,12 +26,7 @@ const SnapshotComponentsList: React.FC<React.PropsWithChildren<SnapshotComponent
   const { name: nameFilter } = filters;
 
   const filteredComponents = React.useMemo(
-    () =>
-      components.filter(
-        (component) =>
-          !nameFilter ||
-          (component.metadata && component.metadata?.name.indexOf(nameFilter.trim()) !== -1),
-      ),
+    () => filterByText(components, nameFilter, (c) => c.metadata?.name),
     [nameFilter, components],
   );
 

--- a/src/components/Snapshots/SnapshotsListView/SnapshotsListView.tsx
+++ b/src/components/Snapshots/SnapshotsListView/SnapshotsListView.tsx
@@ -22,6 +22,7 @@ import { FilterContext } from '~/components/Filter/generic/FilterContext';
 import { BaseTextFilterToolbar } from '~/components/Filter/toolbars/BaseTextFIlterToolbar';
 import { ExternalLink, useDeepCompareMemoize } from '~/shared';
 import { getErrorState } from '~/shared/utils/error-utils';
+import { textMatch } from '~/utils/text-filter-utils';
 import emptySnapshotImgUrl from '../../../assets/Snapshots.svg';
 import { LEARN_MORE_SNAPSHOTS } from '../../../consts/documentation';
 import { PipelineRunEventType, PipelineRunLabel } from '../../../consts/pipelinerun';
@@ -103,13 +104,15 @@ const SnapshotsListView: React.FC<React.PropsWithChildren<SnapshotsListViewProps
       ) {
         return false;
       }
-      if (nameFilter && !s.metadata.name.toLowerCase().includes(nameFilter.toLowerCase())) {
+      if (!textMatch(s.metadata.name, nameFilter)) {
         return false;
       }
-
-      const commitTitle =
-        s.metadata.annotations?.[PipelineRunLabel.TEST_SERVICE_COMMIT_TITLE]?.toLowerCase() ?? '';
-      if (commitMessageFilter && !commitTitle.includes(commitMessageFilter.toLowerCase())) {
+      if (
+        !textMatch(
+          s.metadata.annotations?.[PipelineRunLabel.TEST_SERVICE_COMMIT_TITLE],
+          commitMessageFilter,
+        )
+      ) {
         return false;
       }
       return true;

--- a/src/components/TaskRunListView/TaskRunListView.tsx
+++ b/src/components/TaskRunListView/TaskRunListView.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Bullseye, EmptyState, EmptyStateBody, Spinner } from '@patternfly/react-core';
 import { useTaskRunsForPipelineRuns } from '~/hooks/useTaskRunsV2';
+import { textMatch } from '~/utils/text-filter-utils';
 import { Table, useDeepCompareMemoize } from '../../shared';
 import FilteredEmptyState from '../../shared/components/empty-state/FilteredEmptyState';
 import { getErrorState } from '../../shared/utils/error-utils';
@@ -35,14 +36,11 @@ const TaskRunListView: React.FC<React.PropsWithChildren<Props>> = ({
   // TaskRuns are already sorted by useTaskRunsForPipelineRuns, no need to re-sort
   const filteredTaskRun = React.useMemo(
     () =>
-      nameFilter
-        ? taskRuns.filter(
-            (taskrun) =>
-              taskrun.metadata.name.indexOf(nameFilter) !== -1 ||
-              (taskrun.spec?.taskRef?.name &&
-                taskrun.spec?.taskRef?.name?.indexOf(nameFilter) !== -1),
-          )
-        : taskRuns,
+      taskRuns.filter(
+        (taskrun) =>
+          textMatch(taskrun.metadata.name, nameFilter) ||
+          textMatch(taskrun.spec?.taskRef?.name, nameFilter),
+      ),
     [nameFilter, taskRuns],
   );
 

--- a/src/components/UserAccess/UserAccessListView.tsx
+++ b/src/components/UserAccess/UserAccessListView.tsx
@@ -9,6 +9,7 @@ import {
 } from '@patternfly/react-core';
 import { USER_ACCESS_GRANT_PAGE } from '@routes/paths';
 import { getErrorState } from '~/shared/utils/error-utils';
+import { textMatch } from '~/utils/text-filter-utils';
 import emptyStateImgUrl from '../../assets/Integration-test.svg';
 import { useRoleBindings } from '../../hooks/useRoleBindings';
 import { RoleBindingModel } from '../../models';
@@ -75,9 +76,7 @@ export const UserAccessListView: React.FC<React.PropsWithChildren<unknown>> = ()
       roleBindings.filter(
         (rb) =>
           (!usernameFilter && !rb.subjects) ||
-          rb.subjects?.some((subject) =>
-            subject.name.toLowerCase().includes(usernameFilter.toLowerCase()),
-          ),
+          rb.subjects?.some((subject) => textMatch(subject.name, usernameFilter)),
       ),
     [roleBindings, usernameFilter],
   );

--- a/src/shared/components/ContextSwitcher/ContextSwitcher.tsx
+++ b/src/shared/components/ContextSwitcher/ContextSwitcher.tsx
@@ -85,10 +85,7 @@ export const ContextSwitcher: React.FC<React.PropsWithChildren<ContextSwitcherPr
   }, [menuItems, resourceType, selectedItem, recentItems]);
 
   const [filteredRecentItems, filteredAllItems] = React.useMemo(
-    () => [
-      filteredItems(recentMenuItems, searchText.toLowerCase()),
-      filteredItems(menuItems, searchText.toLowerCase()),
-    ],
+    () => [filteredItems(recentMenuItems, searchText), filteredItems(menuItems, searchText)],
     [menuItems, recentMenuItems, searchText],
   );
 

--- a/src/shared/components/ContextSwitcher/context-switcher-utils.tsx
+++ b/src/shared/components/ContextSwitcher/context-switcher-utils.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Divider, DrilldownMenu, Flex, MenuItem } from '@patternfly/react-core';
+import { textMatch } from '~/utils/text-filter-utils';
 import { ContextMenuItem } from './ContextSwitcher';
 
 export const ContextMenuListItem: React.FC<React.PropsWithChildren<{ item: ContextMenuItem }>> = ({
@@ -48,7 +49,7 @@ export const ContextMenuListItem: React.FC<React.PropsWithChildren<{ item: Conte
 export const filteredItems = (items: ContextMenuItem[], filter: string) => {
   const filtered: ContextMenuItem[] = [];
   items.forEach((item) => {
-    if (item.name.toLowerCase().includes(filter)) {
+    if (textMatch(item.name, filter)) {
       let filteredSubItems: ContextMenuItem[];
       if (item.subItems) {
         filteredSubItems = filteredItems(item.subItems, filter);

--- a/src/shared/components/component-select-menu/ComponentSelectMenu.tsx
+++ b/src/shared/components/component-select-menu/ComponentSelectMenu.tsx
@@ -12,6 +12,7 @@ import {
 import { useField } from 'formik';
 import { flatten, isArray } from 'lodash-es';
 import { CurrentComponentRef } from '~/types/secret';
+import { textMatch } from '~/utils/text-filter-utils';
 import SelectComponentsDropdown from './SelectComponnetsDropdown';
 
 import './ComponentSelectMenu.scss';
@@ -92,8 +93,7 @@ export const ComponentSelectMenu: React.FC<ComponentSelectMenuProps> = ({
   };
 
   const filteredOptions = React.useMemo(() => {
-    const query = searchQuery.toLowerCase();
-    const filterFn = (items: string[]) => items?.filter((i) => i.toLowerCase()?.includes(query));
+    const filterFn = (items: string[]) => items?.filter((i) => textMatch(i, searchQuery));
 
     if (isGrouped) {
       return Object.entries(options).reduce(

--- a/src/shared/components/dropdown/BasicDropdown.tsx
+++ b/src/shared/components/dropdown/BasicDropdown.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import {
+  Badge,
+  Divider,
+  HelperText,
+  HelperTextItem,
   Select,
   SelectList,
   SelectOption,
-  Badge,
-  HelperText,
-  HelperTextItem,
-  Divider,
   ValidatedOptions,
   MenuToggle,
   TextInputGroup,
@@ -17,6 +17,7 @@ import {
 import './BasicDropdown.scss';
 import { TimesIcon } from '@patternfly/react-icons/dist/esm/icons/times-icon';
 import { NO_RESULTS } from '~/consts/constants';
+import { filterByText } from '~/utils/text-filter-utils';
 
 export type DropdownItemObject = {
   key: string;
@@ -61,9 +62,7 @@ const BasicDropdown: React.FC<BasicDropdownProps> = ({
     let newItems = items;
 
     if (filterValue) {
-      newItems = items.filter((item) =>
-        item.value.toLowerCase().includes(filterValue.toLowerCase()),
-      );
+      newItems = filterByText(items, filterValue, (item) => item.value);
 
       // When no options are found after filtering, display 'No results found'
       if (!newItems.length) {


### PR DESCRIPTION
## Fixes 
[KFLUXUI-1197](https://redhat.atlassian.net/browse/KFLUXUI-1197)


## Description
Replaces manual and inconsistent trimming, lowercasing with the new text filtering util, which also adds the ability to use fuzzy sequential search.

Depends on https://github.com/konflux-ci/konflux-ui/pull/817, where more info is provided.


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):



[KFLUXUI-1197]: https://redhat.atlassian.net/browse/KFLUXUI-1197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized text filtering across list views, selection menus, dropdowns and context switcher components by delegating matching to shared text-filter utilities, unifying behavior for empty queries, casing, and matching semantics for a more consistent search/filter experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->