### PR TITLE
refactor(KFLUXUI-1216): add page reload for e2e pipeline run status check

### DIFF
--- a/e2e-tests/support/pages/tabs/PipelinerunsTabPage.ts
+++ b/e2e-tests/support/pages/tabs/PipelinerunsTabPage.ts
@@ -105,12 +105,42 @@ export class DetailsTab {
     UIhelper.clickTab('Details');
   }
 
-  // Setting timeout to 50 minutes (Builds sometimes taking slightly longer than 40 minutes).
-  static waitUntilStatusIsNotRunning() {
-    cy.get(pipelinerunsTabPO.statusPO).scrollIntoView();
-    cy.get(pipelinerunsTabPO.statusPO, { timeout: 3000000 })
-      .should('not.have.text', 'Pending')
-      .and('not.have.text', 'Running');
+  // wait for status to be not running, if it is still running after retries, throw error to fail the test
+  static waitUntilStatusIsNotRunning(
+    timeoutDuration: number = 1800000, // 30 minutes
+    interval: number = 60000, // 60 seconds
+    retries: number = 7, // number of retries before failing the test
+  ) {
+    if (retries <= 0) {
+      assert.fail('Pipelinerun is still running after maximum retries');
+    }
+
+    const maxAttempts = Math.max(1, Math.floor(timeoutDuration / interval));
+
+    const checkStatus = (attempt: number) => {
+      cy.get(pipelinerunsTabPO.statusPO)
+        .scrollIntoView()
+        .invoke('text')
+        .then((statusText) => {
+          if (!statusText.includes('Pending') && !statusText.includes('Running')) {
+            expect(statusText).to.not.include('Running');
+            return;
+          }
+          if (attempt >= maxAttempts) {
+            cy.log(
+              `Status still running. Reloading page (${retries - 1} ${retries - 1 === 1 ? 'retry' : 'retries'} remaining).`,
+            );
+            cy.reload();
+            // 180000 ms = 3 minutes
+            this.waitUntilStatusIsNotRunning(180000, interval, retries - 1);
+            return;
+          }
+          cy.wait(interval);
+          checkStatus(attempt + 1);
+        });
+    };
+
+    checkStatus(0);
   }
 
   static clickOnNode(nodeId: string) {

--- a/e2e-tests/support/pages/tabs/PipelinerunsTabPage.ts
+++ b/e2e-tests/support/pages/tabs/PipelinerunsTabPage.ts
@@ -123,12 +123,11 @@ export class DetailsTab {
         .invoke('text')
         .then((statusText) => {
           if (!statusText.includes('Pending') && !statusText.includes('Running')) {
-            expect(statusText).to.not.include('Running');
             return;
           }
           if (attempt >= maxAttempts) {
             cy.log(
-              `Status still running. Reloading page (${retries - 1} ${retries - 1 === 1 ? 'retry' : 'retries'} remaining).`,
+              `Status is "${statusText}". Reloading page (${retries - 1} ${retries - 1 === 1 ? 'retry' : 'retries'} remaining).`,
             );
             cy.reload();
             // 180000 ms = 3 minutes

--- a/e2e-tests/support/pages/tabs/PipelinerunsTabPage.ts
+++ b/e2e-tests/support/pages/tabs/PipelinerunsTabPage.ts
@@ -111,7 +111,7 @@ export class DetailsTab {
     interval: number = 60000, // 60 seconds
     retries: number = 7, // number of retries before failing the test
   ) {
-    if (retries <= 0) {
+    if (retries < 0) {
       assert.fail('Pipelinerun is still running after maximum retries');
     }
 

--- a/e2e-tests/support/pages/tabs/PipelinerunsTabPage.ts
+++ b/e2e-tests/support/pages/tabs/PipelinerunsTabPage.ts
@@ -105,7 +105,11 @@ export class DetailsTab {
     UIhelper.clickTab('Details');
   }
 
-  // wait for status to be not running, if it is still running after retries, throw error to fail the test
+  // Polls the pipeline run status until it's no longer "Pending" or "Running".
+  // If the status doesn't change after repeated checks, reloads the page and
+  // retries, since the UI may not update without a refresh. Uses recursion
+  // instead of a loop because Cypress commands are asynchronous and don't
+  // support try/catch for flow control.
   static waitUntilStatusIsNotRunning(
     timeoutDuration: number = 1800000, // 30 minutes
     interval: number = 60000, // 60 seconds


### PR DESCRIPTION

## Fixes
Fixes: https://redhat.atlassian.net/browse/KFLUXUI-1216

## Description
Refactors the `waitUntilStatusIsNotRunning` method in `PipelinerunsTabPage` to handle websocket connection loss during long pipeline runs on the local Konflux backend. Instead of a single 50-minute wait that can stall when the websocket drops, the method now waits up to 30 minutes with periodic checks, then reloads the page every ~3 minutes (up to 7 retries) to re-establish the connection and refresh the status.

## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): e2e test improvement

## Screen shots / Gifs for design review
<!-- No UI changes -->

## How to test or reproduce?
- Run the e2e tests that use `DetailsTab.waitUntilStatusIsNotRunning()` against a local Konflux backend
- Verify that when a pipeline run takes longer than 30 minutes, the page reloads and the status is re-checked
- Verify that if the pipeline completes within 30 minutes, no reload occurs

## Browser conformance:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability for monitoring pipeline run status with configurable timeout, polling interval, and retry behavior.
  * Tests now poll status text, auto-refresh, and retry when a run remains in progress to reduce flakiness and catch stalled runs.
  * Tests explicitly fail after maximum retries to surface persistent issues promptly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->