### PR TITLE
chore(KFLUXUI-1263): add debug-e2e-tests skill for CI failure triage

### DIFF
--- a/.claude/skills/debug-e2e-tests/SKILL.md
+++ b/.claude/skills/debug-e2e-tests/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: debug-e2e-tests
+description: >
+  Debug e2e test failures, triage CI failures, analyze Cypress test logs,
+  investigate flaky tests, diagnose test failures, check PR test results,
+  why did tests fail, debug cypress, analyze test artifacts
+---
+
+# Debug E2E Tests Skill
+
+Investigate failed Cypress e2e test runs by downloading logs and artifacts from GitHub Actions, analyzing test failures, and suggesting fixes.
+
+## Startup
+
+```bash
+gh auth status 2>&1 | head -3 && echo "---" && gh repo view --json nameWithOwner -q .nameWithOwner
+```
+
+Expected repo: `konflux-ci/konflux-ui`
+
+## Input
+
+The user provides a **run URL**, **run ID**, **PR number**, or asks about "the latest failure".
+
+- **Run URL or ID:** Extract the run ID and go to Step 2.
+- **PR number:** Find the failed run first (Step 1).
+- **"Latest failure":** Find the latest failed run (Step 1b).
+
+## Workflow
+
+### Step 1 — Find the run (PR number only)
+
+```bash
+HEAD_SHA=$(gh pr view PR_NUMBER --repo konflux-ci/konflux-ui --json headRefOid -q .headRefOid)
+gh api "repos/konflux-ci/konflux-ui/actions/runs?head_sha=$HEAD_SHA&per_page=5" \
+  --jq '.workflow_runs[] | {id, name, status, conclusion}'
+```
+
+### Step 1b — Find the latest failed run (no PR/run ID)
+
+```bash
+gh run list --repo konflux-ci/konflux-ui --workflow "PR Check Test" --status failure --limit 5
+```
+
+### Step 2 — Download artifacts
+
+Single command — gets run status, downloads logs artifact, and lists files:
+
+```bash
+ARTIFACT_DIR=$(mktemp -d) && echo "ARTIFACT_DIR=$ARTIFACT_DIR" && \
+gh run view RUN_ID --repo konflux-ci/konflux-ui --json status,conclusion,jobs \
+  --jq '{status: .status, conclusion: .conclusion, failed_jobs: [.jobs[] | select(.conclusion == "failure") | .name], all_jobs: [.jobs[] | {name: .name, status: .status, conclusion: .conclusion}]}' && \
+echo "---" && \
+gh run download RUN_ID --repo konflux-ci/konflux-ui --name logs --dir "$ARTIFACT_DIR" 2>&1 && \
+echo "--- artifacts:" && \
+find "$ARTIFACT_DIR" -type f | sort
+```
+
+If `status` is `in_progress`, artifacts may still exist from a completed test step — proceed with analysis.
+
+If download fails (no artifacts), fall back to: `gh run view RUN_ID --repo konflux-ci/konflux-ui --log-failed`
+
+### Step 3 — Analyze and report
+
+Use the artifact file list from Step 2. Analyze in priority order — stop early if root cause is clear.
+
+**File paths:** The `find` output from Step 2 prints absolute paths — use those directly when reading files.
+
+**Cascade awareness:** The test suite runs with `testIsolation: false` — tests within a `describe` block share state. Find the **first** failure chronologically; subsequent failures in the same block are likely cascades. Focus on the root failure only.
+
+#### Analysis priority
+
+1. **JUnit XML** (`junit-*.xml`) — Which tests failed, error messages, durations. Identify cascades here.
+2. **Cypress log** (`cypress-log.txt`) — Full terminal output. Search for `CypressError`, `AssertionError`, or `failing` to locate the error, then read the 10-20 commands before it for context.
+3. **Screenshots** (`screenshots/*.png`) — Visual state at failure. Use the Read tool.
+4. **Saved DOMs** (`saved-doms/*.html`) — Check for: element not visible, error banner/modal blocking UI, loading state, logged out.
+5. **Infrastructure logs** — When the failure points to backend/cluster issues:
+
+| File                              | What to look for                                |
+| --------------------------------- | ----------------------------------------------- |
+| `konflux-ui.log`                  | Proxy pod logs, API routing errors              |
+| `pipelinerun-res.log`             | PipelineRun status (empty = none created)       |
+| `taskrun-res.log`                 | TaskRun status, Tekton-level failures           |
+| `failed-pods-logs.log`            | Container failures, OOMKilled, CrashLoopBackOff (only if Warning events exist) |
+| `failed-pods-definitions.yaml`    | Pod specs for failed pods (only if Warning events exist) |
+| `operator-logs.log`               | Operator crashes, reconciliation errors         |
+| `system-resources.log`            | Node CPU/memory pressure, disk usage            |
+| `cluster-resources.log`           | Cluster-wide resource overview                  |
+| `container-resources.log`         | Per-container resource usage                    |
+| `mem.log`                         | Memory usage over time during test run          |
+| `konflux-crs-status.log`          | Custom Resource readiness conditions            |
+| `failed-deployment-event-log.log` | Deployment rollout failures                     |
+| `kyverno-policy-pods.log`         | Kyverno policy violations                       |
+
+6. **Cluster resource dumps** (`artifacts/`) — `events.json` for timing issues, `pipelineruns.json`, `components.json`. Pod logs in `artifacts/pods/` (especially build-service and PaC controller).
+7. **Skip** `index.html` (mochawesome — too large to read) and `videos/*.mp4` (can't view in CLI).
+
+#### If the failure looks like a regression
+
+Check what code was changed: `gh pr diff PR_NUMBER --repo konflux-ci/konflux-ui`
+
+Cross-reference: selector changes (`data-test`), API endpoint changes, component modifications.
+
+#### Root cause categories
+
+| Category                    | Description                                          | Where to fix     |
+| --------------------------- | ---------------------------------------------------- | ---------------- |
+| **A. Test code issue**      | Bad selector, missing wait, wrong assertion          | `e2e-tests/`     |
+| **B. UI bug**               | Component rendering error, broken user flow          | `src/`           |
+| **C. Infrastructure flake** | WebSocket drop, cluster timeout, resource exhaustion | Test resilience  |
+| **D. Pipeline/backend**     | Build failure, API error, auth problem               | Backend/config   |
+| **E. Cascade failure**      | Caused by an earlier test failing                    | Fix root failure |
+
+#### Report format
+
+```markdown
+## E2E Test Failure Analysis
+
+**Run:** [link to GH Actions run]
+**PR:** [link to PR, if applicable]
+**Failed tests:** X of Y (Z cascade failures)
+
+### Root Failure
+**Test:** [test name]
+**Category:** [A/B/C/D/E] — [category name]
+**Error:** [one-line error message]
+
+**Analysis:**
+[2-3 sentences explaining what happened and why]
+
+**Suggested fix:**
+[Concrete suggestion — file path, what to change, or "retry if flake"]
+
+### Cascade Failures (if any)
+- [test name] — caused by root failure above
+
+### Artifacts reviewed
+- [list of files that were analyzed]
+```
+
+## Common failure patterns
+
+| Pattern                                                      | Likely cause                             | Quick check                                      |
+| ------------------------------------------------------------ | ---------------------------------------- | ------------------------------------------------ |
+| `Timed out retrying: cy.get() - element not found`           | Selector changed or element not rendered | Check DOM snapshot for element presence          |
+| `expected X to equal Y` but values look correct              | Whitespace or timing issue               | Check if text has leading/trailing spaces        |
+| `cy.get() - exceeded timeout of 40000ms`                     | Slow page load or missing element        | Check infrastructure logs for API errors         |
+| `Status still running. Reloading page (0 retries remaining)` | Pipeline too slow or websocket dropped   | Check `system-resources.log` for resource issues |
+| All tests after a certain point failed                       | Cascade failure                          | Find the first failure                           |
+| Login-related errors in before() hook                        | Auth/cluster issue                       | Check infrastructure logs for 401/403            |

--- a/.claude/skills/debug-e2e-tests/SKILL.md
+++ b/.claude/skills/debug-e2e-tests/SKILL.md
@@ -13,7 +13,7 @@ Investigate failed Cypress e2e test runs by downloading logs and artifacts from 
 ## Startup
 
 ```bash
-gh auth status 2>&1 | head -3 && echo "---" && gh repo view --json nameWithOwner -q .nameWithOwner
+gh repo view --json nameWithOwner -q .nameWithOwner
 ```
 
 Expected repo: `konflux-ci/konflux-ui`
@@ -76,21 +76,21 @@ Use the artifact file list from Step 2. Analyze in priority order — stop early
 4. **Saved DOMs** (`saved-doms/*.html`) — Check for: element not visible, error banner/modal blocking UI, loading state, logged out.
 5. **Infrastructure logs** — When the failure points to backend/cluster issues:
 
-| File                              | What to look for                                |
-| --------------------------------- | ----------------------------------------------- |
-| `konflux-ui.log`                  | Proxy pod logs, API routing errors              |
-| `pipelinerun-res.log`             | PipelineRun status (empty = none created)       |
-| `taskrun-res.log`                 | TaskRun status, Tekton-level failures           |
+| File                              | What to look for                                                               |
+| --------------------------------- | ------------------------------------------------------------------------------ |
+| `konflux-ui.log`                  | Proxy pod logs, API routing errors                                             |
+| `pipelinerun-res.log`             | PipelineRun status (empty = none created)                                      |
+| `taskrun-res.log`                 | TaskRun status, Tekton-level failures                                          |
 | `failed-pods-logs.log`            | Container failures, OOMKilled, CrashLoopBackOff (only if Warning events exist) |
-| `failed-pods-definitions.yaml`    | Pod specs for failed pods (only if Warning events exist) |
-| `operator-logs.log`               | Operator crashes, reconciliation errors         |
-| `system-resources.log`            | Node CPU/memory pressure, disk usage            |
-| `cluster-resources.log`           | Cluster-wide resource overview                  |
-| `container-resources.log`         | Per-container resource usage                    |
-| `mem.log`                         | Memory usage over time during test run          |
-| `konflux-crs-status.log`          | Custom Resource readiness conditions            |
-| `failed-deployment-event-log.log` | Deployment rollout failures                     |
-| `kyverno-policy-pods.log`         | Kyverno policy violations                       |
+| `failed-pods-definitions.yaml`    | Pod specs for failed pods (only if Warning events exist)                       |
+| `operator-logs.log`               | Operator crashes, reconciliation errors                                        |
+| `system-resources.log`            | Node CPU/memory pressure, disk usage                                           |
+| `cluster-resources.log`           | Cluster-wide resource overview                                                 |
+| `container-resources.log`         | Per-container resource usage                                                   |
+| `mem.log`                         | Memory usage over time during test run                                         |
+| `konflux-crs-status.log`          | Custom Resource readiness conditions                                           |
+| `failed-deployment-event-log.log` | Deployment rollout failures                                                    |
+| `kyverno-policy-pods.log`         | Kyverno policy violations                                                      |
 
 6. **Cluster resource dumps** (`artifacts/`) — `events.json` for timing issues, `pipelineruns.json`, `components.json`. Pod logs in `artifacts/pods/` (especially build-service and PaC controller).
 7. **Skip** `index.html` (mochawesome — too large to read) and `videos/*.mp4` (can't view in CLI).
@@ -121,6 +121,7 @@ Cross-reference: selector changes (`data-test`), API endpoint changes, component
 **Failed tests:** X of Y (Z cascade failures)
 
 ### Root Failure
+
 **Test:** [test name]
 **Category:** [A/B/C/D/E] — [category name]
 **Error:** [one-line error message]
@@ -132,9 +133,11 @@ Cross-reference: selector changes (`data-test`), API endpoint changes, component
 [Concrete suggestion — file path, what to change, or "retry if flake"]
 
 ### Cascade Failures (if any)
+
 - [test name] — caused by root failure above
 
 ### Artifacts reviewed
+
 - [list of files that were analyzed]
 ```
 


### PR DESCRIPTION
## Fixes
<!-- No Jira ticket associated with this change -->

Fixes https://redhat.atlassian.net/browse/KFLUXUI-1263

## Description

Add a Claude Code skill that guides systematic investigation of Cypress e2e test failures in GitHub Actions. The skill provides a structured workflow: discover the failed run (by PR number, run ID, or latest failure), download artifacts, and analyze them in priority order (JUnit XML, Cypress logs, screenshots, saved DOMs, infrastructure logs, cluster resource dumps). It includes cascade failure awareness (`testIsolation: false`), root cause categorization, and a structured report template.

## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Claude Code skill for e2e test debugging workflow

## Screen shots / Gifs for design review
<!-- No UI changes -->

## How to test or reproduce

Invoke the skill by asking Claude Code to debug a failed e2e test run, e.g.:
- `/debug-e2e-tests` then provide a run URL, run ID, or PR number
- "Why did the e2e tests fail on PR #829?"
- "Debug the latest e2e failure"

### Example analyses produced with this skill

<details>
<summary>Run 24918452651 — Pipeline/Backend failure (D)</summary>

E2E Test Failure Analysis

Run: https://github.com/konflux-ci/konflux-ui/actions/runs/24918452651
Failed tests: 7 of 17 (6 cascade failures from 1 root cause)

Root Failure

Test: Merge the auto-generated PR, and verify the event status on modal
Category: D — Pipeline/Backend
Error: Timed out retrying after 300000ms: Expected to find content: 'java-quarkus-177707818-on-pull' within the selector: '[aria-label="Pipeline run List"] tr[role="row"]' but never did.

Analysis:
The test waits for the on-pull-request PipelineRun to appear on the component's Activity > Pipeline runs tab before merging the PR. After 5 minutes of waiting, the pipeline run list remained completely empty (the DOM shows the "Keep tabs on components and activity" empty state). The API fetches for PipelineRuns (GET .../pipelineruns?labelSelector=...component=java-quarkus-177707818) returned 200 but with no items. Additionally, the WebSocket for PipelineRun watching repeatedly disconnected and failed to reconnect after 3 attempts (cons:error: Failed to reconnect WebSocket). This means PaC (Pipelines as Code) either never created the on-pull-request PipelineRun or it took longer than 300 seconds, a backend/infrastructure issue on the staging cluster.

Suggested fix: This is an infrastructure flake — retry the run. If it recurs, investigate the PaC controller and build-service logs on stone-stg-rh01 to determine why the on-pull-request PipelineRun wasn't created.

Cascade Failures

- Verify the Pipeline run details and Node Graph view — no pipeline runs exist to inspect
- Verify that on-pull pipeline was cancelled — no pipeline runs in the list
- Verify Enterprise contract Test pipeline run Details — no test pipeline run was triggered
- Check component build status — components tab shows "Build not started" (no build ran)
- Validate Build Logs are successful — no build logs available since build never started
- Check Component Details > before all hook — component link click failed (element hidden), stale UI state from prior failures

Artifacts reviewed

- junit-379e2e20cb5300d19f143e7b4d3bb5d4.xml
- cypress-log.txt (lines 860-1010, last 120 lines)
- screenshots/...Merge the auto-generated PR... — empty pipeline runs tab
- screenshots/...Check component build status... — "Build not started"
- saved-doms/...Merge the auto-generated PR__(failed).html — empty state in DOM

</details>

<details>
<summary>Run 24753080106 — GitHub App misconfiguration (D)</summary>

E2E Test Failure Analysis

Run: https://github.com/konflux-ci/konflux-ui/actions/runs/24753080106
Job: periodic-local-e2e-test
Failed tests: 9 of 17 (8 cascade failures from 1 root cause)

Root Failure

Test: Merge the auto-generated PR, and verify the event status on modal
Category: D — Pipeline/Backend
Error: Timed out retrying after 300000ms: Expected to find content: 'java-quarkus-177681742-on-pull' within the selector '[aria-label="Pipeline run List"] tr[role="row"]' but never did.

Analysis:
The build-service logs reveal the exact cause. PaC provisioning for component java-quarkus-177681742 failed at 00:24:04 with:

"error": "GET https://api.github.com/app: 404 Integration not found []"

The GitHub App integration is not properly configured in the local e2e cluster environment. Without a working GitHub App, PaC cannot create the initial PR, no webhook fires, and no on-pull-request PipelineRun is created. The pipelinerun-res.log confirms: items: [] — zero PipelineRuns existed throughout the entire test run.

Additionally, the build-service hit a K8s conflict error ("the object has been modified") during component onboarding, which it retried — but the retry also failed on the GitHub App issue.

Suggested fix: The local e2e cluster's GitHub App credentials need to be fixed. Check the pipelines-as-code-secret in the pipelines-as-code namespace — the GitHub App ID and private key are either missing, expired, or the app was uninstalled/revoked on GitHub's side.

Cascade Failures

- Verify the Pipeline run details and Node Graph view — no pipeline runs exist
- Verify that on-pull pipeline was cancelled — no pipeline runs to cancel
- Verify Enterprise contract Test pipeline run Details — no test pipeline runs triggered
- Check component build status — "Build not started" (build never ran)
- Validate Build Logs are successful — no build logs since build never started
- Check Component Details > before all hook — build-logs modal left open from previous test covers the component link
- Delete the application via UI — page is at about:blank after session was cleared by previous hook failure
- after all hook: collectBackendCoverage — no baseUrl available since page is blank

Artifacts reviewed

- junit-ee9f0734bad9f5f3b129c7b013c30b22.xml
- pipelinerun-res.log — empty, zero PipelineRuns created
- artifacts/pods/build-service_...log — GitHub App 404 error
- artifacts/pods/pipelines-as-code_...log — only startup logs, no webhook activity
- system-resources.log — healthy (15Gi RAM, 4 CPUs, load 1.31)
- screenshots/...Delete the application... — page shows "Default blank page"

</details>

<details>
<summary>Run 24981123755 / PR #829 — Infrastructure flake (C)</summary>

E2E Test Failure Analysis

Run: https://github.com/konflux-ci/konflux-ui/actions/runs/24981123755
PR: https://github.com/konflux-ci/konflux-ui/pull/829
Failed tests: 5 of 17 (4 cascade failures)

Root Failure

Test: Verify the Pipeline run details and Node Graph view
Category: C — Infrastructure flake
Error: Timed out retrying after 3000000ms: expected '<span>' not to have text 'Running'

Analysis:
The on-push pipeline run (java-quarkus-177727405-on-push-qwdf4) got stuck with 11/12 tasks completed. The clair-scan TaskRun remained in Running status indefinitely — all its containers were pulled and started successfully, but the task never completed. The cluster had adequate resources (10Gi available memory, 50% disk usage), so this is a clair-scan task hang, not resource exhaustion. The test waited 50 minutes via a simple Cypress .should('not.have.text', 'Running') assertion with a 3,000,000ms timeout — no page reloads occur during this wait, so if the WebSocket connection dropped at any point during those 50 minutes, the UI would also show stale "Running" status even if the backend eventually progressed. However, the taskrun artifacts confirm clair-scan was genuinely still Running when collected.

Suggested fix:
The immediate failure is an infra flake — retry the run. However, the waitUntilStatusIsNotRunning method has a design weakness: it relies on a single Cypress assertion with a very long timeout (50 min) and no page reloads. If the WebSocket connection drops mid-wait, the UI will show stale data indefinitely. Adding periodic page reloads (e.g., every few minutes) would make this wait more resilient to both WebSocket disconnects and transient UI staleness.

Cascade Failures

- Verify Enterprise contract Test pipeline run Details — the integration test pipeline never triggered because the build pipeline never completed
- Check component build status — expected "Build completed" but build was still running (stuck clair-scan)
- Validate Build Logs are successful — can't find apply-tags task in log viewer; pipeline incomplete
- Verify deployed image exists (before all hook) — element click blocked by log gutter overlay; downstream UI state corruption from prior failures

Artifacts reviewed

- junit-cc7a9bbf88a51843f6623cffc4b49011.xml
- pipelinerun-res.log — on-push PLR stuck at 11/12 tasks (Succeeded: Unknown, reason=Running)
- taskrun-res.log — clair-scan TaskRun still Running, all others Succeeded
- system-resources.log — cluster resources adequate
- artifacts/events.json — clair-scan pod events show all containers started normally
- Screenshots: pipeline run details (Running status), component build status (Build running), enterprise contract (no Test row)
- PipelinerunsTabPage.ts (PR branch) — waitUntilStatusIsNotRunning uses a single 3M ms Cypress timeout with no page reloads

</details>

## Browser conformance
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide for diagnosing failed Cypress E2E tests in CI: how to select relevant workflow runs, prioritized artifact inspection (JUnit XML, Cypress logs, screenshots, saved DOMs, infra logs), fallback log retrieval, cascade-failure detection, regression checks via PR diff, root-cause taxonomy (test/UI/infra/pipeline/cascade), common failure patterns with quick checks, and a standardized failure-report template.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konflux-ci/konflux-ui/pull/836?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->