### PR TITLE
feat(KFLUXUI-1224): [Virtualized Log Viewer] keyboard navigation with react-hotkeys-hook and shortcuts popover

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -23,7 +23,7 @@ export default {
   },
   roots: ['<rootDir>/src/'],
   transformIgnorePatterns: [
-    '/node_modules/(?!@patternfly|uuid|lodash-es|@popperjs|i18next|d3|d3-array|delaunator|robust-predicates|internmap|react-dnd|react-dnd-html5-backend|dnd-core|@react-dnd|p-limit|yocto-queue)',
+    '/node_modules/(?!@patternfly|uuid|lodash-es|@popperjs|i18next|d3|d3-array|delaunator|robust-predicates|internmap|react-dnd|react-dnd-html5-backend|dnd-core|@react-dnd|p-limit|yocto-queue|react-hotkeys-hook)',
   ],
   collectCoverageFrom: [
     'src/**/*.{js,jsx,ts,tsx}',

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^18.3.1",
+    "react-hotkeys-hook": "^5.2.4",
     "react-i18next": "15.0.1",
     "react-router-dom": "6.25.1",
     "sanitize-html": "^2.13.0",

--- a/src/shared/components/keyboard-shortcut-hint/KeyboardShortcutHint.scss
+++ b/src/shared/components/keyboard-shortcut-hint/KeyboardShortcutHint.scss
@@ -1,0 +1,57 @@
+.keyboard-shortcut-hint {
+  padding: var(--pf-v5-global--spacer--sm);
+
+  &__title {
+    font-weight: var(--pf-v5-global--FontWeight--bold);
+    margin-bottom: var(--pf-v5-global--spacer--sm);
+    font-size: var(--pf-v5-global--FontSize--sm);
+  }
+
+  &__entry {
+    padding: var(--pf-v5-global--spacer--xs) 0;
+    align-items: center;
+  }
+
+  &__keys {
+    text-align: right;
+    white-space: nowrap;
+    padding-right: var(--pf-v5-global--spacer--md);
+  }
+
+  &__description {
+    font-size: var(--pf-v5-global--FontSize--sm);
+    color: var(--pf-v5-global--Color--200);
+  }
+
+  &__helper-text {
+    margin-top: var(--pf-v5-global--spacer--sm);
+    font-size: var(--pf-v5-global--FontSize--xs);
+    color: var(--pf-v5-global--Color--200);
+    font-style: italic;
+  }
+}
+
+.keyboard-shortcut {
+  &__command {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+  }
+
+  &__key {
+    display: inline-block;
+    padding: 2px 6px;
+    font-size: var(--pf-v5-global--FontSize--xs);
+    font-family: inherit;
+    border: 1px solid var(--pf-v5-global--BorderColor--100);
+    border-radius: 3px;
+    background-color: var(--pf-v5-global--BackgroundColor--200);
+    line-height: 1.4;
+  }
+
+  &__separator {
+    font-size: var(--pf-v5-global--FontSize--xs);
+    color: var(--pf-v5-global--Color--200);
+    padding: 0 1px;
+  }
+}

--- a/src/shared/components/keyboard-shortcut-hint/KeyboardShortcutHint.tsx
+++ b/src/shared/components/keyboard-shortcut-hint/KeyboardShortcutHint.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { Grid, GridItem } from '@patternfly/react-core';
+import { ShortcutCommand } from './ShortcutCommand';
+import './KeyboardShortcutHint.scss';
+
+export interface ShortcutEntry {
+  keys: string;
+  macKeys?: string;
+  description: string;
+}
+
+interface KeyboardShortcutHintProps {
+  shortcuts: ShortcutEntry[];
+  title?: string;
+  helperText?: string;
+}
+
+const isMac = (): boolean => {
+  if (typeof navigator === 'undefined') return false;
+  return /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
+};
+
+export const KeyboardShortcutHint: React.FC<KeyboardShortcutHintProps> = ({
+  shortcuts,
+  title,
+  helperText,
+}) => {
+  return (
+    <div className="keyboard-shortcut-hint">
+      {title && <div className="keyboard-shortcut-hint__title">{title}</div>}
+      {shortcuts.map((shortcut) => {
+        const displayKeys = isMac() && shortcut.macKeys ? shortcut.macKeys : shortcut.keys;
+        return (
+          <Grid key={shortcut.keys} className="keyboard-shortcut-hint__entry">
+            <GridItem span={5} className="keyboard-shortcut-hint__keys">
+              <ShortcutCommand keys={displayKeys} />
+            </GridItem>
+            <GridItem span={7} className="keyboard-shortcut-hint__description">
+              {shortcut.description}
+            </GridItem>
+          </Grid>
+        );
+      })}
+      {helperText && <div className="keyboard-shortcut-hint__helper-text">{helperText}</div>}
+    </div>
+  );
+};

--- a/src/shared/components/keyboard-shortcut-hint/ShortcutCommand.tsx
+++ b/src/shared/components/keyboard-shortcut-hint/ShortcutCommand.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import './KeyboardShortcutHint.scss';
+
+interface ShortcutCommandProps {
+  keys: string; // e.g. "Shift+?" or "PageUp" or "Fn+ArrowUp"
+}
+
+export const ShortcutCommand: React.FC<ShortcutCommandProps> = ({ keys }) => {
+  const segments = keys.split('+').map((s) => s.trim());
+  return (
+    <span className="keyboard-shortcut__command">
+      {segments.map((segment, index) => (
+        <React.Fragment key={`${index}-${segment}`}>
+          {index > 0 && <span className="keyboard-shortcut__separator">+</span>}
+          <kbd className="keyboard-shortcut__key">{segment}</kbd>
+        </React.Fragment>
+      ))}
+    </span>
+  );
+};

--- a/src/shared/components/keyboard-shortcut-hint/__tests__/KeyboardShortcutHint.spec.tsx
+++ b/src/shared/components/keyboard-shortcut-hint/__tests__/KeyboardShortcutHint.spec.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react';
+import { KeyboardShortcutHint, ShortcutEntry } from '../KeyboardShortcutHint';
+import { ShortcutCommand } from '../ShortcutCommand';
+
+const sampleShortcuts: ShortcutEntry[] = [
+  { keys: 'PageUp', description: 'Scroll up one page' },
+  { keys: 'PageDown', description: 'Scroll down one page' },
+  { keys: 'Shift+?', description: 'Show keyboard shortcuts' },
+];
+
+describe('KeyboardShortcutHint', () => {
+  const originalUserAgent = navigator.userAgent;
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: originalUserAgent,
+      configurable: true,
+    });
+  });
+
+  it('should render all provided shortcuts', () => {
+    render(<KeyboardShortcutHint shortcuts={sampleShortcuts} />);
+    expect(screen.getByText('Scroll up one page')).toBeInTheDocument();
+    expect(screen.getByText('Scroll down one page')).toBeInTheDocument();
+    expect(screen.getByText('Show keyboard shortcuts')).toBeInTheDocument();
+  });
+
+  it('should render title when provided', () => {
+    render(<KeyboardShortcutHint shortcuts={sampleShortcuts} title="Keyboard Shortcuts" />);
+    expect(screen.getByText('Keyboard Shortcuts')).toBeInTheDocument();
+  });
+
+  it('should not render title when not provided', () => {
+    const { container } = render(<KeyboardShortcutHint shortcuts={sampleShortcuts} />);
+    expect(container.querySelector('.keyboard-shortcut-hint__title')).toBeNull();
+  });
+
+  it('should render helperText when provided', () => {
+    render(
+      <KeyboardShortcutHint shortcuts={sampleShortcuts} helperText="Focus the log area first" />,
+    );
+    expect(screen.getByText('Focus the log area first')).toBeInTheDocument();
+  });
+
+  it('should not render helperText when not provided', () => {
+    const { container } = render(<KeyboardShortcutHint shortcuts={sampleShortcuts} />);
+    expect(container.querySelector('.keyboard-shortcut-hint__helper-text')).toBeNull();
+  });
+
+  it('should show macKeys on Mac', () => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+      configurable: true,
+    });
+
+    const shortcuts: ShortcutEntry[] = [{ keys: 'Ctrl+C', macKeys: 'Cmd+C', description: 'Copy' }];
+
+    render(<KeyboardShortcutHint shortcuts={shortcuts} />);
+    expect(screen.getByText('Cmd')).toBeInTheDocument();
+    expect(screen.queryByText('Ctrl')).toBeNull();
+  });
+
+  it('should show regular keys on non-Mac', () => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+      configurable: true,
+    });
+
+    const shortcuts: ShortcutEntry[] = [{ keys: 'Ctrl+C', macKeys: 'Cmd+C', description: 'Copy' }];
+
+    render(<KeyboardShortcutHint shortcuts={shortcuts} />);
+    expect(screen.getByText('Ctrl')).toBeInTheDocument();
+    expect(screen.queryByText('Cmd')).toBeNull();
+  });
+});
+
+describe('ShortcutCommand', () => {
+  it('should render a single key in a kbd element', () => {
+    render(<ShortcutCommand keys="PageUp" />);
+    const kbd = screen.getByText('PageUp');
+    expect(kbd).toBeInTheDocument();
+    expect(kbd.tagName).toBe('KBD');
+  });
+
+  it('should render compound keys with separator', () => {
+    render(<ShortcutCommand keys="Shift+?" />);
+    expect(screen.getByText('Shift')).toBeInTheDocument();
+    expect(screen.getByText('?')).toBeInTheDocument();
+    expect(screen.getByText('+')).toBeInTheDocument();
+
+    const kbdElements = screen.getByText('Shift').closest('.keyboard-shortcut__command');
+    expect(kbdElements).toBeInTheDocument();
+
+    const shiftKbd = screen.getByText('Shift');
+    const questionKbd = screen.getByText('?');
+    expect(shiftKbd.tagName).toBe('KBD');
+    expect(questionKbd.tagName).toBe('KBD');
+  });
+});

--- a/src/shared/components/keyboard-shortcut-hint/index.ts
+++ b/src/shared/components/keyboard-shortcut-hint/index.ts
@@ -1,0 +1,3 @@
+export { ShortcutCommand } from './ShortcutCommand';
+export { KeyboardShortcutHint } from './KeyboardShortcutHint';
+export type { ShortcutEntry } from './KeyboardShortcutHint';

--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
@@ -7,6 +7,7 @@ import {
   Checkbox,
   Flex,
   FlexItem,
+  Popover,
   Spinner,
   Toolbar,
   ToolbarContent,
@@ -18,6 +19,7 @@ import {
   CompressIcon,
   DownloadIcon,
   ExpandIcon,
+  OutlinedKeyboardIcon,
   OutlinedPlayCircleIcon,
 } from '@patternfly/react-icons/dist/esm/icons';
 import {
@@ -30,6 +32,10 @@ import { saveAs } from 'file-saver';
 import { debounce } from 'lodash-es';
 import { v4 as uuidv4 } from 'uuid';
 import { FeatureFlagIndicator } from '~/feature-flags/FeatureFlagIndicator';
+import {
+  KeyboardShortcutHint,
+  type ShortcutEntry,
+} from '~/shared/components/keyboard-shortcut-hint';
 import { useAutoScrollWithResume } from '~/shared/components/pipeline-run-logs/logs/useAutoScrollWithResume';
 import { useLogViewerSearch } from '~/shared/components/pipeline-run-logs/logs/useLogViewerSearch';
 import { LoadingInline } from '~/shared/components/status-box/StatusBox';
@@ -40,6 +46,15 @@ import LogsTaskDuration from './LogsTaskDuration';
 import { useLogViewerTheme } from './useLogViewerTheme';
 
 import './LogViewer.scss';
+
+const LOG_VIEWER_SHORTCUTS: ShortcutEntry[] = [
+  { keys: 'Arrow Up', macKeys: 'Arrow Up', description: 'Scroll up one line' },
+  { keys: 'Arrow Down', macKeys: 'Arrow Down', description: 'Scroll down one line' },
+  { keys: 'PageUp', macKeys: 'Fn + Arrow Up', description: 'Scroll up one page' },
+  { keys: 'PageDown', macKeys: 'Fn + Arrow Down', description: 'Scroll down one page' },
+  { keys: 'Home', macKeys: 'Fn + Arrow Left', description: 'Scroll to top' },
+  { keys: 'End', macKeys: 'Fn + Arrow Right', description: 'Scroll to bottom' },
+];
 
 // ANSI escape code regex for removing color codes from terminal output
 // ESC character (\u001b) is a control character but necessary for ANSI escape sequences
@@ -101,6 +116,7 @@ const LogViewer: React.FC<Props> = ({
   const [isFullscreen, fullscreenRef, fullscreenToggle, isFullscreenSupported] =
     useFullscreen<HTMLDivElement>();
   const [downloadAllStatus, setDownloadAllStatus] = React.useState(false);
+  const [showShortcutHint, setShowShortcutHint] = React.useState(false);
 
   const downloadLogs = () => {
     if (!data) return;
@@ -242,6 +258,30 @@ const LogViewer: React.FC<Props> = ({
                       </Button>
                     </ToolbarItem>
                   )}
+                  <ToolbarItem variant="separator" className="log-viewer__divider" />
+                  <ToolbarItem>
+                    <Popover
+                      aria-label="Keyboard shortcuts"
+                      isVisible={showShortcutHint}
+                      shouldClose={() => setShowShortcutHint(false)}
+                      bodyContent={
+                        <KeyboardShortcutHint
+                          shortcuts={LOG_VIEWER_SHORTCUTS}
+                          title="Keyboard shortcuts"
+                          helperText="Click the log area to enable these shortcuts."
+                        />
+                      }
+                      hasAutoWidth
+                    >
+                      <Button
+                        variant="plain"
+                        aria-label="Show keyboard shortcuts"
+                        onClick={() => setShowShortcutHint((prev) => !prev)}
+                      >
+                        <OutlinedKeyboardIcon />
+                      </Button>
+                    </Popover>
+                  </ToolbarItem>
                 </ToolbarGroup>
               </ToolbarContent>
             </Toolbar>

--- a/src/shared/components/pipeline-run-logs/logs/__tests__/LogViewer.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/__tests__/LogViewer.spec.tsx
@@ -639,6 +639,30 @@ describe('LogViewer Integration Tests', () => {
     });
   });
 
+  describe('Keyboard shortcuts popover', () => {
+    it('should render the keyboard shortcut button', () => {
+      render(<LogViewer {...defaultProps} />);
+
+      const button = screen.getByRole('button', { name: /show keyboard shortcuts/i });
+      expect(button).toBeInTheDocument();
+    });
+
+    it('should toggle the shortcuts popover on button click', async () => {
+      const user = userEvent.setup();
+      render(<LogViewer {...defaultProps} />);
+
+      const button = screen.getByRole('button', { name: /show keyboard shortcuts/i });
+      await user.click(button);
+
+      expect(screen.getByText('Keyboard shortcuts')).toBeInTheDocument();
+      expect(screen.getByText('Scroll up one line')).toBeInTheDocument();
+      expect(screen.getByText('Scroll down one line')).toBeInTheDocument();
+      expect(screen.getByText('Scroll to top')).toBeInTheDocument();
+      expect(screen.getByText('Scroll to bottom')).toBeInTheDocument();
+      expect(screen.getByText('Click the log area to enable these shortcuts.')).toBeInTheDocument();
+    });
+  });
+
   describe('Edge cases', () => {
     it('should handle null taskRun gracefully', () => {
       expect(() => {

--- a/src/shared/components/virtualized-log-viewer/VirtualizedLogContent.tsx
+++ b/src/shared/components/virtualized-log-viewer/VirtualizedLogContent.tsx
@@ -42,7 +42,7 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
   searchText = '',
   currentSearchMatch,
 }) => {
-  const parentRef = React.useRef<HTMLDivElement>(null);
+  const parentRef = React.useRef<HTMLDivElement | null>(null);
   const [itemSize, setItemSize] = React.useState(VIRTUALIZATION_CONFIG.FALLBACK_LINE_HEIGHT);
   // Fallback values for when DOM measurement is unavailable (SSR, Canvas API failure, etc.)
   const avgCharWidthRef = React.useRef(VIRTUALIZATION_CONFIG.FALLBACK_CHAR_WIDTH);
@@ -143,11 +143,21 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
   const { highlightedLines, handleLineClick, isLineHighlighted } = useLineNumberNavigation();
 
   // Enable keyboard navigation (PageUp, PageDown, Home, End)
-  useKeyboardNavigation({
-    virtualizer,
+  const navRef = useKeyboardNavigation({
     scrollElementRef: parentRef,
+    lineHeight: itemSize,
     enabled: true,
   });
+
+  const scrollContainerRef = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      parentRef.current = node;
+      if (navRef && 'current' in navRef) {
+        (navRef as React.MutableRefObject<HTMLDivElement | null>).current = node;
+      }
+    },
+    [navRef],
+  );
 
   // Scroll to highlighted lines when hash changes or on initial load
   React.useEffect(() => {
@@ -211,7 +221,7 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
 
       {/* Scrollable container with gutter */}
       <div
-        ref={parentRef}
+        ref={scrollContainerRef}
         className="log-content__list log-content__with-gutter"
         tabIndex={0}
         style={{
@@ -220,9 +230,6 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
           overflow: 'auto',
         }}
         onClick={() => {
-          // Ensure the container gets focus when clicked
-          // This is necessary because child elements with absolute positioning
-          // prevent clicks from reaching the parent
           parentRef.current?.focus();
         }}
       >

--- a/src/shared/components/virtualized-log-viewer/__tests__/useKeyboardNavigation.spec.ts
+++ b/src/shared/components/virtualized-log-viewer/__tests__/useKeyboardNavigation.spec.ts
@@ -1,192 +1,179 @@
-import { Virtualizer } from '@tanstack/react-virtual';
-import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { render, act, cleanup } from '@testing-library/react';
 import { useKeyboardNavigation } from '../useKeyboardNavigation';
 
+const TestComponent: React.FC<{
+  scrollElementRef: React.RefObject<HTMLDivElement>;
+  lineHeight?: number;
+  enabled?: boolean;
+}> = ({ scrollElementRef, lineHeight, enabled = true }) => {
+  const navRef = useKeyboardNavigation({ scrollElementRef, lineHeight, enabled });
+
+  const ref = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      (scrollElementRef as React.MutableRefObject<HTMLDivElement | null>).current = node;
+      (navRef as React.MutableRefObject<HTMLDivElement | null>).current = node;
+    },
+    [scrollElementRef, navRef],
+  );
+
+  return React.createElement('div', {
+    ref,
+    tabIndex: 0,
+    'data-test': 'scroll-container',
+    style: { height: '500px', overflow: 'auto' },
+  });
+};
+
 describe('useKeyboardNavigation', () => {
-  let mockVirtualizer: Partial<Virtualizer<HTMLDivElement, Element>>;
-  let mockScrollElement: HTMLDivElement;
-  let scrollElementRef: React.RefObject<HTMLDivElement>;
   let scrollTopValue: number;
 
-  // 🔧 setup helpers
   const setup = (enabled = true) => {
-    mockScrollElement.focus();
+    const scrollElementRef: React.MutableRefObject<HTMLDivElement | null> = { current: null };
 
-    return renderHook(() =>
-      useKeyboardNavigation({
-        virtualizer: mockVirtualizer as Virtualizer<HTMLDivElement, Element>,
+    const result = render(
+      React.createElement(TestComponent, {
         scrollElementRef,
+        lineHeight: 20,
         enabled,
       }),
     );
-  };
 
-  const fireKey = (key: string) => {
-    const event = new KeyboardEvent('keydown', { key, bubbles: true });
-    Object.defineProperty(event, 'preventDefault', { value: jest.fn() });
-    document.dispatchEvent(event);
-  };
-
-  beforeEach(() => {
-    mockScrollElement = document.createElement('div');
-    mockScrollElement.tabIndex = 0;
-    document.body.appendChild(mockScrollElement);
-
-    Object.defineProperty(mockScrollElement, 'clientHeight', {
-      configurable: true,
-      value: 500,
-    });
+    const scrollContainer = result.getByTestId('scroll-container');
 
     scrollTopValue = 100;
-    Object.defineProperty(mockScrollElement, 'scrollTop', {
+    Object.defineProperty(scrollContainer, 'scrollTop', {
       configurable: true,
       get() {
         return scrollTopValue;
       },
-      set(value) {
+      set(value: number) {
         scrollTopValue = value;
       },
     });
 
-    scrollElementRef = { current: mockScrollElement };
+    Object.defineProperty(scrollContainer, 'clientHeight', {
+      configurable: true,
+      value: 500,
+    });
 
-    mockVirtualizer = {
-      scrollOffset: 100,
-      getTotalSize: jest.fn(() => 5000),
-      options: {
-        estimateSize: jest.fn(() => 20),
-      },
-    } as unknown as Virtualizer<HTMLDivElement, Element>;
-  });
+    Object.defineProperty(scrollContainer, 'scrollHeight', {
+      configurable: true,
+      value: 5000,
+    });
+
+    act(() => {
+      scrollContainer.focus();
+    });
+
+    return { scrollContainer };
+  };
+
+  // useHotkeys attaches native event listeners, so userEvent (synthetic events) won't trigger them
+  const fireKey = (element: HTMLElement, key: string) => {
+    act(() => {
+      element.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key,
+          code: key,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+  };
 
   afterEach(() => {
-    document.body.removeChild(mockScrollElement);
-    jest.clearAllMocks();
+    cleanup();
   });
 
-  // ================= Arrow keys =================
   describe('Arrow keys', () => {
     it('handles ArrowDown', () => {
-      setup();
-
-      fireKey('ArrowDown');
-
-      expect(mockScrollElement.scrollTop).toBe(120);
+      const { scrollContainer } = setup();
+      fireKey(scrollContainer, 'ArrowDown');
+      expect(scrollTopValue).toBe(120);
     });
 
     it('handles ArrowUp', () => {
-      mockScrollElement.scrollTop = 120;
-      setup();
-
-      fireKey('ArrowUp');
-
-      expect(mockScrollElement.scrollTop).toBe(100);
+      const { scrollContainer } = setup();
+      scrollTopValue = 120;
+      fireKey(scrollContainer, 'ArrowUp');
+      expect(scrollTopValue).toBe(100);
     });
 
     it('does not scroll below 0', () => {
-      mockScrollElement.scrollTop = 10;
-      setup();
-
-      fireKey('ArrowUp');
-
-      expect(mockScrollElement.scrollTop).toBe(0);
-    });
-
-    it('does not scroll beyond max on ArrowDown', () => {
-      mockScrollElement.scrollTop = 4495;
-      setup();
-
-      fireKey('ArrowDown');
-
-      expect(mockScrollElement.scrollTop).toBe(4500);
+      const { scrollContainer } = setup();
+      scrollTopValue = 10;
+      fireKey(scrollContainer, 'ArrowUp');
+      expect(scrollTopValue).toBe(0);
     });
   });
 
-  // ================= Page keys =================
   describe('Page keys', () => {
     it('handles PageDown', () => {
-      setup();
-
-      fireKey('PageDown');
-
-      expect(mockScrollElement.scrollTop).toBe(600);
+      const { scrollContainer } = setup();
+      fireKey(scrollContainer, 'PageDown');
+      expect(scrollTopValue).toBe(600);
     });
 
     it('handles PageUp', () => {
-      mockScrollElement.scrollTop = 600;
-      setup();
-
-      fireKey('PageUp');
-
-      expect(mockScrollElement.scrollTop).toBe(100);
+      const { scrollContainer } = setup();
+      scrollTopValue = 600;
+      fireKey(scrollContainer, 'PageUp');
+      expect(scrollTopValue).toBe(100);
     });
 
     it('does not scroll below 0 on PageUp', () => {
-      mockScrollElement.scrollTop = 100;
-      setup();
-
-      fireKey('PageUp');
-
-      expect(mockScrollElement.scrollTop).toBe(0);
-    });
-
-    it('does not scroll beyond max on PageDown', () => {
-      mockScrollElement.scrollTop = 4800;
-      setup();
-
-      fireKey('PageDown');
-
-      expect(mockScrollElement.scrollTop).toBe(5000);
+      const { scrollContainer } = setup();
+      scrollTopValue = 100;
+      fireKey(scrollContainer, 'PageUp');
+      expect(scrollTopValue).toBe(0);
     });
   });
 
-  // ================= Home / End =================
   describe('Home / End keys', () => {
     it('handles Home', () => {
-      setup();
-
-      fireKey('Home');
-
-      expect(mockScrollElement.scrollTop).toBe(0);
+      const { scrollContainer } = setup();
+      fireKey(scrollContainer, 'Home');
+      expect(scrollTopValue).toBe(0);
     });
 
     it('handles End', () => {
-      setup();
-
-      fireKey('End');
-
-      expect(mockScrollElement.scrollTop).toBe(5000);
+      const { scrollContainer } = setup();
+      fireKey(scrollContainer, 'End');
+      expect(scrollTopValue).toBe(5000);
     });
   });
 
-  // ================= misc =================
   describe('other behaviors', () => {
     it('ignores unsupported keys', () => {
-      const initial = mockScrollElement.scrollTop;
-      setup();
-
-      fireKey('Tab');
-
-      expect(mockScrollElement.scrollTop).toBe(initial);
+      const { scrollContainer } = setup();
+      const initial = scrollTopValue;
+      fireKey(scrollContainer, 'Tab');
+      expect(scrollTopValue).toBe(initial);
     });
 
     it('does nothing when disabled', () => {
-      const initial = mockScrollElement.scrollTop;
-      setup(false);
-
-      fireKey('PageDown');
-
-      expect(mockScrollElement.scrollTop).toBe(initial);
+      const { scrollContainer } = setup(false);
+      const initial = scrollTopValue;
+      fireKey(scrollContainer, 'PageDown');
+      expect(scrollTopValue).toBe(initial);
     });
 
-    it('cleans up event listener on unmount', () => {
-      const spy = jest.spyOn(document, 'removeEventListener');
-
-      const { unmount } = setup();
-
-      unmount();
-
-      expect(spy).toHaveBeenCalledWith('keydown', expect.any(Function));
+    it('does nothing when scrollElementRef is null', () => {
+      const nullRef: React.MutableRefObject<HTMLDivElement | null> = { current: null };
+      const result = render(
+        React.createElement(TestComponent, {
+          scrollElementRef: nullRef,
+          enabled: true,
+        }),
+      );
+      const el = result.getByTestId('scroll-container');
+      scrollTopValue = 100;
+      nullRef.current = null;
+      el.focus();
+      fireKey(el, 'ArrowDown');
+      expect(scrollTopValue).toBe(100);
     });
   });
 });

--- a/src/shared/components/virtualized-log-viewer/useKeyboardNavigation.ts
+++ b/src/shared/components/virtualized-log-viewer/useKeyboardNavigation.ts
@@ -1,48 +1,35 @@
-import React from 'react';
-import { Virtualizer } from '@tanstack/react-virtual';
+import type { RefObject } from 'react';
+import { useHotkeys } from 'react-hotkeys-hook';
+
+const DEFAULT_LINE_HEIGHT = 20;
 
 interface UseKeyboardNavigationParams {
-  virtualizer: Virtualizer<HTMLDivElement, Element>;
-  scrollElementRef: React.RefObject<HTMLDivElement>;
+  scrollElementRef: RefObject<HTMLDivElement>;
+  lineHeight?: number;
   enabled?: boolean;
 }
 
-const NAV_KEYS = new Set(['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End']);
-
 export const useKeyboardNavigation = ({
-  virtualizer,
   scrollElementRef,
+  lineHeight = DEFAULT_LINE_HEIGHT,
   enabled = true,
-}: UseKeyboardNavigationParams) => {
-  React.useEffect(() => {
-    if (!enabled) return;
-
-    const scrollElement = scrollElementRef.current;
-    if (!scrollElement) return;
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      const active = document.activeElement;
-
-      if (!active || (active !== scrollElement && !scrollElement.contains(active))) {
-        return;
-      }
-
-      const { key } = event;
-      if (!NAV_KEYS.has(key)) return;
+}: UseKeyboardNavigationParams): RefObject<HTMLDivElement | null> => {
+  return useHotkeys<HTMLDivElement>(
+    'up,down,pageup,pagedown,home,end',
+    (event) => {
+      const scrollElement = scrollElementRef.current;
+      if (!scrollElement) return;
 
       event.preventDefault();
       event.stopPropagation();
 
       const current = scrollElement.scrollTop;
       const viewport = scrollElement.clientHeight;
-      const total = virtualizer.getTotalSize();
-      const lineHeight = virtualizer.options.estimateSize?.(0) ?? 20;
-
-      const maxScroll = Math.max(0, total - viewport);
+      const total = scrollElement.scrollHeight;
 
       let next = current;
 
-      switch (key) {
+      switch (event.key) {
         case 'ArrowUp':
           next = current - lineHeight;
           break;
@@ -62,23 +49,11 @@ export const useKeyboardNavigation = ({
           next = total;
           break;
         default:
-          // do nothing
           break;
       }
 
-      if (key === 'End') {
-        scrollElement.scrollTop = total;
-      } else if (key === 'PageDown') {
-        scrollElement.scrollTop = Math.min(total, next);
-      } else {
-        scrollElement.scrollTop = Math.min(maxScroll, Math.max(0, next));
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [enabled, scrollElementRef, virtualizer]);
+      scrollElement.scrollTop = Math.max(0, next);
+    },
+    { enabled },
+  );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10944,6 +10944,7 @@ __metadata:
     react-dnd: "npm:^16.0.1"
     react-dnd-html5-backend: "npm:^16.0.1"
     react-dom: "npm:^18.3.1"
+    react-hotkeys-hook: "npm:^5.2.4"
     react-i18next: "npm:15.0.1"
     react-refresh: "npm:^0.14.2"
     react-router-dom: "npm:6.25.1"
@@ -13189,6 +13190,16 @@ __metadata:
   version: 3.2.2
   resolution: "react-fast-compare@npm:3.2.2"
   checksum: 10/a6826180ba75cefba1c8d3ac539735f9b627ca05d3d307fe155487f5d0228d376dac6c9708d04a283a7b9f9aee599b637446635b79c8c8753d0b4eece56c125c
+  languageName: node
+  linkType: hard
+
+"react-hotkeys-hook@npm:^5.2.4":
+  version: 5.2.4
+  resolution: "react-hotkeys-hook@npm:5.2.4"
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: 10/118ffdc15e8932e0c67d2f0479d088ba50d759b4f5974e2394bc720286918530291bbde317b39cbde7ee1239813038ae7b90f6eb24794783036944b3fa2a1ba2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Fixes

Fixes https://redhat.atlassian.net/browse/KFLUXUI-1224

## Description

This PR replaces the manual `onKeyDown` callback in `useKeyboardNavigation` with `react-hotkeys-hook`'s `useHotkeys` for scoped key bindings. The hook no longer depends on the virtualizer - it reads `scrollHeight` directly from the DOM and accepts an optional `lineHeight` prop, making it a generic keyboard scroll navigation hook for any scrollable container.

Additionally, this PR introduces:
- **Shared keyboard shortcut hint components** (`KeyboardShortcutHint`, `ShortcutCommand`) - reusable components for displaying keyboard shortcuts in a popover, with OS-aware key labels (macOS vs standard)
- **Keyboard shortcuts popover in the LogViewer toolbar** - a keyboard icon button that opens a popover listing available navigation shortcuts, with helper text prompting users to focus the log area first

## Type of change

- [x] Feature
- [x] Refactoring (no functional changes, no api changes)

## Screen shots / Gifs for design review

https://github.com/user-attachments/assets/2da0de93-62c1-4906-a1ea-37d4853a456b

## How to test or reproduce?

- Navigate to a PLR log view with enough lines to scroll
- Click the log content area to focus it
- Verify ArrowDown/ArrowUp scrolls by one line
- Verify PageDown/PageUp (on Mac: Fn + Arrow Down / Fn + Arrow Up) scrolls by one viewport
- Verify Home (on Mac: Fn + Arrow Left) scrolls to the top, End (on Mac: Fn + Arrow Right) scrolls to the bottom
- Click the keyboard icon in the toolbar - verify the shortcuts popover appears listing all navigation shortcuts with a helper text
- Click the icon again or click outside - verify the popover closes

## Browser conformance:
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a keyboard shortcuts hint dialog in the log viewer toolbar with platform-aware key labels and helper text.
  * Exposed a reusable shortcut command display component.

* **Refactor**
  * Simplified keyboard navigation and consolidated how scroll targets are managed.

* **Style**
  * Added styles for the keyboard shortcut hint UI.

* **Tests**
  * Added and updated tests for shortcut UI and keyboard navigation.

* **Chores**
  * Registered a hotkeys library and enabled it in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->