### PR TITLE
chore(KFLUXUI-1242): add parent linking, Story type, and compact jira-ticket skill

### DIFF
--- a/.claude/skills/jira-ticket/SKILL.md
+++ b/.claude/skills/jira-ticket/SKILL.md
@@ -11,44 +11,34 @@ description: >
 
 ## Startup
 
-**MUST do before anything else:**
-
-1. Read `./conventions.md` (sibling file in the same directory as this skill) to load project-specific rules: project key, issue types, title format, templates, components, labels, and epic linking rules.
-2. Check if the `atlassian` MCP server is available by looking for `jira_create_issue` in the available MCP tools. Record whether it's available — this determines behavior at Step 6.
-3. **NEVER read `.env.local`, `.env`, or any file matching `.env.*`** — credentials are handled by the MCP server process, not by this skill.
+1. Read `./conventions.md` to load project rules (project key, issue types, title format, templates, parent linking).
+2. Check if `jira_create_issue` is available in MCP tools. Record availability for Step 6.
+3. **NEVER read `.env.local`, `.env`, or any `.env.*` file.**
 
 ## Context Gathering
 
-Before starting the interview, scan for existing context:
-- **Conversation history**: errors, stack traces, failing tests, problem descriptions the user has been discussing.
-- **Command arguments**: if invoked via a slash command with `$ARGUMENTS`, use that as starting input.
-- **Session context**: recent build failures, test output, or console errors.
-
-Pre-fill as many fields as possible from this context. Only ask the user for information you can't infer.
+Scan conversation history, `$ARGUMENTS`, and session context (errors, stack traces, test failures) before starting. Pre-fill fields from context — only ask for what you can't infer.
 
 ## Interview Flow
 
 Do NOT call any Jira create tool until all required fields are collected and confirmed.
 
 ### Step 1 — Determine issue type
-If already pinned by a slash command or obvious from context (e.g., user said "file a bug", or context contains an error/defect), set the type without asking. Otherwise ask:
-> What type of issue? (available types from conventions.md: Bug, Task, etc.)
+If obvious from context or slash command, set type silently. Otherwise ask.
 
 ### Step 2 — Collect title
-Propose a title derived from context, formatted per conventions.md title format. If no context is available, ask for a summary. Validate format and show the proposed title for approval.
+Propose a title formatted per conventions.md (`[Area] imperative summary`). Ask for approval.
 
 ### Step 3 — Collect description
-Use the template from conventions.md for the issue type (Bug Template, Task Template, etc.). Pre-fill sections from conversation context where possible — stack traces, error messages, reproduction steps the user already described. Refer to the Templates section below for fill-in guidance on each section. Ask only for missing sections.
+Use the template from conventions.md for the issue type. Pre-fill from context. Ask only for missing sections. See fill-in guidance below.
 
 ### Step 4 — Collect optional fields
-Check conventions.md for:
-- Component (if configured, ask; if marked "skip", skip silently)
-- Labels (if configured, ask; if marked "skip", skip silently)
-- Priority: suggest one based on the Severity and Priority guidelines below, then let the user confirm or override
-- Epic link (if required by conventions.md for this issue type, ask; otherwise skip)
+- Component / Labels: ask if configured in conventions.md, skip if marked "skip"
+- Priority: suggest based on conventions.md defaults, let user confirm or override
+- Parent: use if provided in context/args. Ask only if user mentions a parent but didn't give the key. Do NOT ask unprompted.
 
 ### Step 5 — Show and confirm (MANDATORY GATE)
-Render the complete draft:
+Render the draft, then ask for confirmation. Do NOT call the create tool until the user explicitly confirms.
 
 ```
 ## Ticket Draft
@@ -59,295 +49,164 @@ Render the complete draft:
 **Priority:** <priority>
 **Component:** <if applicable>
 **Labels:** <if applicable>
-**Epic:** <if applicable>
+**Parent:** <parent ticket key, if applicable>
 
 ### Description
 <full description from template>
 ```
 
-Then ask:
-> Does this look good? Reply "yes" or "confirm" to create the ticket, or tell me what to change.
-
-**Do NOT call the create tool until the user explicitly confirms.**
-
 ### Step 6 — Create
 
-**If MCP server is available:** Call `jira_create_issue` with all collected fields. Submit the description as markdown — the MCP server handles ADF conversion.
+**If MCP available:** Call `jira_create_issue`. Submit description as markdown — the MCP server handles ADF conversion.
 
-**Tool call shape:**
 ```python
 jira_create_issue(
     project_key="<from conventions.md>",
-    issue_type="<Bug | Task>",
+    issue_type="<Bug | Task | Story>",
     summary="<validated title>",
     description="<filled template as markdown>",
-    # components="<from conventions.md, if configured>",
-    additional_fields={
-        "priority": {"name": "<priority>"},
-        # "labels": ["<label1>", "<label2>"],  # if configured in conventions.md
-        # "customfield_XXXXX": "<value>",       # epic link or other custom fields from conventions.md
-    }
+    # components="<if configured>",
+    additional_fields='{"priority": {"name": "<priority>"}}'
+    # With parent: '{"priority": {"name": "<priority>"}, "parent": "<PARENT_KEY>"}'
+    # With labels: '{"priority": {"name": "<priority>"}, "labels": ["<label1>"]}'
 )
 ```
 
-**If MCP server is NOT available:** Do not attempt the call. Instead, present the complete ticket details in a copyable format so the user can create it manually:
-
-```
-## Ready to create — MCP server not available
-
-Jira MCP server is not configured. Create this ticket manually at <Jira URL from conventions.md>.
-To enable automatic creation, export `JIRA_URL`, `JIRA_USERNAME`, and `JIRA_API_TOKEN` in your shell profile and restart Claude Code. See `.env.example` for details.
-
-**Project:** <project key>
-**Type:** <issue type>
-**Title:** <title>
-**Priority:** <priority>
-**Component:** <if applicable>
-**Labels:** <if applicable>
-
-### Description
-<full description>
-```
+**If MCP NOT available:** Render the same draft format from Step 5 with a note:
+> Jira MCP server is not configured. Create this ticket manually at \<Jira URL from conventions.md\>.
+> To enable, configure the `atlassian` MCP server with `pipx run mcp-atlassian --env-file <path>` and restart Claude Code.
 
 ### Step 7 — Post-creation
-- Report the created ticket key and URL to the user.
-- If conventions.md specifies a PR linking rule and there is a current PR, offer to add the PR URL as a comment on the newly created ticket.
+Report ticket key and URL. If conventions.md has a PR linking rule and there's a current PR, offer to add it as a comment.
 
-## Markdown Formatting Guidelines
+## Fill-in Guidance
 
-The MCP server converts markdown to Jira-compatible format. Use these conventions for best rendering:
-
-### Headers
-- `##` for section headers (→ `h2.` in Jira)
-- `###` for subsection headers (→ `h3.` in Jira)
-
-### Text Formatting
-- `**bold**` → `*bold*` in Jira
-- `*italic*` → `_italic_` in Jira
-- `` `inline code` `` → `{{code}}` in Jira
-
-### Lists
-- Bullet lists: use `- Item` (not `*`). Indent nested items with 2 spaces.
-- Numbered lists: use `1.` for all items. Indent nested items with 4 spaces.
-- Do NOT use `*`, `#`, or other symbols for lists.
-
-### Code Blocks
-Use fenced code blocks with language identifier:
-````
-```python
-code here
-```
-````
-Converts to `{code:python}...{code}` in Jira.
-
-### Links
-- `[link text](url)` → `[link text|url]` in Jira
-
-### Tables
-- Use standard markdown table format with `|` separators — auto-converted to Jira `||` header format.
-
-## Severity and Priority
-
-Use these guidelines when asking the user for priority, or when suggesting one based on context.
-
-### Severity (Bugs only)
-- **Critical**: Broken core functionality, crashes, data loss, no workaround, security vulnerability
-- **Major**: Non-critical functional issue, performance degradation, reasonable workaround exists
-- **Normal**: Default — validation issues, non-blocking functional problems
-- **Minor**: Cosmetic issues (alignment, layout, color, copy)
-- **Trivial**: Console warnings, log noise, no user impact
-
-### Priority Mapping
-| Severity | Suggested Priority |
-|----------|-------------------|
-| Critical | Blocker or Critical |
-| Major | Major |
-| Normal | Normal |
-| Minor | Minor |
-| Trivial | Minor |
-
-For Tasks, default to Normal unless the user specifies urgency.
-
-## Templates — Fill-in Guidance
-
-The canonical template structure comes from conventions.md. Below is guidance on how to fill each section. If conventions.md defines a template for the issue type, use that structure and apply this guidance.
-
-### Bug — Section Guidance
-
-| Section | How to fill |
-|---------|-------------|
-| Description of problem | Be specific — what is broken, where, and for whom |
-| How reproducible | One of: Always, Sometimes, One-time |
-| Steps to Reproduce | Numbered steps a stranger could follow. Minimum 3 steps. Include preconditions (logged in? specific page?) |
-| Actual results | What happens — include error messages, console output, or visual description |
-| Expected results | What should happen instead — be concrete |
+### Bug
+| Section | Guidance |
+|---------|----------|
+| Description of problem | What is broken, where, for whom |
+| How reproducible | Always / Sometimes / One-time |
+| Steps to Reproduce | Numbered steps a stranger could follow, minimum 3. Include preconditions |
+| Actual results | Include error messages, console output |
+| Expected results | Be concrete |
 | Is this a customer issue | Yes or No |
-| Logs/screenshots | Paste raw errors in a fenced code block. If from conversation context, include verbatim |
+| Logs/screenshots | Raw errors in fenced code blocks |
 
-### Task — Section Guidance
+### Task
+| Section | Guidance |
+|---------|----------|
+| Description | 3-7 actionable bullet points covering scope, approach, edge cases. Not a restatement of the title |
 
-| Section | How to fill |
-|---------|-------------|
-| Description | Bullet points summarizing the work. Each bullet should be an actionable item, not a restatement of the title. Aim for 3-7 bullets covering scope, approach, and edge cases |
+### Story
+| Section | Guidance |
+|---------|----------|
+| Acceptance Criteria | 3-7 testable criteria using "As a \<user\>, I can \<action\> so that \<outcome\>" format |
+| Notes | Developer notes, design doc links, API specs. Optional — skip if nothing to add |
 
 ## Anti-patterns
 
-Before confirming a ticket, actively check for and reject these:
-
-1. **Vague titles** starting with "Fix", "Update", "Change" without specifics — rewrite to be descriptive.
-   - Bad: `Fix the bug`
-   - Good: `[LogViewer] Fix log line duplication when switching tabs`
-2. **Bug descriptions without reproduction steps** — all Steps to Reproduce fields must be filled.
-3. **Task descriptions that just restate the title** — bullet points must add actionable detail beyond the summary.
-4. **Missing required template sections** — every section in the template must have content, not blanks or placeholders.
-5. **Epic link missing on Stories** (when conventions.md requires it) — block creation until provided.
-6. **Filing as Bug when it's not a Bug.** A Bug is a defect — something that should work but doesn't. These are NOT Bugs:
-   - New functionality that doesn't exist yet (→ Task or Story)
-   - Flaky/intermittent test failures without a proven product defect (→ Task)
-   - Test coverage gaps (→ Task)
-   - Refactoring or code cleanup (→ Task)
-   - Feature requests or improvements beyond current expected behavior (→ Task)
-   
-   If the user asks to "file a bug" but the description is actually a feature request or test fix, flag it and suggest Task instead.
+Reject these before confirming:
+1. **Vague titles** — "Fix the bug" is bad. "[LogViewer] Fix log line duplication when switching tabs" is good.
+2. **Bugs without repro steps** — all Steps to Reproduce fields must be filled.
+3. **Task descriptions restating the title** — bullets must add detail beyond the summary.
+4. **Empty template sections** — every section needs content, not blanks.
+5. **Missing parent** — if user mentioned a parent ticket, it must be in the draft.
+6. **Wrong issue type** — new features, flaky tests, refactoring, and test coverage gaps are Tasks or Stories, not Bugs. Flag and suggest the right type.
 
 ## Worked Examples
 
-### Example 1: Bug
+### Example 1: Task under a parent epic
 
-**User:** "The sidebar crashes when you click the settings icon on Firefox"
+**User:** "Create a task under KFLUXUI-1200 for adding pagination to the pipeline runs table"
 
-**Skill interview:**
-> Issue type is Bug. Let me draft the title.
->
-> Proposed title: `[Sidebar] Fix crash when clicking settings icon on Firefox`
->
-> Let me fill out the bug template. A few questions:
-> 1. How reproducible is this? (always / sometimes / one-time)
-> 2. What are the exact steps — do you need to be logged in? Any specific page?
-> 3. What's the actual result — blank screen, error message, console error?
-> 4. Is this a customer issue?
+**Interview:** Type is Task, parent is KFLUXUI-1200. Propose title: `[PipelineRuns] Add pagination to pipeline runs table`. Ask what the task should cover.
 
-**User provides answers.**
+**User:** "Use numbered pagination with a default page size of 20. The API already supports limit/offset."
 
-**Skill shows draft:**
+**Draft:**
 ```
 ## Ticket Draft
 
-**Project:** <PROJECT_KEY>
-**Type:** Bug
-**Title:** [Sidebar] Fix crash when clicking settings icon on Firefox
-**Priority:** Major
+**Project:** KFLUXUI
+**Type:** Task
+**Title:** [PipelineRuns] Add pagination to pipeline runs table
+**Priority:** Normal
+**Parent:** KFLUXUI-1200
 
 ### Description
-Description of problem:
-Clicking the settings icon in the sidebar causes a crash on Firefox 128.
-
-How reproducible:
-Always
-
-Steps to Reproduce:
-
-1. Open the application in Firefox 128
-2. Navigate to any page with the sidebar visible
-3. Click the settings (gear) icon in the sidebar
-
-Actual results:
-Page crashes with a blank white screen. Console shows: TypeError: Cannot read properties of undefined (reading 'map')
-
-Expected results:
-Settings panel opens in the sidebar without errors.
-
-Is this a customer issue: No
-
-Please attach any logs/print screens to the ticket or share any additional info/links:
-Console stacktrace attached.
+- Add numbered pagination to the pipeline runs table
+- Default page size of 20 rows
+- Use limit/offset query parameters against the existing API
+- Update table footer with page controls (previous, next, page numbers)
+- Preserve current sort and filter state across page changes
 ```
 
-> Does this look good? Reply "yes" or "confirm" to create the ticket.
-
-**User:** "yes"
-
-**Skill tool call:**
+**Tool call after confirmation:**
 ```python
 jira_create_issue(
-    project_key="<PROJECT_KEY>",
-    issue_type="Bug",
-    summary="[Sidebar] Fix crash when clicking settings icon on Firefox",
-    description="""Description of problem:
-Clicking the settings icon in the sidebar causes a crash on Firefox 128.
-
-How reproducible:
-Always
-
-Steps to Reproduce:
-
-1. Open the application in Firefox 128
-2. Navigate to any page with the sidebar visible
-3. Click the settings (gear) icon in the sidebar
-
-Actual results:
-Page crashes with a blank white screen. Console shows: TypeError: Cannot read properties of undefined (reading 'map')
-
-Expected results:
-Settings panel opens in the sidebar without errors.
-
-Is this a customer issue: No
-
-Please attach any logs/print screens to the ticket or share any additional info/links:
-Console stacktrace attached.""",
-    additional_fields={
-        "priority": {"name": "Major"}
-    }
+    project_key="KFLUXUI",
+    issue_type="Task",
+    summary="[PipelineRuns] Add pagination to pipeline runs table",
+    description="""- Add numbered pagination to the pipeline runs table
+- Default page size of 20 rows
+- Use limit/offset query parameters against the existing API
+- Update table footer with page controls (previous, next, page numbers)
+- Preserve current sort and filter state across page changes""",
+    additional_fields='{"priority": {"name": "Normal"}, "parent": "KFLUXUI-1200"}'
 )
 ```
 
-### Example 2: Task
+### Example 2: Story under a parent epic
 
-**User:** "I need a ticket to add unit tests for the commit label component"
+**User:** "Create a story under KFLUXUI-1200 for letting users filter pipeline runs by status"
 
-**Skill interview:**
-> Issue type is Task. Let me draft the title.
->
-> Proposed title: `[CommitLabel] Add unit tests for CommitLabel component`
->
-> What should the task cover? Any specific scenarios or edge cases to test?
+**Interview:** Type is Story, parent is KFLUXUI-1200. Propose title: `[PipelineRuns] Add status filter to pipeline runs table`. Ask about filterable statuses and design references.
 
-**User:** "Test the rendering with different commit SHAs, truncation logic, and the copy-to-clipboard behavior"
+**User:** "Succeeded, Failed, Running, and Pending. Mockup: https://figma.com/file/abc123"
 
-**Skill shows draft:**
+**Draft:**
 ```
 ## Ticket Draft
 
-**Project:** <PROJECT_KEY>
-**Type:** Task
-**Title:** [CommitLabel] Add unit tests for CommitLabel component
+**Project:** KFLUXUI
+**Type:** Story
+**Title:** [PipelineRuns] Add status filter to pipeline runs table
 **Priority:** Normal
+**Parent:** KFLUXUI-1200
 
 ### Description
-- Add unit tests for the CommitLabel component
-- Test rendering with full and short commit SHAs
-- Verify SHA truncation logic displays correct abbreviated format
-- Test copy-to-clipboard behavior on click
-- Cover edge cases: empty SHA, undefined SHA, extremely long input
+## Acceptance Criteria
+
+- [ ] As a user, I can filter pipeline runs by status so that I can focus on runs that need attention
+- [ ] As a user, I can select multiple statuses (Succeeded, Failed, Running, Pending) so that I can view combinations of results
+- [ ] As a user, I can clear the status filter so that I can return to the unfiltered view
+- [ ] As a user, I can see the active filter state reflected in the URL so that I can share filtered views
+
+## Notes
+
+- Mockup: https://figma.com/file/abc123
+- Statuses to support: Succeeded, Failed, Running, Pending
+- Filter should integrate with existing table toolbar alongside search
 ```
 
-> Does this look good? Reply "yes" or "confirm" to create the ticket.
-
-**User:** "confirm"
-
-**Skill tool call:**
+**Tool call after confirmation:**
 ```python
 jira_create_issue(
-    project_key="<PROJECT_KEY>",
-    issue_type="Task",
-    summary="[CommitLabel] Add unit tests for CommitLabel component",
-    description="""- Add unit tests for the CommitLabel component
-- Test rendering with full and short commit SHAs
-- Verify SHA truncation logic displays correct abbreviated format
-- Test copy-to-clipboard behavior on click
-- Cover edge cases: empty SHA, undefined SHA, extremely long input""",
-    additional_fields={
-        "priority": {"name": "Normal"}
-    }
+    project_key="KFLUXUI",
+    issue_type="Story",
+    summary="[PipelineRuns] Add status filter to pipeline runs table",
+    description="""## Acceptance Criteria
+
+- [ ] As a user, I can filter pipeline runs by status so that I can focus on runs that need attention
+- [ ] As a user, I can select multiple statuses (Succeeded, Failed, Running, Pending) so that I can view combinations of results
+- [ ] As a user, I can clear the status filter so that I can return to the unfiltered view
+- [ ] As a user, I can see the active filter state reflected in the URL so that I can share filtered views
+
+## Notes
+
+- Mockup: https://figma.com/file/abc123
+- Statuses to support: Succeeded, Failed, Running, Pending
+- Filter should integrate with existing table toolbar alongside search""",
+    additional_fields='{"priority": {"name": "Normal"}, "parent": "KFLUXUI-1200"}'
 )
 ```

--- a/.claude/skills/jira-ticket/conventions.md
+++ b/.claude/skills/jira-ticket/conventions.md
@@ -10,6 +10,7 @@
 ## Issue Types
 - Bug
 - Task
+- Story
 
 ## Required Fields (all types)
 - Summary (title)
@@ -31,12 +32,27 @@ Not yet configured — skip in interview.
 ## Priority Defaults
 - Bug: infer from severity (Critical→Blocker, Major→Major, default→Normal, cosmetic→Minor)
 - Task: default Normal unless user specifies otherwise
+- Story: default Normal unless user specifies otherwise
 
-## Epic Linking
-Not required.
+## Epic / Parent Linking
+Optional. When the user provides a parent ticket ID (e.g., an epic key like `KFLUXUI-1234`), the new issue should be created as a child of that parent.
+
+**Jira Cloud field:** Use `"parent": "<PARENT_KEY>"` in `additional_fields`. Do NOT use the legacy `customfield_10014` epic link field.
 
 ## Task Template
 Title + description with bullet points summarizing the work.
+
+## Story Template
+```
+## Acceptance Criteria
+
+- [ ] As a <user>, I can <action> so that <outcome>
+- [ ] ...
+
+## Notes
+
+<Developer notes, links to design docs, references to related documentation, or any additional context>
+```
 
 ## Bug Template
 ```


### PR DESCRIPTION
## Fixes
Fixes: https://redhat.atlassian.net/browse/KFLUXUI-1242

## Description
Enhances the jira-ticket skill to support creating issues under a parent ticket (e.g., an epic) and adds Story as a new issue type with an acceptance criteria + notes template. Also fixes the `additional_fields` format to use JSON strings matching the actual MCP tool API, updates stale anti-patterns and fallback instructions, and compacts the SKILL.md from 469 to 212 lines by removing redundant sections (markdown formatting guide, severity table, straightforward examples) while preserving all load-bearing instructions.

## Type of change
- [x] Other (please describe): AI skill/tooling configuration update

## How to test or reproduce?
- Invoke `/jira-ticket` and create a task under a parent epic — verify the parent field is included in the tool call
- Invoke `/jira-ticket` and create a story — verify the acceptance criteria template is used
- Review SKILL.md to confirm all interview flow steps, tool call shape, and examples are intact


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating Story-type issues in Jira with acceptance criteria templates.
  * Improved parent ticket linking with clearer workflows.

* **Documentation**
  * Streamlined ticket creation guidance with issue-specific fill-in instructions.
  * Simplified MCP server configuration instructions.
  * Updated examples to reflect current best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->