### PR TITLE
chore: connect to fullsend agent pipeline

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -13,13 +13,11 @@ name: fullsend
 
 on:
   issues:
-    types: [opened, edited, labeled]
+    types: [labeled]
   issue_comment:
     types: [created]
   pull_request_target:
     types: [opened, synchronize, ready_for_review]
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   dispatch-triage:
@@ -28,14 +26,7 @@ jobs:
       group: triage-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: true
     if: >-
-      (github.event_name == 'issues' && (
-        github.event.action == 'opened' ||
-        (github.event.action == 'edited' &&
-          !contains(toJSON(github.event.issue.labels.*.name), 'ready-to-code') &&
-          !contains(toJSON(github.event.issue.labels.*.name), 'needs-info') &&
-          !contains(toJSON(github.event.issue.labels.*.name), 'duplicate'))
-      )) ||
-      (github.event_name == 'issue_comment' && (
+      github.event_name == 'issue_comment' && (
         github.event.comment.body == '/triage' ||
         startsWith(github.event.comment.body, '/triage ') ||
         (
@@ -44,7 +35,7 @@ jobs:
           !endsWith(github.event.comment.user.login, '[bot]') &&
           contains(toJSON(github.event.issue.labels.*.name), 'needs-info')
         )
-      ))
+      )
     steps:
       - name: Dispatch triage
         env:

--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -1,0 +1,110 @@
+# fullsend shim workflow
+# Routes events to per-role agent dispatch workflows in .fullsend.
+#
+# Security: pull_request_target runs the BASE branch version of this workflow,
+# preventing PRs from modifying it to exfiltrate the dispatch token.
+# This shim never checks out PR code, so it is not vulnerable to "pwn request"
+# attacks (see: Trivy CVE-2026-33634, hackerbot-claw campaign).
+#
+# The event payload is passed via an environment variable (not inline shell)
+# to prevent script injection from attacker-controlled fields like issue
+# titles, comment bodies, and PR descriptions.
+name: fullsend
+
+on:
+  issues:
+    types: [opened, edited, labeled]
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, ready_for_review]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  dispatch-triage:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: triage-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: true
+    if: >-
+      (github.event_name == 'issues' && (
+        github.event.action == 'opened' ||
+        (github.event.action == 'edited' &&
+          !contains(toJSON(github.event.issue.labels.*.name), 'ready-to-code') &&
+          !contains(toJSON(github.event.issue.labels.*.name), 'needs-info') &&
+          !contains(toJSON(github.event.issue.labels.*.name), 'duplicate'))
+      )) ||
+      (github.event_name == 'issue_comment' && (
+        github.event.comment.body == '/triage' ||
+        startsWith(github.event.comment.body, '/triage ') ||
+        (
+          (github.event.comment.author_association != 'NONE' ||
+            github.event.comment.user.login == github.event.issue.user.login) &&
+          !endsWith(github.event.comment.user.login, '[bot]') &&
+          contains(toJSON(github.event.issue.labels.*.name), 'needs-info')
+        )
+      ))
+    steps:
+      - name: Dispatch triage
+        env:
+          GH_TOKEN: ${{ secrets.FULLSEND_DISPATCH_TOKEN }}
+          EVENT_PAYLOAD: ${{ toJSON(github.event) }}
+          EVENT_TYPE: ${{ github.event_name }}
+          SOURCE_REPO: ${{ github.repository }}
+          DISPATCH_REPO: ${{ github.repository_owner }}/.fullsend
+        run: |
+          gh workflow run triage.yml \
+            --repo "$DISPATCH_REPO" \
+            --field event_type="$EVENT_TYPE" \
+            --field source_repo="$SOURCE_REPO" \
+            --field event_payload="$EVENT_PAYLOAD"
+
+  dispatch-code:
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'issues' && github.event.action == 'labeled'
+        && github.event.label.name == 'ready-to-code') ||
+      (github.event_name == 'issue_comment' && (
+        github.event.comment.body == '/code' ||
+        startsWith(github.event.comment.body, '/code ')
+      ))
+    steps:
+      - name: Dispatch code
+        env:
+          GH_TOKEN: ${{ secrets.FULLSEND_DISPATCH_TOKEN }}
+          EVENT_PAYLOAD: ${{ toJSON(github.event) }}
+          EVENT_TYPE: ${{ github.event_name }}
+          SOURCE_REPO: ${{ github.repository }}
+          DISPATCH_REPO: ${{ github.repository_owner }}/.fullsend
+        run: |
+          gh workflow run code.yml \
+            --repo "$DISPATCH_REPO" \
+            --field event_type="$EVENT_TYPE" \
+            --field source_repo="$SOURCE_REPO" \
+            --field event_payload="$EVENT_PAYLOAD"
+
+  dispatch-review:
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'issues' && github.event.action == 'labeled'
+        && github.event.label.name == 'ready-for-review') ||
+      (github.event_name == 'issue_comment' && (
+        github.event.comment.body == '/review' ||
+        startsWith(github.event.comment.body, '/review ')
+      )) ||
+      github.event_name == 'pull_request_target'
+    steps:
+      - name: Dispatch review
+        env:
+          GH_TOKEN: ${{ secrets.FULLSEND_DISPATCH_TOKEN }}
+          EVENT_PAYLOAD: ${{ toJSON(github.event) }}
+          EVENT_TYPE: ${{ github.event_name }}
+          SOURCE_REPO: ${{ github.repository }}
+          DISPATCH_REPO: ${{ github.repository_owner }}/.fullsend
+        run: |
+          gh workflow run review.yml \
+            --repo "$DISPATCH_REPO" \
+            --field event_type="$EVENT_TYPE" \
+            --field source_repo="$SOURCE_REPO" \
+            --field event_payload="$EVENT_PAYLOAD"


### PR DESCRIPTION
## Summary

- Adds the fullsend shim workflow to route GitHub events to per-role agent dispatch workflows in `.fullsend`
- The `pull_request_review` event is registered for future use but intentionally not wired to `dispatch-review` to prevent feedback loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced an automated workflow routing system that forwards issue and pull-request events to centralized downstream workflows for triage, coding, and review.
  * Triggers include issue labels, slash-command comments (e.g., /triage, /code, /review), and pull request events to streamline processing.
  * Dispatches events with secure authentication and payload forwarding to improve automation and operational efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->