### PR TITLE
KFLUXUI-1226 [Syntax Highlighting] fix scroll to line when opening log URLs with line hash

### DIFF
--- a/src/shared/components/virtualized-log-viewer/VirtualizedLogContent.tsx
+++ b/src/shared/components/virtualized-log-viewer/VirtualizedLogContent.tsx
@@ -176,7 +176,7 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
           if (!isMounted) return;
           virtualizer.scrollToIndex(scrollIndex, {
             align: 'center',
-            behavior: 'smooth',
+            behavior: 'auto',
           });
         });
       });

--- a/src/shared/components/virtualized-log-viewer/__tests__/VirtualizedLogContent.spec.tsx
+++ b/src/shared/components/virtualized-log-viewer/__tests__/VirtualizedLogContent.spec.tsx
@@ -8,6 +8,22 @@ import { VirtualizedLogContent } from '../VirtualizedLogContent';
 // Register the log language
 registerLogSyntax(Prism);
 
+// Spy to capture scrollToIndex calls from the virtualizer.
+let scrollToIndexSpy: jest.Mock | null = null;
+jest.mock('@tanstack/react-virtual', () => {
+  const actual = jest.requireActual('@tanstack/react-virtual');
+  return {
+    ...actual,
+    useVirtualizer: (options: unknown) => {
+      const virtualizer = actual.useVirtualizer(options);
+      if (scrollToIndexSpy) {
+        return { ...virtualizer, scrollToIndex: scrollToIndexSpy };
+      }
+      return virtualizer;
+    },
+  };
+});
+
 // Mock lodash-es debounce to make tests synchronous
 jest.mock('lodash-es', () => ({
   ...jest.requireActual('lodash-es'),
@@ -655,6 +671,30 @@ Another short line`;
       // Should render normally
       const listElement = document.querySelector('.log-content__list');
       expect(listElement).toBeInTheDocument();
+    });
+
+    it('should use instant scroll (behavior: auto) for hash navigation', () => {
+      window.location.hash = '#L2';
+
+      // Make RAF synchronous so the double-RAF in the scroll effect executes immediately
+      const originalRAF = window.requestAnimationFrame;
+      window.requestAnimationFrame = (cb: FrameRequestCallback) => {
+        cb(0);
+        return 0;
+      };
+
+      // Enable the module-level scrollToIndex spy
+      scrollToIndexSpy = jest.fn();
+
+      renderWithQueryClientAndRouter(<VirtualizedLogContent {...defaultProps} />);
+
+      expect(scrollToIndexSpy).toHaveBeenCalled();
+      const lastCall = scrollToIndexSpy.mock.calls[scrollToIndexSpy.mock.calls.length - 1];
+      expect(lastCall[1]).toEqual(expect.objectContaining({ behavior: 'auto' }));
+
+      // Cleanup
+      scrollToIndexSpy = null;
+      window.requestAnimationFrame = originalRAF;
     });
   });
 });


### PR DESCRIPTION

## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->

Fixes https://redhat.atlassian.net/browse/KFLUXUI-1226

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

There's a bug when trying to load the Logs page with an url that has line hash (e.g. `L100-L150`), the scroll to the correct place/line is not working.

When taking a look at the browser console, I saw the following errors:

```
installHook.js:1 The `smooth` scroll behavior is not fully supported with dynamic size.
overrideMethod	@	installHook.js:1
```

```
installHook.js:1 Failed to scroll to index 34868 after 10 attempts.
overrideMethod	@	installHook.js:1
requestAnimationFrame		
(anonymous)	@	VirtualizedLogContent.tsx:177
requestAnimationFrame		
(anonymous)	@	VirtualizedLogContent.tsx:175
requestAnimationFrame		
(anonymous)	@	VirtualizedLogContent.tsx:173
S.scheduleRefresh	@	installHook.js:1
setTimeout		
$ReactRefreshModuleRuntime$	@	VirtualizedLogContent.tsx:36
6206	@	VirtualizedLogContent.tsx:36
options.factory	@	react refresh:37
__webpack_require__	@	bootstrap:28
_requireSelf	@	hot module replacement:101
onAccepted	@	jsonp chunk loading:446
```

It seems `@tanstack/react-virtual` does not fully support `smooth` scroll with dynamic item sizes.

The fix is basically to switch the scroll `behavior` to `auto` instead of `smooth` in `VirtualizedLogContent` component.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

https://github.com/user-attachments/assets/7428bce5-e6aa-4a48-ac7b-e17ac6a10c98

After:

https://github.com/user-attachments/assets/a4801a04-c2c7-46e5-8f45-cb8facbf6ccd


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

- go to any Logs page
- select some lines (notice line hash will be set in the url e.g. `L100-L150`)
- reload the page
- it should scroll to the correct place
- :coffee:


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Log viewer navigation now uses instant (non-animated) scrolling when jumping to highlighted lines for snappier, more responsive behavior.

* **Tests**
  * Added an integration test to verify instant scroll behavior during hash/navigation to highlighted lines, ensuring smooth animated scrolling is not used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->