### PR TITLE
feat(KFLUXUI-1189): use childReferences displayName for matrix tasks

### DIFF
--- a/src/components/PipelineRun/PipelineRunDetailsView/visualization/utils/pipelinerun-graph-utils.ts
+++ b/src/components/PipelineRun/PipelineRunDetailsView/visualization/utils/pipelinerun-graph-utils.ts
@@ -24,6 +24,7 @@ import {
   TektonResultsRun,
 } from '../../../../../types';
 import {
+  getDisplayNameFromChildReferences,
   pipelineRunStatus,
   taskRunStatus,
   isTaskV1Beta1,
@@ -312,7 +313,8 @@ export const appendStatus = (
           .filter((v) => v !== null && v !== '');
 
         const displayName: string =
-          paramValues.length > 0 ? paramValues.join(', ') : `Instance ${index + 1}`;
+          getDisplayNameFromChildReferences(pipelineRun, taskRun.metadata?.name) ||
+          (paramValues.length > 0 ? paramValues.join(', ') : `Instance ${index + 1}`);
 
         const matrixTask = createMatrixTaskEntry(task, taskRun, displayName);
         result.push(matrixTask);

--- a/src/components/TaskRunDetailsView/TaskRunDetailsView.tsx
+++ b/src/components/TaskRunDetailsView/TaskRunDetailsView.tsx
@@ -8,8 +8,9 @@ import { getErrorState } from '~/shared/utils/error-utils';
 import { TektonResourceLabel } from '~/types';
 import { downloadYamlAction } from '~/utils/common-utils';
 import { isResourceEnterpriseContract } from '~/utils/conforma-utils';
-import { taskRunStatus } from '~/utils/pipeline-utils';
+import { getDisplayNameFromChildReferences, taskRunStatus } from '~/utils/pipeline-utils';
 import { FeatureFlagIndicator } from '../../feature-flags/FeatureFlagIndicator';
+import { usePipelineRunV2 } from '../../hooks/usePipelineRunsV2';
 import { useTaskRunV2 } from '../../hooks/useTaskRunsV2';
 import {
   PIPELINERUN_DETAILS_PATH,
@@ -49,11 +50,13 @@ export const TaskRunDetailsView: React.FC = () => {
     }
   }, [activeTab, baseURL, navigate, trStatus]);
 
+  const plrName = taskRun?.metadata?.labels?.[TektonResourceLabel.pipelinerun];
+  const [pipelineRun] = usePipelineRunV2(namespace, plrName || '');
+  const taskDisplayName = getDisplayNameFromChildReferences(pipelineRun, taskRunName);
+
   if (error) {
     return getErrorState(error, loaded, 'task run');
   }
-
-  const plrName = taskRun?.metadata?.labels?.[TektonResourceLabel.pipelinerun];
 
   if (!loaded || !plrName) {
     return (
@@ -104,7 +107,10 @@ export const TaskRunDetailsView: React.FC = () => {
       title={
         <>
           <FeatureFlagIndicator flags={['taskruns-kubearchive']} />
-          <span className="pf-v5-u-mr-sm">{taskRunName}</span>
+          <span className="pf-v5-u-mr-sm">
+            {taskRunName}
+            {taskDisplayName ? ` (${taskDisplayName})` : ''}
+          </span>
           <StatusIconWithTextLabel status={trStatus} />
         </>
       }

--- a/src/components/TaskRunDetailsView/TaskRunDetailsView.tsx
+++ b/src/components/TaskRunDetailsView/TaskRunDetailsView.tsx
@@ -4,13 +4,13 @@ import { Bullseye, Spinner } from '@patternfly/react-core';
 import { RouterParams } from '@routes/utils';
 import { PipelineRunLabel, runStatus } from '~/consts/pipelinerun';
 import { CONFORMA_TASK } from '~/consts/security';
+import { usePipelineRunV2 } from '~/hooks/usePipelineRunsV2';
 import { getErrorState } from '~/shared/utils/error-utils';
 import { TektonResourceLabel } from '~/types';
 import { downloadYamlAction } from '~/utils/common-utils';
 import { isResourceEnterpriseContract } from '~/utils/conforma-utils';
 import { getDisplayNameFromChildReferences, taskRunStatus } from '~/utils/pipeline-utils';
 import { FeatureFlagIndicator } from '../../feature-flags/FeatureFlagIndicator';
-import { usePipelineRunV2 } from '../../hooks/usePipelineRunsV2';
 import { useTaskRunV2 } from '../../hooks/useTaskRunsV2';
 import {
   PIPELINERUN_DETAILS_PATH,

--- a/src/components/TaskRunDetailsView/TaskRunDetailsView.tsx
+++ b/src/components/TaskRunDetailsView/TaskRunDetailsView.tsx
@@ -58,7 +58,7 @@ export const TaskRunDetailsView: React.FC = () => {
     return getErrorState(error, loaded, 'task run');
   }
 
-  if (!loaded || !plrName) {
+  if (!loaded) {
     return (
       <Bullseye>
         <Spinner />

--- a/src/components/TaskRunDetailsView/__tests__/TaskRunDetailsView.spec.tsx
+++ b/src/components/TaskRunDetailsView/__tests__/TaskRunDetailsView.spec.tsx
@@ -5,8 +5,9 @@ import { CONFORMA_TASK, ENTERPRISE_CONTRACT_LABEL } from '~/consts/security';
 import { TektonResourceLabel } from '~/types';
 import { mockUseNamespaceHook } from '~/unit-test-utils/mock-namespace';
 import { downloadYaml } from '~/utils/common-utils';
+import { usePipelineRunV2 } from '../../../hooks/usePipelineRunsV2';
 import { useTaskRunV2 } from '../../../hooks/useTaskRunsV2';
-import { createUseParamsMock, renderWithQueryClientAndRouter } from '../../../utils/test-utils';
+import { renderWithQueryClientAndRouter } from '../../../utils/test-utils';
 import { testTaskRuns } from '../../TaskRunListView/__data__/mock-TaskRun-data';
 import { TaskRunDetailsView } from '../TaskRunDetailsView';
 
@@ -17,15 +18,22 @@ jest.mock('react-i18next', () => ({
 const navigateMock = jest.fn();
 const mockTaskRun = testTaskRuns[0];
 
+const useParamsMock = jest.fn().mockReturnValue({ taskRunName: mockTaskRun.metadata.name });
+
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');
   return {
     ...actual,
     Link: (props) => <a href={props.to}>{props.children}</a>,
     useNavigate: () => navigateMock,
+    useParams: () => useParamsMock(),
     useSearchParams: () => React.useState(() => new URLSearchParams()),
   };
 });
+
+jest.mock('../../../hooks/usePipelineRunsV2', () => ({
+  usePipelineRunV2: jest.fn(),
+}));
 
 jest.mock('../../../hooks/useTaskRunsV2', () => ({
   useTaskRunV2: jest.fn(),
@@ -46,12 +54,15 @@ jest.mock('~/utils/common-utils', () => {
 });
 
 const useTaskRunMock = useTaskRunV2 as jest.Mock;
+const usePipelineRunV2Mock = usePipelineRunV2 as jest.Mock;
 const downloadYamlMock = downloadYaml as jest.Mock;
-// const sanitizeHtmlMock = sanitizeHtml as jest.Mock;
 
 describe('TaskRunDetailsView', () => {
-  createUseParamsMock({ taskRunName: mockTaskRun.metadata.name });
   mockUseNamespaceHook('test-ns');
+
+  beforeEach(() => {
+    usePipelineRunV2Mock.mockReturnValue([undefined, false]);
+  });
 
   it('should render spinner if taskrun data is not loaded', () => {
     useTaskRunMock.mockReturnValue([null, false]);
@@ -117,5 +128,50 @@ describe('TaskRunDetailsView', () => {
 
     renderWithQueryClientAndRouter(<TaskRunDetailsView />);
     expect(screen.getByRole('tab', { name: /security/i })).toBeInTheDocument();
+  });
+
+  it('should show displayName from childReferences when available', () => {
+    useTaskRunMock.mockReturnValue([mockTaskRun, true]);
+    usePipelineRunV2Mock.mockReturnValue([
+      {
+        status: {
+          childReferences: [
+            {
+              name: mockTaskRun.metadata.name,
+              pipelineTaskName: 'example-task',
+              displayName: 'Build for linux/amd64',
+            },
+          ],
+        },
+      },
+      true,
+    ]);
+
+    renderWithQueryClientAndRouter(<TaskRunDetailsView />);
+    const titleSpan = document.querySelector('.pf-v5-u-mr-sm');
+    expect(titleSpan).not.toBeNull();
+    expect(titleSpan.textContent).toContain('(Build for linux/amd64)');
+  });
+
+  it('should not show displayName parentheses when childReferences has no displayName', () => {
+    useTaskRunMock.mockReturnValue([mockTaskRun, true]);
+    usePipelineRunV2Mock.mockReturnValue([
+      {
+        status: {
+          childReferences: [
+            {
+              name: mockTaskRun.metadata.name,
+              pipelineTaskName: 'example-task',
+            },
+          ],
+        },
+      },
+      true,
+    ]);
+
+    renderWithQueryClientAndRouter(<TaskRunDetailsView />);
+    const titleSpan = document.querySelector('.pf-v5-u-mr-sm');
+    expect(titleSpan).not.toBeNull();
+    expect(titleSpan.textContent).not.toContain('(');
   });
 });

--- a/src/components/TaskRunDetailsView/__tests__/TaskRunDetailsView.spec.tsx
+++ b/src/components/TaskRunDetailsView/__tests__/TaskRunDetailsView.spec.tsx
@@ -2,12 +2,12 @@ import * as React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CONFORMA_TASK, ENTERPRISE_CONTRACT_LABEL } from '~/consts/security';
+import { usePipelineRunV2 } from '~/hooks/usePipelineRunsV2';
+import { useTaskRunV2 } from '~/hooks/useTaskRunsV2';
 import { TektonResourceLabel } from '~/types';
 import { mockUseNamespaceHook } from '~/unit-test-utils/mock-namespace';
 import { downloadYaml } from '~/utils/common-utils';
-import { usePipelineRunV2 } from '../../../hooks/usePipelineRunsV2';
-import { useTaskRunV2 } from '../../../hooks/useTaskRunsV2';
-import { renderWithQueryClientAndRouter } from '../../../utils/test-utils';
+import { renderWithQueryClientAndRouter } from '~/utils/test-utils';
 import { testTaskRuns } from '../../TaskRunListView/__data__/mock-TaskRun-data';
 import { TaskRunDetailsView } from '../TaskRunDetailsView';
 
@@ -31,11 +31,11 @@ jest.mock('react-router-dom', () => {
   };
 });
 
-jest.mock('../../../hooks/usePipelineRunsV2', () => ({
+jest.mock('~/hooks/usePipelineRunsV2', () => ({
   usePipelineRunV2: jest.fn(),
 }));
 
-jest.mock('../../../hooks/useTaskRunsV2', () => ({
+jest.mock('~/hooks/useTaskRunsV2', () => ({
   useTaskRunV2: jest.fn(),
 }));
 

--- a/src/types/pipeline-run.ts
+++ b/src/types/pipeline-run.ts
@@ -119,6 +119,15 @@ export type PipelineRunParam = {
   resource?: object;
 };
 
+export type ChildReference = {
+  apiVersion?: string;
+  kind?: string;
+  name?: string;
+  pipelineTaskName?: string;
+  displayName?: string;
+  whenExpressions?: WhenExpression[];
+};
+
 export type PipelineRunStatus = {
   succeededCondition?: string;
   creationTimestamp?: string;
@@ -126,6 +135,7 @@ export type PipelineRunStatus = {
   startTime?: string;
   completionTime?: string;
   taskRuns?: PLRTaskRuns;
+  childReferences?: ChildReference[];
   pipelineSpec: PipelineSpec;
   skippedTasks?: {
     name: string;
@@ -175,6 +185,7 @@ export type PipelineRunStatusV1Beta1 = {
   startTime?: string;
   completionTime?: string;
   taskRuns?: PLRTaskRunsV1Beta1;
+  childReferences?: ChildReference[];
   pipelineSpec: PipelineSpec;
   skippedTasks?: {
     name: string;

--- a/src/utils/__tests__/pipeline-utils.spec.ts
+++ b/src/utils/__tests__/pipeline-utils.spec.ts
@@ -16,6 +16,7 @@ import {
   taskTestResultStatus,
   testOutputResultToRunStatus,
   isTaskRunInPipelineRun,
+  getDisplayNameFromChildReferences,
 } from '../pipeline-utils';
 
 const samplePipelineRun = testPipelineRuns[DataState.SUCCEEDED];
@@ -346,5 +347,53 @@ describe('isTaskRunInPipelineRun', () => {
     expect(isTaskRunInPipelineRun(mockPipelineRuns[0] as PipelineRunKind, 'clone-repository')).toBe(
       true,
     );
+  });
+});
+
+describe('getDisplayNameFromChildReferences', () => {
+  const pipelineRunWithChildRefs = {
+    status: {
+      childReferences: [
+        { name: 'build-task-run-1', pipelineTaskName: 'build', displayName: 'Build linux/amd64' },
+        { name: 'build-task-run-2', pipelineTaskName: 'build', displayName: 'Build linux/arm64' },
+        { name: 'test-task-run', pipelineTaskName: 'test' },
+      ],
+    },
+  } as PipelineRunKind;
+
+  it('should return displayName when childReference matches', () => {
+    expect(getDisplayNameFromChildReferences(pipelineRunWithChildRefs, 'build-task-run-1')).toBe(
+      'Build linux/amd64',
+    );
+    expect(getDisplayNameFromChildReferences(pipelineRunWithChildRefs, 'build-task-run-2')).toBe(
+      'Build linux/arm64',
+    );
+  });
+
+  it('should return undefined when childReference has no displayName', () => {
+    expect(
+      getDisplayNameFromChildReferences(pipelineRunWithChildRefs, 'test-task-run'),
+    ).toBeUndefined();
+  });
+
+  it('should return undefined when taskRunName does not match any childReference', () => {
+    expect(
+      getDisplayNameFromChildReferences(pipelineRunWithChildRefs, 'non-existent'),
+    ).toBeUndefined();
+  });
+
+  it('should return undefined when pipelineRun is undefined', () => {
+    expect(getDisplayNameFromChildReferences(undefined, 'build-task-run-1')).toBeUndefined();
+  });
+
+  it('should return undefined when taskRunName is undefined', () => {
+    expect(getDisplayNameFromChildReferences(pipelineRunWithChildRefs, undefined)).toBeUndefined();
+  });
+
+  it('should return undefined when pipelineRun has no childReferences', () => {
+    const pipelineRunNoRefs = { status: {} } as PipelineRunKind;
+    expect(
+      getDisplayNameFromChildReferences(pipelineRunNoRefs, 'build-task-run-1'),
+    ).toBeUndefined();
   });
 });

--- a/src/utils/pipeline-utils.ts
+++ b/src/utils/pipeline-utils.ts
@@ -74,9 +74,8 @@ export const getRandomChars = (len = 6): string => {
     .slice(2, len + 2);
 };
 
-export const isPipelineV1Beta1 = (
-  pipeline: PipelineRunKind,
-): pipeline is PipelineRunKindV1Beta1 => pipeline?.apiVersion === 'tekton.dev/v1beta1';
+export const isPipelineV1Beta1 = (pipeline: PipelineRunKind): pipeline is PipelineRunKindV1Beta1 =>
+  pipeline?.apiVersion === 'tekton.dev/v1beta1';
 
 export const isTaskV1Beta1 = (task: TaskRunKind): task is TaskRunKindV1Beta1 =>
   task?.apiVersion === 'tekton.dev/v1beta1';
@@ -396,6 +395,17 @@ export const testOutputResultToRunStatus = (
     default:
       return runStatus.Unknown;
   }
+};
+
+export const getDisplayNameFromChildReferences = (
+  pipelineRun: PipelineRunKind | undefined,
+  taskRunName: string | undefined,
+): string | undefined => {
+  const childRefs = pipelineRun?.status?.childReferences;
+  if (!childRefs || !taskRunName) return undefined;
+
+  const childRef = childRefs.find((ref) => ref.name === taskRunName);
+  return childRef?.displayName;
 };
 
 export const isTaskRunInPipelineRun = (


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->

Fixes https://redhat.atlassian.net/browse/KFLUXUI-1189
Closes #406

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In this PR we're adding a logic to prefer `displayName` from `pipelineRun.status?.childReferences` when available for matrix task instances, falling back to parameter values or instance index.

main changes:

- PLR Graph: matrix task nodes now use `displayName` from `childReferences` (when available) instead of raw parameter values
- TaskRun Details View: the task's `displayName` is shown in parentheses next to the `TaskRun` name in the page title (e.g. `build-task-run-1 (Build for linux/amd64)`)
- Types: dded `ChildReference` type and `childReferences` field to `PipelineRunStatus`
- utility: added `getDisplayNameFromChildReferences()` helper in `pipeline-utils.ts`

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

https://github.com/user-attachments/assets/52a3586e-894c-41c3-bf87-2becde0dee50

After:

https://github.com/user-attachments/assets/530d49e7-4d9e-4cc8-833c-2d58b7edd9e7

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

- find a PLR that has a matrixed task. If you don't have any, feel free to check the following example: https://localhost:8080/ns/rh-ee-rgalvao-tenant/applications/testing-123/pipelineruns/matrix-example-component-on-push-c8qvq
- if you wanna try it yourself, you can use the following PR changes as inspiration: https://github.com/rrosatti/konflux-app-example/pull/116

and if you're curious to know a bit more how the matrix `displayName` works, take a look at the following doc https://tekton.dev/docs/pipelines/matrix/#displayname :)

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TaskRun details page now appends derived display names to titles when available, improving clarity for individual task executions.
  * Pipeline run visualization shows more descriptive names for expanded matrix task instances, with sensible fallbacks when display names are absent.
  * Added display-name resolution from pipeline run child references.

* **Testing**
  * Added tests covering display-name lookup and title rendering across task and pipeline views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->