### PR TITLE
chore(KFLUXUI-1176): collapse/expand option added to logs step

### DIFF
--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.scss
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.scss
@@ -39,6 +39,73 @@
     width: 100%; // Ensure content respects container width
   }
 
+  &__content--sections {
+    overflow-y: auto;
+  }
+
+  &__section {
+    border-bottom: 1px solid var(--pf-v5-global--BorderColor--100);
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  &__section-header {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    padding: var(--pf-v5-global--spacer--sm) var(--pf-v5-global--spacer--md);
+    border: none;
+    background: var(--pf-v5-global--BackgroundColor--100);
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+
+    &:hover {
+      background: var(--pf-v5-global--BackgroundColor--200);
+    }
+  }
+
+  &__section-heading {
+    min-width: 0;
+    font-weight: var(--pf-v5-global--FontWeight--bold);
+  }
+
+  &__section-toggle-icon {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    color: var(--pf-v5-global--Color--200);
+  }
+
+  &__section-body {
+    flex: 0 0 auto;
+    padding: 0 var(--pf-v5-global--spacer--md) var(--pf-v5-global--spacer--md);
+  }
+
+  &__content--sections-single {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  &__content--sections-single .log-viewer__section {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+  }
+
+  &__content--sections-single .log-viewer__section-body {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+  }
+
   &__resume-stream-button-wrapper {
     position: absolute;
     bottom: 0;

--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
@@ -20,6 +20,8 @@ import {
   ExpandIcon,
   OutlinedPlayCircleIcon,
 } from '@patternfly/react-icons/dist/esm/icons';
+import { AngleDownIcon } from '@patternfly/react-icons/dist/esm/icons/angle-down-icon';
+import { AngleUpIcon } from '@patternfly/react-icons/dist/esm/icons/angle-up-icon';
 import {
   LogViewerSearch,
   LogViewerContext,
@@ -46,8 +48,28 @@ import './LogViewer.scss';
 // eslint-disable-next-line no-control-regex
 const ANSI_ESCAPE_REGEX = /\u001b\[[0-9;]*m/g;
 
+/** Virtualized row height matches `VirtualizedLogContent` default estimate. */
+const SECTION_LOG_LINE_PX = 20;
+const SECTION_LOG_MIN_PX = 64;
+const SECTION_LOG_MAX_PX = 440;
+/** Gutter / chrome inside the log viewport (not line text). */
+const SECTION_LOG_CHROME_PX = 24;
+
+/** Tight viewport for few lines; caps long output so each step scrolls internally. */
+function getSectionLogViewportHeightPx(logText: string): number {
+  const lineCount = Math.max(1, logText.split('\n').length);
+  const contentPx = lineCount * SECTION_LOG_LINE_PX + SECTION_LOG_CHROME_PX;
+  return Math.round(Math.min(SECTION_LOG_MAX_PX, Math.max(SECTION_LOG_MIN_PX, contentPx)));
+}
+
+export type LogSection = { id: string; title: string; data: string };
+
 export type Props = {
   showSearch?: boolean;
+  /** When set, one block per step (container) with its own heading and collapsible body. */
+  logSections?: LogSection[];
+  /** Step (container) currently in progress; unfolded by default while others start folded. */
+  inProgressSectionId?: string;
   data: string;
   allowAutoScroll?: boolean;
   downloadAllLabel?: string;
@@ -64,6 +86,8 @@ export type Props = {
 
 const LogViewer: React.FC<Props> = ({
   showSearch = true,
+  logSections,
+  inProgressSectionId,
   allowAutoScroll,
   data = '',
   downloadAllLabel,
@@ -76,6 +100,45 @@ const LogViewer: React.FC<Props> = ({
   const taskName = taskRun?.spec.taskRef?.name ?? taskRun?.metadata.name;
   const [logTheme, setLogTheme] = useLogViewerTheme();
   const themeCheckboxId = React.useId();
+
+  const sectionCount = logSections?.length ?? 0;
+  const useSectionedLayout = sectionCount > 0;
+  const singleSectionLayout = sectionCount === 1;
+  const multiSectionLayout = sectionCount > 1;
+  const showSearchToolbar = showSearch && (!useSectionedLayout || singleSectionLayout);
+
+  const getDefaultCollapsedSectionIds = React.useCallback((): ReadonlySet<string> => {
+    const defaultCollapsed = new Set((logSections ?? []).map((section) => section.id));
+    if (inProgressSectionId) {
+      defaultCollapsed.delete(inProgressSectionId);
+    }
+    return defaultCollapsed;
+  }, [logSections, inProgressSectionId]);
+
+  const [collapsedSectionIds, setCollapsedSectionIds] = React.useState<ReadonlySet<string>>(
+    getDefaultCollapsedSectionIds,
+  );
+  const [hasUserToggledSections, setHasUserToggledSections] = React.useState(false);
+
+  const toggleSectionCollapsed = React.useCallback((sectionId: string) => {
+    setHasUserToggledSections(true);
+    setCollapsedSectionIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(sectionId)) {
+        next.delete(sectionId);
+      } else {
+        next.add(sectionId);
+      }
+      return next;
+    });
+  }, []);
+
+  React.useEffect(() => {
+    if (!useSectionedLayout || hasUserToggledSections) {
+      return;
+    }
+    setCollapsedSectionIds(getDefaultCollapsedSectionIds());
+  }, [useSectionedLayout, hasUserToggledSections, getDefaultCollapsedSectionIds]);
 
   // Auto-scroll and resume button logic
   const { autoScroll, showResumeStreamButton, handleScroll, handleResumeClick } =
@@ -90,7 +153,15 @@ const LogViewer: React.FC<Props> = ({
     return data.replace(/\r/g, '\n').replace(ANSI_ESCAPE_REGEX, '');
   }, [data]);
 
-  const lines = React.useMemo(() => processedData.split('\n'), [processedData]);
+  const lines = React.useMemo(() => {
+    if (multiSectionLayout) {
+      return processedData.split('\n');
+    }
+    if (singleSectionLayout && logSections?.[0]) {
+      return logSections[0].data.replace(/\r/g, '\n').replace(ANSI_ESCAPE_REGEX, '').split('\n');
+    }
+    return processedData.split('\n');
+  }, [multiSectionLayout, singleSectionLayout, logSections, processedData]);
 
   // Search state and context management
   const { logViewerContextValue, toolbarContextValue, scrolledRow } = useLogViewerSearch({
@@ -128,6 +199,16 @@ const LogViewer: React.FC<Props> = ({
   const [viewerHeight, setViewerHeight] = React.useState<number | undefined>(undefined);
 
   React.useEffect(() => {
+    if (multiSectionLayout) {
+      setViewerHeight(undefined);
+      return undefined;
+    }
+
+    if (singleSectionLayout && logSections?.[0] && collapsedSectionIds.has(logSections[0].id)) {
+      setViewerHeight(undefined);
+      return undefined;
+    }
+
     const updateHeight = (immediate = false) => {
       if (containerRef.current) {
         const measured = containerRef.current.clientHeight;
@@ -157,7 +238,7 @@ const LogViewer: React.FC<Props> = ({
       window.removeEventListener('resize', debouncedUpdateHeight);
       debouncedUpdateHeight.cancel();
     };
-  }, [isFullscreen]);
+  }, [isFullscreen, multiSectionLayout, singleSectionLayout, logSections, collapsedSectionIds]);
 
   return (
     <LogViewerContext.Provider value={logViewerContextValue}>
@@ -184,7 +265,7 @@ const LogViewer: React.FC<Props> = ({
                     <FeatureFlagIndicator flags={['kubearchive-logs', 'taskruns-kubearchive']} />
                   </ToolbarItem>
                 </ToolbarGroup>
-                {showSearch && (
+                {showSearchToolbar && (
                   <ToolbarGroup>
                     <ToolbarItem>
                       <LogViewerSearch placeholder="Search" minSearchChars={0} />
@@ -268,16 +349,70 @@ const LogViewer: React.FC<Props> = ({
           </Banner>
 
           {/* Log Viewer */}
-          <div ref={containerRef} className="log-viewer__content">
-            {viewerHeight && (
-              <VirtualizedLogViewer
-                data={processedData}
-                height={viewerHeight}
-                scrollToRow={scrolledRow}
-                onScroll={handleScroll}
-              />
-            )}
-          </div>
+          {useSectionedLayout ? (
+            <div
+              className={classNames(
+                'log-viewer__content',
+                'log-viewer__content--sections',
+                singleSectionLayout && 'log-viewer__content--sections-single',
+              )}
+            >
+              {(logSections ?? []).map((sec) => {
+                const sectionData = sec.data.replace(/\r/g, '\n').replace(ANSI_ESCAPE_REGEX, '');
+                const isCollapsed = collapsedSectionIds.has(sec.id);
+                const showViewer = multiSectionLayout || viewerHeight;
+                const sectionContentHeightPx = getSectionLogViewportHeightPx(sectionData);
+                const sectionViewerHeightPx = multiSectionLayout
+                  ? sectionContentHeightPx
+                  : Math.min(viewerHeight ?? SECTION_LOG_MAX_PX, sectionContentHeightPx);
+
+                return (
+                  <div key={sec.id} className="log-viewer__section">
+                    <button
+                      type="button"
+                      className="log-viewer__section-header"
+                      onClick={() => toggleSectionCollapsed(sec.id)}
+                      aria-expanded={!isCollapsed}
+                      aria-controls={`log-viewer-section-body-${sec.id}`}
+                      data-test={`log-section-toggle-${sec.id}`}
+                    >
+                      <span className="log-viewer__section-heading">{sec.title}</span>
+                      <span className="log-viewer__section-toggle-icon" aria-hidden="true">
+                        {isCollapsed ? <AngleDownIcon /> : <AngleUpIcon />}
+                      </span>
+                    </button>
+                    {!isCollapsed && (
+                      <div
+                        id={`log-viewer-section-body-${sec.id}`}
+                        ref={singleSectionLayout ? containerRef : undefined}
+                        className="log-viewer__section-body"
+                      >
+                        {showViewer && (
+                          <VirtualizedLogViewer
+                            data={sectionData}
+                            height={sectionViewerHeightPx}
+                            scrollToRow={singleSectionLayout ? scrolledRow : undefined}
+                            onScroll={handleScroll}
+                          />
+                        )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div ref={containerRef} className="log-viewer__content">
+              {viewerHeight && (
+                <VirtualizedLogViewer
+                  data={processedData}
+                  height={viewerHeight}
+                  scrollToRow={scrolledRow}
+                  onScroll={handleScroll}
+                />
+              )}
+            </div>
+          )}
 
           {/* Footer */}
           {showResumeStreamButton && (

--- a/src/shared/components/pipeline-run-logs/logs/Logs.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/Logs.tsx
@@ -12,7 +12,7 @@ import { PodModel } from '../../../../models/pod';
 import { TaskRunKind } from '../../../../types';
 import { PodKind, ContainerSpec, ContainerStatus } from '../../types';
 import { containerToLogSourceStatus, LOG_SOURCE_TERMINATED } from '../utils';
-import LogViewer, { type Props as LogViewerProps } from './LogViewer';
+import LogViewer, { type LogSection, type Props as LogViewerProps } from './LogViewer';
 
 type LogSources = { [containerName: string]: string };
 
@@ -191,6 +191,30 @@ const Logs: React.FC<LogsProps> = ({
     [logSources, containers],
   );
 
+  const logSections: LogSection[] | undefined = React.useMemo(() => {
+    if (containers.length === 0) {
+      return undefined;
+    }
+    return containers.map((container) => ({
+      id: container.name,
+      title: container.name,
+      data: logSources[container.name] || '',
+    }));
+  }, [containers, logSources]);
+
+  const inProgressSectionId = React.useMemo<string | undefined>(() => {
+    if (containers.length === 0) {
+      return undefined;
+    }
+    const allStatuses: ContainerStatus[] = resource?.status?.containerStatuses ?? [];
+    const inProgressContainer = containers.find((container) => {
+      const status = allStatuses.find((c) => c.name === container.name);
+      return containerToLogSourceStatus(status) !== LOG_SOURCE_TERMINATED;
+    });
+
+    return inProgressContainer?.name;
+  }, [containers, resource?.status?.containerStatuses]);
+
   const allLogsTerminated = React.useMemo<boolean>(() => {
     if (containers.length === 0) return false;
 
@@ -217,6 +241,8 @@ const Logs: React.FC<LogsProps> = ({
   return (
     <LogViewer
       data={formattedLogs}
+      logSections={logSections}
+      inProgressSectionId={inProgressSectionId}
       allowAutoScroll={allowAutoScroll && !allLogsTerminated}
       onScroll={onScroll}
       downloadAllLabel={downloadAllLabel}

--- a/src/shared/components/pipeline-run-logs/logs/__tests__/LogViewer.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/__tests__/LogViewer.spec.tsx
@@ -181,6 +181,73 @@ describe('LogViewer Integration Tests', () => {
     });
   });
 
+  describe('Multi-step logs (logSections)', () => {
+    it('should hide search and keep sections folded by default', () => {
+      render(
+        <LogViewer
+          {...defaultProps}
+          showSearch
+          logSections={[
+            { id: 'a', title: 'step-a', data: 'one' },
+            { id: 'b', title: 'step-b', data: 'two' },
+          ]}
+          data="merged"
+        />,
+      );
+
+      expect(screen.queryByPlaceholderText('Search')).not.toBeInTheDocument();
+      const toggleA = screen.getByTestId('log-section-toggle-a');
+      const toggleB = screen.getByTestId('log-section-toggle-b');
+      expect(toggleA).toHaveAttribute('aria-expanded', 'false');
+      expect(toggleB).toHaveAttribute('aria-expanded', 'false');
+      expect(document.querySelectorAll('.pf-v5-c-log-viewer__main').length).toBe(0);
+    });
+
+    it('should unfold only in-progress section by default and allow toggling', async () => {
+      const user = userEvent.setup();
+      render(
+        <LogViewer
+          {...defaultProps}
+          inProgressSectionId="a"
+          logSections={[
+            { id: 'a', title: 'step-a', data: 'line-a' },
+            { id: 'b', title: 'step-b', data: 'line-b' },
+          ]}
+          data="merged"
+        />,
+      );
+
+      const logMainCount = () => document.querySelectorAll('.pf-v5-c-log-viewer__main').length;
+      expect(logMainCount()).toBe(1);
+
+      const toggleA = screen.getByTestId('log-section-toggle-a');
+      const toggleB = screen.getByTestId('log-section-toggle-b');
+      expect(toggleA).toHaveAttribute('aria-expanded', 'true');
+      expect(toggleB).toHaveAttribute('aria-expanded', 'false');
+      await user.click(toggleA);
+      expect(toggleA).toHaveAttribute('aria-expanded', 'false');
+      expect(logMainCount()).toBe(0);
+
+      await user.click(toggleA);
+      expect(toggleA).toHaveAttribute('aria-expanded', 'true');
+      expect(logMainCount()).toBe(1);
+    });
+
+    it('should keep search for a single step section', () => {
+      render(
+        <LogViewer
+          {...defaultProps}
+          showSearch
+          logSections={[{ id: 'only', title: 'only-step', data: 'x\ny' }]}
+          data="merged"
+        />,
+      );
+
+      expect(screen.getByPlaceholderText('Search')).toBeInTheDocument();
+      expect(screen.getByTestId('log-section-toggle-only')).toBeInTheDocument();
+    });
+  });
+
   describe('ANSI escape code processing', () => {
     it('should strip ANSI escape codes from log data', () => {
       const dataWithAnsi = '\x1b[32mSuccess\x1b[0m\n\x1b[31mError\x1b[0m\nPlain text';

--- a/src/shared/components/pipeline-run-logs/logs/__tests__/Logs.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/__tests__/Logs.spec.tsx
@@ -138,6 +138,11 @@ describe('Logs', () => {
           data: expect.any(String),
           allowAutoScroll: true,
           onScroll: undefined,
+          inProgressSectionId: 'container1',
+          logSections: [
+            { id: 'container1', title: 'container1', data: '' },
+            { id: 'container2', title: 'container2', data: '' },
+          ],
         }),
       );
     });
@@ -169,6 +174,7 @@ describe('Logs', () => {
         expect(mockLogViewer).toHaveBeenCalledWith(
           expect.objectContaining({
             data: '',
+            logSections: undefined,
           }),
         );
       });


### PR DESCRIPTION
[KFLUXUI-1176](https://redhat.atlassian.net/browse/KFLUXUI-1176)


## Description
This pull request improves the task log viewer by showing one block per Tekton step (pod container) instead of a single merged stream, adds expand/collapse on each step heading, sizes each step’s log viewport from how much text is present (with sensible min/max bounds).


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

### Before
<img width="1432" height="681" alt="image" src="https://github.com/user-attachments/assets/204c4dfe-c384-4253-bb09-f783eff9e7a3" />


<hr>

### After

<img width="1423" height="589" alt="image" src="https://github.com/user-attachments/assets/7cb03a5c-2db9-4fca-934f-21017fc2b3c8" />

https://github.com/user-attachments/assets/efd997de-32e6-47d3-a416-41911403bc52

**InProgress steps will be unfolded & completed tasks will remain folded.**

https://github.com/user-attachments/assets/4d83a181-ad04-46d1-9011-68505477a857




## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


[KFLUXUI-1176]: https://redhat.atlassian.net/browse/KFLUXUI-1176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Log viewer shows logs in collapsible sections per step/container; the active/in-progress section is expanded by default and user toggles persist. Search visibility adapts between multi- and single-section layouts.
* **Style**
  * Added styling for sectioned layouts, single-section mode, headers, separators, toggle icons, and scroll/overflow behavior.
* **Tests**
  * Added multi-section tests and updated existing tests to cover new section props and interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->