### PR TITLE
feat(KFLUXUI-1277): refactor log data flow to use structured per-container data

### DIFF
--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
@@ -33,7 +33,7 @@ import { FeatureFlagIndicator } from '~/feature-flags/FeatureFlagIndicator';
 import { useAutoScrollWithResume } from '~/shared/components/pipeline-run-logs/logs/useAutoScrollWithResume';
 import { useLogViewerSearch } from '~/shared/components/pipeline-run-logs/logs/useLogViewerSearch';
 import { LoadingInline } from '~/shared/components/status-box/StatusBox';
-import { VirtualizedLogViewer } from '~/shared/components/virtualized-log-viewer';
+import { VirtualizedLogViewer, LogSection } from '~/shared/components/virtualized-log-viewer';
 import { useFullscreen } from '~/shared/hooks/fullscreen';
 import { TaskRunKind } from '~/types';
 import LogsTaskDuration from './LogsTaskDuration';
@@ -48,7 +48,13 @@ const ANSI_ESCAPE_REGEX = /\u001b\[[0-9;]*m/g;
 
 export type Props = {
   showSearch?: boolean;
-  data: string;
+
+  // Either data or sections should be provided, not both.
+  // data: single string when logs come pre-aggregated (TektonTaskRunLog)
+  // sections: structured per-container data when fetched individually (Logs.tsx)
+  data?: string;
+  sections?: LogSection[];
+
   allowAutoScroll?: boolean;
   downloadAllLabel?: string;
   onDownloadAll?: () => Promise<Error>;
@@ -66,6 +72,7 @@ const LogViewer: React.FC<Props> = ({
   showSearch = true,
   allowAutoScroll,
   data = '',
+  sections,
   downloadAllLabel,
   onDownloadAll,
   taskRun,
@@ -86,9 +93,20 @@ const LogViewer: React.FC<Props> = ({
 
   // Console rewind action adds \r to the logs, this replaces them not to cause line overlap
   // Remove ANSI escape codes for plain text display
+  const processedSections = React.useMemo<LogSection[] | undefined>(() => {
+    if (!sections) return undefined;
+    return sections.map((section) => ({
+      containerName: section.containerName,
+      lines: section.lines.map((line) => line.replace(/\r/g, '\n').replace(ANSI_ESCAPE_REGEX, '')),
+    }));
+  }, [sections]);
+
   const processedData = React.useMemo(() => {
+    if (processedSections) {
+      return processedSections.flatMap((s) => [s.containerName, ...s.lines]).join('\n');
+    }
     return data.replace(/\r/g, '\n').replace(ANSI_ESCAPE_REGEX, '');
-  }, [data]);
+  }, [data, processedSections]);
 
   const lines = React.useMemo(() => processedData.split('\n'), [processedData]);
 
@@ -102,9 +120,16 @@ const LogViewer: React.FC<Props> = ({
     useFullscreen<HTMLDivElement>();
   const [downloadAllStatus, setDownloadAllStatus] = React.useState(false);
 
+  const downloadData = React.useMemo(() => {
+    if (processedSections) {
+      return processedSections.map((s) => `${s.containerName}\n${s.lines.join('\n')}`).join('\n\n');
+    }
+    return data;
+  }, [data, processedSections]);
+
   const downloadLogs = () => {
-    if (!data) return;
-    const blob = new Blob([data], {
+    if (!downloadData) return;
+    const blob = new Blob([downloadData], {
       type: 'text/plain;charset=utf-8',
     });
     saveAs(blob, `${taskName || `task-run-${uuidv4()}`}.log`);
@@ -112,7 +137,7 @@ const LogViewer: React.FC<Props> = ({
 
   const startDownloadAll = () => {
     setDownloadAllStatus(true);
-    onDownloadAll()
+    onDownloadAll?.()
       .then(() => {
         setDownloadAllStatus(false);
       })
@@ -273,6 +298,7 @@ const LogViewer: React.FC<Props> = ({
               <VirtualizedLogViewer
                 key={taskRun?.metadata?.uid || 'default'}
                 data={processedData}
+                sections={processedSections}
                 height={viewerHeight}
                 scrollToRow={scrolledRow}
                 onScroll={handleScroll}

--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
@@ -33,7 +33,7 @@ import { FeatureFlagIndicator } from '~/feature-flags/FeatureFlagIndicator';
 import { useAutoScrollWithResume } from '~/shared/components/pipeline-run-logs/logs/useAutoScrollWithResume';
 import { useLogViewerSearch } from '~/shared/components/pipeline-run-logs/logs/useLogViewerSearch';
 import { LoadingInline } from '~/shared/components/status-box/StatusBox';
-import { VirtualizedLogViewer, LogSection } from '~/shared/components/virtualized-log-viewer';
+import { VirtualizedLogViewer, type LogSection } from '~/shared/components/virtualized-log-viewer';
 import { useFullscreen } from '~/shared/hooks/fullscreen';
 import { TaskRunKind } from '~/types';
 import LogsTaskDuration from './LogsTaskDuration';
@@ -124,7 +124,7 @@ const LogViewer: React.FC<Props> = ({
     if (processedSections) {
       return processedSections.map((s) => `${s.containerName}\n${s.lines.join('\n')}`).join('\n\n');
     }
-    return data;
+    return data.replace(/\r/g, '\n').replace(ANSI_ESCAPE_REGEX, '');
   }, [data, processedSections]);
 
   const downloadLogs = () => {

--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
@@ -32,6 +32,7 @@ import { saveAs } from 'file-saver';
 import { debounce } from 'lodash-es';
 import { v4 as uuidv4 } from 'uuid';
 import { FeatureFlagIndicator } from '~/feature-flags/FeatureFlagIndicator';
+import { logger } from '~/monitoring/logger';
 import {
   KeyboardShortcutHint,
   type ShortcutEntry,
@@ -40,6 +41,7 @@ import { useAutoScrollWithResume } from '~/shared/components/pipeline-run-logs/l
 import { useLogViewerSearch } from '~/shared/components/pipeline-run-logs/logs/useLogViewerSearch';
 import { LoadingInline } from '~/shared/components/status-box/StatusBox';
 import { VirtualizedLogViewer, type LogSection } from '~/shared/components/virtualized-log-viewer';
+import { buildLines } from '~/shared/components/virtualized-log-viewer/log-viewer-utils';
 import { useFullscreen } from '~/shared/hooks/fullscreen';
 import { TaskRunKind } from '~/types';
 import LogsTaskDuration from './LogsTaskDuration';
@@ -94,18 +96,7 @@ const LogViewer: React.FC<Props> = ({
       onScroll: onScrollProp,
     });
 
-  const lines = React.useMemo(() => {
-    const result: string[] = [];
-    for (const section of sections) {
-      if (section.containerName) {
-        result.push(section.containerName);
-      }
-      if (section.data) {
-        result.push(...section.data.split('\n'));
-      }
-    }
-    return result;
-  }, [sections]);
+  const lines = React.useMemo(() => buildLines(sections), [sections]);
 
   // Search state and context management
   const { logViewerContextValue, toolbarContextValue, scrolledRow } = useLogViewerSearch({
@@ -140,8 +131,7 @@ const LogViewer: React.FC<Props> = ({
       })
       .catch((err: Error) => {
         setDownloadAllStatus(false);
-        // eslint-disable-next-line no-console
-        console.warn(err.message || 'Error downloading logs.');
+        logger.warn(err.message || 'Error downloading logs.');
       });
   };
 

--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
@@ -39,7 +39,7 @@ import {
 import { useAutoScrollWithResume } from '~/shared/components/pipeline-run-logs/logs/useAutoScrollWithResume';
 import { useLogViewerSearch } from '~/shared/components/pipeline-run-logs/logs/useLogViewerSearch';
 import { LoadingInline } from '~/shared/components/status-box/StatusBox';
-import { VirtualizedLogViewer } from '~/shared/components/virtualized-log-viewer';
+import { VirtualizedLogViewer, type LogSection } from '~/shared/components/virtualized-log-viewer';
 import { useFullscreen } from '~/shared/hooks/fullscreen';
 import { TaskRunKind } from '~/types';
 import LogsTaskDuration from './LogsTaskDuration';
@@ -56,14 +56,9 @@ const LOG_VIEWER_SHORTCUTS: ShortcutEntry[] = [
   { keys: 'End', macKeys: 'Fn + Arrow Right', description: 'Scroll to bottom' },
 ];
 
-// ANSI escape code regex for removing color codes from terminal output
-// ESC character (\u001b) is a control character but necessary for ANSI escape sequences
-// eslint-disable-next-line no-control-regex
-const ANSI_ESCAPE_REGEX = /\u001b\[[0-9;]*m/g;
-
 export type Props = {
   showSearch?: boolean;
-  data: string;
+  sections: LogSection[];
   allowAutoScroll?: boolean;
   downloadAllLabel?: string;
   onDownloadAll?: () => Promise<Error>;
@@ -80,7 +75,7 @@ export type Props = {
 const LogViewer: React.FC<Props> = ({
   showSearch = true,
   allowAutoScroll,
-  data = '',
+  sections,
   downloadAllLabel,
   onDownloadAll,
   taskRun,
@@ -99,13 +94,18 @@ const LogViewer: React.FC<Props> = ({
       onScroll: onScrollProp,
     });
 
-  // Console rewind action adds \r to the logs, this replaces them not to cause line overlap
-  // Remove ANSI escape codes for plain text display
-  const processedData = React.useMemo(() => {
-    return data.replace(/\r/g, '\n').replace(ANSI_ESCAPE_REGEX, '');
-  }, [data]);
-
-  const lines = React.useMemo(() => processedData.split('\n'), [processedData]);
+  const lines = React.useMemo(() => {
+    const result: string[] = [];
+    for (const section of sections) {
+      if (section.containerName) {
+        result.push(section.containerName);
+      }
+      if (section.data) {
+        result.push(...section.data.split('\n'));
+      }
+    }
+    return result;
+  }, [sections]);
 
   // Search state and context management
   const { logViewerContextValue, toolbarContextValue, scrolledRow } = useLogViewerSearch({
@@ -118,9 +118,15 @@ const LogViewer: React.FC<Props> = ({
   const [downloadAllStatus, setDownloadAllStatus] = React.useState(false);
   const [showShortcutHint, setShowShortcutHint] = React.useState(false);
 
+  const downloadData = React.useMemo(() => {
+    return sections
+      .map((s) => (s.containerName ? `${s.containerName}\n${s.data}` : s.data))
+      .join('\n\n');
+  }, [sections]);
+
   const downloadLogs = () => {
-    if (!data) return;
-    const blob = new Blob([data], {
+    if (!downloadData) return;
+    const blob = new Blob([downloadData], {
       type: 'text/plain;charset=utf-8',
     });
     saveAs(blob, `${taskName || `task-run-${uuidv4()}`}.log`);
@@ -128,7 +134,7 @@ const LogViewer: React.FC<Props> = ({
 
   const startDownloadAll = () => {
     setDownloadAllStatus(true);
-    onDownloadAll()
+    onDownloadAll?.()
       .then(() => {
         setDownloadAllStatus(false);
       })
@@ -312,7 +318,7 @@ const LogViewer: React.FC<Props> = ({
             {viewerHeight && (
               <VirtualizedLogViewer
                 key={taskRun?.metadata?.uid || 'default'}
-                data={processedData}
+                sections={sections}
                 height={viewerHeight}
                 scrollToRow={scrolledRow}
                 onScroll={handleScroll}

--- a/src/shared/components/pipeline-run-logs/logs/Logs.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/Logs.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Base64 } from 'js-base64';
 import { useIsOnFeatureFlag } from '~/feature-flags/hooks';
 import { KUBEARCHIVE_PATH_PREFIX } from '~/kubearchive/const';
-import { useDebounceCallback } from '~/shared/hooks/useDebounceCallback';
+import { LogSection } from '~/shared/components/virtualized-log-viewer';
 import { ResourceSource } from '~/types/k8s';
 import { commonFetchText } from '../../../../k8s';
 import { getK8sResourceURL, getWebsocketSubProtocolAndPathPrefix } from '../../../../k8s/k8s-utils';
@@ -18,18 +18,6 @@ import LogViewer, { type Props as LogViewerProps } from './LogViewer';
 type LogSources = { [containerName: string]: string };
 
 const WEB_SOCKET_RETRY_COUNT = 5;
-
-export const processLogs = (logSources: LogSources, containers: ContainerSpec[]): string => {
-  let allLogs = '';
-  for (const container of containers) {
-    const containerName = container.name;
-    if (logSources[containerName]) {
-      allLogs += `\n\n${containerName.toUpperCase()}\n`;
-      allLogs += `  ${logSources[containerName].replace(/\n/g, '\n  ')}`;
-    }
-  }
-  return allLogs.trim();
-};
 
 const retryWebSocket = (
   watchURL: string,
@@ -181,29 +169,6 @@ const Logs: React.FC<LogsProps> = ({
     };
   }, [containers, resource, resName, resNamespace, appendLog, source, isKubearchiveEnabled]);
 
-  const [formattedLogs, setFormattedLogs] = React.useState('');
-  const [processingLogs, setProcessingLogs] = React.useState(false);
-  const containersRef = React.useRef(containers);
-  containersRef.current = containers;
-
-  const processAndSetLogs = useDebounceCallback(() => {
-    const result = processLogs(logSources, containersRef.current);
-    setFormattedLogs(result);
-    setProcessingLogs(false);
-  }, 300);
-
-  React.useEffect(() => {
-    if (Object.keys(logSources).length === 0) {
-      setFormattedLogs('');
-      return;
-    }
-
-    setProcessingLogs(true);
-    processAndSetLogs();
-
-    return () => processAndSetLogs.cancel();
-  }, [logSources, processAndSetLogs]);
-
   const allLogsTerminated = React.useMemo<boolean>(() => {
     if (containers.length === 0) return false;
 
@@ -227,15 +192,24 @@ const Logs: React.FC<LogsProps> = ({
     return allTerminated;
   }, [containers, resource?.status?.containerStatuses]);
 
+  const sections = React.useMemo<LogSection[]>(() => {
+    return containers
+      .filter((c) => logSources[c.name])
+      .map((c) => ({
+        containerName: c.name,
+        lines: logSources[c.name].split('\n'),
+      }));
+  }, [logSources, containers]);
+
   return (
     <LogViewer
-      data={formattedLogs}
+      sections={sections}
       allowAutoScroll={allowAutoScroll && !allLogsTerminated}
       onScroll={onScroll}
       downloadAllLabel={downloadAllLabel}
       onDownloadAll={onDownloadAll}
       taskRun={taskRun}
-      isLoading={isLoading || processingLogs}
+      isLoading={isLoading}
       errorMessage={error ? t('An error occurred while retrieving the requested logs.') : null}
     />
   );

--- a/src/shared/components/pipeline-run-logs/logs/Logs.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/Logs.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Base64 } from 'js-base64';
 import { useIsOnFeatureFlag } from '~/feature-flags/hooks';
 import { KUBEARCHIVE_PATH_PREFIX } from '~/kubearchive/const';
-import { LogSection } from '~/shared/components/virtualized-log-viewer';
+import { type LogSection } from '~/shared/components/virtualized-log-viewer';
 import { ResourceSource } from '~/types/k8s';
 import { commonFetchText } from '../../../../k8s';
 import { getK8sResourceURL, getWebsocketSubProtocolAndPathPrefix } from '../../../../k8s/k8s-utils';
@@ -196,8 +196,8 @@ const Logs: React.FC<LogsProps> = ({
     return containers
       .filter((c) => logSources[c.name])
       .map((c) => ({
-        containerName: c.name,
-        lines: logSources[c.name].split('\n'),
+        containerName: c.name.toUpperCase(),
+        lines: logSources[c.name].split('\n').map((line) => `  ${line}`),
       }));
   }, [logSources, containers]);
 

--- a/src/shared/components/pipeline-run-logs/logs/Logs.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/Logs.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Base64 } from 'js-base64';
 import { useIsOnFeatureFlag } from '~/feature-flags/hooks';
 import { KUBEARCHIVE_PATH_PREFIX } from '~/kubearchive/const';
-import { useDebounceCallback } from '~/shared/hooks/useDebounceCallback';
+import { type LogSection } from '~/shared/components/virtualized-log-viewer';
 import { ResourceSource } from '~/types/k8s';
 import { commonFetchText } from '../../../../k8s';
 import { getK8sResourceURL, getWebsocketSubProtocolAndPathPrefix } from '../../../../k8s/k8s-utils';
@@ -18,18 +18,6 @@ import LogViewer, { type Props as LogViewerProps } from './LogViewer';
 type LogSources = { [containerName: string]: string };
 
 const WEB_SOCKET_RETRY_COUNT = 5;
-
-export const processLogs = (logSources: LogSources, containers: ContainerSpec[]): string => {
-  let allLogs = '';
-  for (const container of containers) {
-    const containerName = container.name;
-    if (logSources[containerName]) {
-      allLogs += `\n\n${containerName.toUpperCase()}\n`;
-      allLogs += `  ${logSources[containerName].replace(/\n/g, '\n  ')}`;
-    }
-  }
-  return allLogs.trim();
-};
 
 const retryWebSocket = (
   watchURL: string,
@@ -181,29 +169,6 @@ const Logs: React.FC<LogsProps> = ({
     };
   }, [containers, resource, resName, resNamespace, appendLog, source, isKubearchiveEnabled]);
 
-  const [formattedLogs, setFormattedLogs] = React.useState('');
-  const [processingLogs, setProcessingLogs] = React.useState(false);
-  const containersRef = React.useRef(containers);
-  containersRef.current = containers;
-
-  const processAndSetLogs = useDebounceCallback(() => {
-    const result = processLogs(logSources, containersRef.current);
-    setFormattedLogs(result);
-    setProcessingLogs(false);
-  }, 300);
-
-  React.useEffect(() => {
-    if (Object.keys(logSources).length === 0) {
-      setFormattedLogs('');
-      return;
-    }
-
-    setProcessingLogs(true);
-    processAndSetLogs();
-
-    return () => processAndSetLogs.cancel();
-  }, [logSources, processAndSetLogs]);
-
   const allLogsTerminated = React.useMemo<boolean>(() => {
     if (containers.length === 0) return false;
 
@@ -227,15 +192,24 @@ const Logs: React.FC<LogsProps> = ({
     return allTerminated;
   }, [containers, resource?.status?.containerStatuses]);
 
+  const sections = React.useMemo<LogSection[]>(() => {
+    return containers
+      .filter((c) => logSources[c.name])
+      .map((c) => ({
+        containerName: c.name.toUpperCase(),
+        data: logSources[c.name],
+      }));
+  }, [logSources, containers]);
+
   return (
     <LogViewer
-      data={formattedLogs}
+      sections={sections}
       allowAutoScroll={allowAutoScroll && !allLogsTerminated}
       onScroll={onScroll}
       downloadAllLabel={downloadAllLabel}
       onDownloadAll={onDownloadAll}
       taskRun={taskRun}
-      isLoading={isLoading || processingLogs}
+      isLoading={isLoading}
       errorMessage={error ? t('An error occurred while retrieving the requested logs.') : null}
     />
   );

--- a/src/shared/components/pipeline-run-logs/logs/TektonTaskRunLog.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/TektonTaskRunLog.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { type LogSection } from '~/shared/components/virtualized-log-viewer';
 import { useTRTaskRunLog } from '../../../../hooks/useTektonResults';
 import { HttpError } from '../../../../k8s/error';
 import { TaskRunKind } from '../../../../types';
@@ -23,9 +24,14 @@ export const TektonTaskRunLog: React.FC<React.PropsWithChildren<TektonTaskRunLog
       ? `Logs are no longer accessible for ${taskName} task`
       : null;
 
+  const sections = React.useMemo<LogSection[]>(() => {
+    if (!trResults) return [];
+    return [{ containerName: '', data: trResults }];
+  }, [trResults]);
+
   return (
     <LogViewer
-      data={trResults ?? ''}
+      sections={sections}
       downloadAllLabel={downloadAllLabel}
       onDownloadAll={onDownloadAll}
       taskRun={taskRun}

--- a/src/shared/components/pipeline-run-logs/logs/__tests__/LogViewer.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/__tests__/LogViewer.spec.tsx
@@ -553,6 +553,55 @@ describe('LogViewer Integration Tests', () => {
     });
   });
 
+  describe('Sections support', () => {
+    const sectionProps = {
+      ...defaultProps,
+      data: undefined,
+      sections: [
+        { containerName: 'step-build', lines: ['building...', 'done'] },
+        { containerName: 'step-test', lines: ['testing...', 'passed'] },
+      ],
+    };
+
+    it('should render log content from sections', () => {
+      const { container } = render(<LogViewer {...sectionProps} />);
+
+      const logList = container.querySelector('.log-content__list');
+      expect(logList).toBeInTheDocument();
+      expect(logList?.textContent).toContain('building...');
+      expect(logList?.textContent).toContain('testing...');
+    });
+
+    it('should strip ANSI codes from section lines', () => {
+      const sectionsWithAnsi = {
+        ...defaultProps,
+        data: undefined,
+        sections: [
+          {
+            containerName: 'step-build',
+            lines: ['\x1b[32mSuccess\x1b[0m', 'plain line'],
+          },
+        ],
+      };
+
+      const { container } = render(<LogViewer {...sectionsWithAnsi} />);
+
+      const logList = container.querySelector('.log-content__list');
+      expect(logList?.textContent).not.toContain('\x1b');
+      expect(logList?.textContent).toContain('Success');
+    });
+
+    it('should support download when using sections', async () => {
+      const user = userEvent.setup();
+      render(<LogViewer {...sectionProps} />);
+
+      const downloadButton = screen.getByRole('button', { name: /^Download$/i });
+      await user.click(downloadButton);
+
+      expect(mockSaveAs).toHaveBeenCalledWith(expect.any(Blob), 'test-task.log');
+    });
+  });
+
   describe('Task information display', () => {
     it('should display task name with truncation', () => {
       const longTaskName = 'very-long-task-name-that-should-be-truncated-in-the-ui';

--- a/src/shared/components/pipeline-run-logs/logs/__tests__/LogViewer.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/__tests__/LogViewer.spec.tsx
@@ -68,7 +68,7 @@ describe('LogViewer Integration Tests', () => {
   };
 
   const defaultProps = {
-    data: 'line 1\nline 2\nline 3\nline 4\nline 5',
+    sections: [{ containerName: '', data: 'line 1\nline 2\nline 3\nline 4\nline 5' }],
     isLoading: false,
     errorMessage: null,
     taskRun: mockTaskRun,
@@ -186,7 +186,9 @@ describe('LogViewer Integration Tests', () => {
     it('should strip ANSI escape codes from log data', () => {
       const dataWithAnsi = '\x1b[32mSuccess\x1b[0m\n\x1b[31mError\x1b[0m\nPlain text';
 
-      const { container } = render(<LogViewer {...defaultProps} data={dataWithAnsi} />);
+      const { container } = render(
+        <LogViewer {...defaultProps} sections={[{ containerName: '', data: dataWithAnsi }]} />,
+      );
 
       // Virtualization may not render all lines, but the visible ones should have ANSI codes stripped
       // Check that rendered content doesn't contain ANSI escape codes
@@ -200,7 +202,9 @@ describe('LogViewer Integration Tests', () => {
     it('should handle carriage returns in log data', () => {
       const dataWithCR = 'line 1\roverwrite\nline 2';
 
-      const { container } = render(<LogViewer {...defaultProps} data={dataWithCR} />);
+      const { container } = render(
+        <LogViewer {...defaultProps} sections={[{ containerName: '', data: dataWithCR }]} />,
+      );
 
       // \r should be replaced with \n - check that processed lines are visible
       const logList = container.querySelector('.log-content__list');
@@ -325,7 +329,7 @@ describe('LogViewer Integration Tests', () => {
 
     it('should not download when data is empty', async () => {
       const user = userEvent.setup();
-      render(<LogViewer {...defaultProps} data="" />);
+      render(<LogViewer {...defaultProps} sections={[{ containerName: '', data: '' }]} />);
 
       const downloadButton = screen.getByRole('button', { name: /^Download$/i });
       await user.click(downloadButton);
@@ -526,14 +530,16 @@ describe('LogViewer Integration Tests', () => {
       expect(logList).toBeInTheDocument();
 
       const newData = 'new line 1\nnew line 2\nnew line 3';
-      rerender(<LogViewer {...defaultProps} data={newData} />);
+      rerender(<LogViewer {...defaultProps} sections={[{ containerName: '', data: newData }]} />);
 
       logList = container.querySelector('.log-content__list');
       expect(logList).toBeInTheDocument();
     });
 
     it('should handle empty data', () => {
-      const { container } = render(<LogViewer {...defaultProps} data="" />);
+      const { container } = render(
+        <LogViewer {...defaultProps} sections={[{ containerName: '', data: '' }]} />,
+      );
 
       const logList = container.querySelector('.log-content__list');
       expect(logList).toBeInTheDocument();
@@ -542,7 +548,9 @@ describe('LogViewer Integration Tests', () => {
     it('should handle very long log data', () => {
       const longData = Array.from({ length: 1000 }, (_, i) => `line ${i + 1}`).join('\n');
 
-      const { container } = render(<LogViewer {...defaultProps} data={longData} />);
+      const { container } = render(
+        <LogViewer {...defaultProps} sections={[{ containerName: '', data: longData }]} />,
+      );
 
       const logList = container.querySelector('.log-content__list');
       expect(logList).toBeInTheDocument();
@@ -550,6 +558,53 @@ describe('LogViewer Integration Tests', () => {
       // Should use virtualization (only render visible items)
       const visibleItems = container.querySelectorAll('.pf-v5-c-log-viewer__list-item');
       expect(visibleItems.length).toBeLessThan(1000);
+    });
+  });
+
+  describe('Sections support', () => {
+    const sectionProps = {
+      ...defaultProps,
+      sections: [
+        { containerName: 'step-build', data: 'building...\ndone' },
+        { containerName: 'step-test', data: 'testing...\npassed' },
+      ],
+    };
+
+    it('should render log content from sections', () => {
+      const { container } = render(<LogViewer {...sectionProps} />);
+
+      const logList = container.querySelector('.log-content__list');
+      expect(logList).toBeInTheDocument();
+      expect(logList?.textContent).toContain('building...');
+      expect(logList?.textContent).toContain('testing...');
+    });
+
+    it('should strip ANSI codes from section data', () => {
+      const sectionsWithAnsi = {
+        ...defaultProps,
+        sections: [
+          {
+            containerName: 'step-build',
+            data: '\x1b[32mSuccess\x1b[0m\nplain line',
+          },
+        ],
+      };
+
+      const { container } = render(<LogViewer {...sectionsWithAnsi} />);
+
+      const logList = container.querySelector('.log-content__list');
+      expect(logList?.textContent).not.toContain('\x1b');
+      expect(logList?.textContent).toContain('Success');
+    });
+
+    it('should support download when using sections', async () => {
+      const user = userEvent.setup();
+      render(<LogViewer {...sectionProps} />);
+
+      const downloadButton = screen.getByRole('button', { name: /^Download$/i });
+      await user.click(downloadButton);
+
+      expect(mockSaveAs).toHaveBeenCalledWith(expect.any(Blob), 'test-task.log');
     });
   });
 
@@ -682,7 +737,9 @@ describe('LogViewer Integration Tests', () => {
     });
 
     it('should handle data with only newlines', () => {
-      const { container } = render(<LogViewer {...defaultProps} data="\n\n\n\n" />);
+      const { container } = render(
+        <LogViewer {...defaultProps} sections={[{ containerName: '', data: '\n\n\n\n' }]} />,
+      );
 
       const logList = container.querySelector('.log-content__list');
       expect(logList).toBeInTheDocument();
@@ -691,7 +748,9 @@ describe('LogViewer Integration Tests', () => {
     it('should handle data with special characters', () => {
       const specialData = 'line with <html> tags\nline with & ampersand\nline with "quotes"';
 
-      const { container } = render(<LogViewer {...defaultProps} data={specialData} />);
+      const { container } = render(
+        <LogViewer {...defaultProps} sections={[{ containerName: '', data: specialData }]} />,
+      );
 
       const logList = container.querySelector('.log-content__list');
       expect(logList).toBeInTheDocument();

--- a/src/shared/components/pipeline-run-logs/logs/__tests__/LogViewer.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/__tests__/LogViewer.spec.tsx
@@ -385,7 +385,7 @@ describe('LogViewer Integration Tests', () => {
         expect(downloadAllButton).not.toBeDisabled();
       });
 
-      expect(consoleSpy).toHaveBeenCalledWith('Download failed');
+      expect(consoleSpy).toHaveBeenCalledWith('[WARN] Download failed', '');
       consoleSpy.mockRestore();
     });
   });

--- a/src/shared/components/pipeline-run-logs/logs/__tests__/Logs.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/__tests__/Logs.spec.tsx
@@ -10,12 +10,19 @@ import {
 import { TaskRunKind } from '../../../../../types';
 import { ContainerStatus, PodKind, ContainerSpec } from '../../../types';
 import { containerToLogSourceStatus } from '../../utils';
-import Logs, { processLogs } from '../Logs';
+import Logs from '../Logs';
 
 const mockLogViewer = jest.fn();
+
+const getLastSectionsLines = (): string[] => {
+  const lastCall = mockLogViewer.mock.calls[mockLogViewer.mock.calls.length - 1][0];
+  return (lastCall.sections || []).flatMap((s: { lines: string[] }) => s.lines);
+};
+
 jest.mock('../LogViewer', () => {
   return function MockLogViewer(props: {
-    data: string;
+    sections?: Array<{ containerName: string; lines: string[] }>;
+    data?: string;
     allowAutoScroll: boolean;
     isLoading?: boolean;
     onScroll?: () => void;
@@ -136,7 +143,7 @@ describe('Logs', () => {
 
       expect(mockLogViewer).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: expect.any(String),
+          sections: expect.any(Array),
           allowAutoScroll: true,
           onScroll: undefined,
         }),
@@ -169,94 +176,168 @@ describe('Logs', () => {
         expect(screen.getByTestId('mock-log-viewer')).toBeInTheDocument();
         expect(mockLogViewer).toHaveBeenCalledWith(
           expect.objectContaining({
-            data: '',
+            sections: [],
           }),
         );
       });
     });
   });
 
-  describe('processLogs function', () => {
-    it('should format logs with container headers and indentation', () => {
-      const logSources = {
-        container1: 'log line 1\nlog line 2',
-        container2: 'log line 3\nlog line 4',
+  describe('sections prop', () => {
+    it('should pass sections with correct container names and pre-split lines', async () => {
+      const terminatedContainer1: ContainerStatus = {
+        name: 'container1',
+        state: { terminated: { exitCode: 0 } },
+        ready: false,
+        restartCount: 0,
+        image: 'test-image',
+        imageID: 'test-image-id',
       };
-      const containers: ContainerSpec[] = [{ name: 'container1' }, { name: 'container2' }];
-
-      const result = processLogs(logSources, containers);
-
-      // should contain container headers and indented logs
-      expect(result).toContain('CONTAINER1'); // Header should be uppercase
-      expect(result).toContain('CONTAINER2');
-      expect(result).toContain('  log line 1'); // Logs should be indented
-      expect(result).toContain('  log line 2');
-      expect(result).toContain('  log line 3');
-      expect(result).toContain('  log line 4');
-    });
-
-    it('should handle containers with no logs', () => {
-      const logSources = {};
-      const containers: ContainerSpec[] = [{ name: 'container1' }];
-
-      const result = processLogs(logSources, containers);
-
-      expect(result).toBe('');
-    });
-
-    it('should handle empty containers array', () => {
-      const logSources = { container1: 'some logs' };
-      const containers: ContainerSpec[] = [];
-
-      const result = processLogs(logSources, containers);
-
-      expect(result).toBe('');
-    });
-
-    it('should process containers in specific order', () => {
-      const logSources = {
-        container1: 'first container logs',
-        container2: 'second container logs',
+      const terminatedContainer2: ContainerStatus = {
+        name: 'container2',
+        state: { terminated: { exitCode: 0 } },
+        ready: false,
+        restartCount: 0,
+        image: 'test-image',
+        imageID: 'test-image-id',
       };
-      const containers: ContainerSpec[] = [{ name: 'container2' }, { name: 'container1' }];
 
-      const result = processLogs(logSources, containers);
+      const resourceWithStatus: PodKind = {
+        ...mockResource,
+        status: {
+          phase: 'Succeeded',
+          containerStatuses: [terminatedContainer1, terminatedContainer2],
+        },
+      };
 
-      const container2Index = result.indexOf('CONTAINER2');
-      const container1Index = result.indexOf('CONTAINER1');
+      (containerToLogSourceStatus as jest.Mock).mockReturnValue('terminated');
+      (commonFetchText as jest.Mock)
+        .mockResolvedValueOnce('log line 1\nlog line 2')
+        .mockResolvedValueOnce('log line 3\nlog line 4');
 
-      // container2 should appear first since it's first in the containers array
-      expect(container2Index).toBeLessThan(container1Index);
-      expect(container2Index).toBeGreaterThanOrEqual(0);
-      expect(container1Index).toBeGreaterThanOrEqual(0);
+      render(
+        <Logs
+          {...defaultProps}
+          resource={resourceWithStatus}
+          containers={[{ name: 'container1' }, { name: 'container2' }]}
+        />,
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockLogViewer).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          sections: expect.arrayContaining([
+            { containerName: 'container1', lines: ['log line 1', 'log line 2'] },
+            { containerName: 'container2', lines: ['log line 3', 'log line 4'] },
+          ]),
+        }),
+      );
     });
 
-    it('should skip containers without log sources', () => {
-      const logSources = {
-        container1: 'has logs',
-        // container2 has no logs
+    it('should preserve container ordering from containers prop', async () => {
+      const terminatedContainer1: ContainerStatus = {
+        name: 'container1',
+        state: { terminated: { exitCode: 0 } },
+        ready: false,
+        restartCount: 0,
+        image: 'test-image',
+        imageID: 'test-image-id',
       };
-      const containers: ContainerSpec[] = [{ name: 'container1' }, { name: 'container2' }];
+      const terminatedContainer2: ContainerStatus = {
+        name: 'container2',
+        state: { terminated: { exitCode: 0 } },
+        ready: false,
+        restartCount: 0,
+        image: 'test-image',
+        imageID: 'test-image-id',
+      };
 
-      const result = processLogs(logSources, containers);
+      const resourceWithStatus: PodKind = {
+        ...mockResource,
+        status: {
+          phase: 'Succeeded',
+          containerStatuses: [terminatedContainer1, terminatedContainer2],
+        },
+      };
 
-      expect(result).toContain('CONTAINER1');
-      expect(result).not.toContain('CONTAINER2');
-      expect(result).toContain('  has logs');
+      (containerToLogSourceStatus as jest.Mock).mockReturnValue('terminated');
+      (commonFetchText as jest.Mock).mockResolvedValueOnce('first').mockResolvedValueOnce('second');
+
+      render(
+        <Logs
+          {...defaultProps}
+          resource={resourceWithStatus}
+          containers={[{ name: 'container2' }, { name: 'container1' }]}
+        />,
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      const lastCall = mockLogViewer.mock.calls[mockLogViewer.mock.calls.length - 1][0];
+      expect(lastCall.sections[0].containerName).toBe('container2');
+      expect(lastCall.sections[1].containerName).toBe('container1');
     });
 
-    it('should handle multi-line logs with proper indentation', () => {
-      const logSources = {
-        'test-container': 'line 1\nline 2\nline 3',
+    it('should skip containers without log sources', async () => {
+      const terminatedContainer1: ContainerStatus = {
+        name: 'container1',
+        state: { terminated: { exitCode: 0 } },
+        ready: false,
+        restartCount: 0,
+        image: 'test-image',
+        imageID: 'test-image-id',
       };
-      const containers: ContainerSpec[] = [{ name: 'test-container' }];
+      const terminatedContainer2: ContainerStatus = {
+        name: 'container2',
+        state: { terminated: { exitCode: 0 } },
+        ready: false,
+        restartCount: 0,
+        image: 'test-image',
+        imageID: 'test-image-id',
+      };
 
-      const result = processLogs(logSources, containers);
+      const resourceWithStatus: PodKind = {
+        ...mockResource,
+        status: {
+          phase: 'Succeeded',
+          containerStatuses: [terminatedContainer1, terminatedContainer2],
+        },
+      };
 
-      expect(result).toContain('TEST-CONTAINER');
-      expect(result).toContain('  line 1');
-      expect(result).toContain('  line 2');
-      expect(result).toContain('  line 3');
+      (containerToLogSourceStatus as jest.Mock).mockReturnValue('terminated');
+      (commonFetchText as jest.Mock).mockResolvedValueOnce('has logs').mockResolvedValueOnce(''); // container2 returns empty string (no logs)
+
+      render(
+        <Logs
+          {...defaultProps}
+          resource={resourceWithStatus}
+          containers={[{ name: 'container1' }, { name: 'container2' }]}
+        />,
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // container2 has empty logs, so it should be filtered out by the sections memo
+      const lastCall = mockLogViewer.mock.calls[mockLogViewer.mock.calls.length - 1][0];
+      expect(lastCall.sections).toHaveLength(1);
+      expect(lastCall.sections[0].containerName).toBe('container1');
+    });
+
+    it('should pass empty sections when no containers have logs', () => {
+      render(<Logs {...defaultProps} containers={[]} />);
+
+      expect(mockLogViewer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sections: [],
+        }),
+      );
     });
   });
 
@@ -385,11 +466,7 @@ describe('Logs', () => {
 
       // Should show error message in LogViewer
       await waitFor(() => {
-        expect(mockLogViewer).toHaveBeenCalledWith(
-          expect.objectContaining({
-            data: expect.stringContaining('LOG FETCH ERROR'),
-          }),
-        );
+        expect(getLastSectionsLines().join('\n')).toContain('LOG FETCH ERROR');
       });
     });
 
@@ -427,11 +504,7 @@ describe('Logs', () => {
 
       // Should NOT show error message for 404 (missing logs) - should remain empty
       await waitFor(() => {
-        expect(mockLogViewer).toHaveBeenCalledWith(
-          expect.objectContaining({
-            data: expect.not.stringContaining('LOG FETCH ERROR'),
-          }),
-        );
+        expect(getLastSectionsLines().join('\n')).not.toContain('LOG FETCH ERROR');
       });
     });
 
@@ -523,11 +596,7 @@ describe('Logs', () => {
       });
 
       await waitFor(() => {
-        expect(mockLogViewer).toHaveBeenCalledWith(
-          expect.objectContaining({
-            data: expect.stringContaining('decoded-aGVsbG8gd29ybGQ='),
-          }),
-        );
+        expect(getLastSectionsLines().join('\n')).toContain('decoded-aGVsbG8gd29ybGQ=');
       });
     });
   });
@@ -802,9 +871,7 @@ describe('Logs', () => {
   });
 
   describe('loading indicator while processing logs', () => {
-    it('should show loading while logs are being debounced', async () => {
-      jest.useFakeTimers();
-
+    it('should not add processingLogs to isLoading', () => {
       const terminatedContainer: ContainerStatus = {
         name: 'container1',
         state: { terminated: { exitCode: 0 } },
@@ -833,30 +900,12 @@ describe('Logs', () => {
         />,
       );
 
-      // After fetch resolves but before debounce fires, isLoading should be true
-      await act(async () => {
-        await Promise.resolve(); // let fetch resolve
-      });
-
+      // isLoading should only reflect the prop, not internal processing
       expect(mockLogViewer).toHaveBeenCalledWith(
         expect.objectContaining({
-          isLoading: true,
-        }),
-      );
-
-      // After debounce fires, isLoading should be false
-      act(() => {
-        jest.advanceTimersByTime(300);
-      });
-
-      expect(mockLogViewer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
           isLoading: false,
-          data: expect.stringContaining('some log output'),
         }),
       );
-
-      jest.useRealTimers();
     });
 
     it('should not show loading when there are no log sources', () => {
@@ -865,7 +914,7 @@ describe('Logs', () => {
       expect(mockLogViewer).toHaveBeenCalledWith(
         expect.objectContaining({
           isLoading: false,
-          data: '',
+          sections: [],
         }),
       );
     });

--- a/src/shared/components/pipeline-run-logs/logs/__tests__/Logs.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/__tests__/Logs.spec.tsx
@@ -230,8 +230,8 @@ describe('Logs', () => {
       expect(mockLogViewer).toHaveBeenLastCalledWith(
         expect.objectContaining({
           sections: expect.arrayContaining([
-            { containerName: 'container1', lines: ['log line 1', 'log line 2'] },
-            { containerName: 'container2', lines: ['log line 3', 'log line 4'] },
+            { containerName: 'CONTAINER1', lines: ['  log line 1', '  log line 2'] },
+            { containerName: 'CONTAINER2', lines: ['  log line 3', '  log line 4'] },
           ]),
         }),
       );
@@ -279,8 +279,8 @@ describe('Logs', () => {
       });
 
       const lastCall = mockLogViewer.mock.calls[mockLogViewer.mock.calls.length - 1][0];
-      expect(lastCall.sections[0].containerName).toBe('container2');
-      expect(lastCall.sections[1].containerName).toBe('container1');
+      expect(lastCall.sections[0].containerName).toBe('CONTAINER2');
+      expect(lastCall.sections[1].containerName).toBe('CONTAINER1');
     });
 
     it('should skip containers without log sources', async () => {
@@ -327,7 +327,7 @@ describe('Logs', () => {
       // container2 has empty logs, so it should be filtered out by the sections memo
       const lastCall = mockLogViewer.mock.calls[mockLogViewer.mock.calls.length - 1][0];
       expect(lastCall.sections).toHaveLength(1);
-      expect(lastCall.sections[0].containerName).toBe('container1');
+      expect(lastCall.sections[0].containerName).toBe('CONTAINER1');
     });
 
     it('should pass empty sections when no containers have logs', () => {

--- a/src/shared/components/pipeline-run-logs/logs/__tests__/Logs.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/__tests__/Logs.spec.tsx
@@ -10,12 +10,18 @@ import {
 import { TaskRunKind } from '../../../../../types';
 import { ContainerStatus, PodKind, ContainerSpec } from '../../../types';
 import { containerToLogSourceStatus } from '../../utils';
-import Logs, { processLogs } from '../Logs';
+import Logs from '../Logs';
 
 const mockLogViewer = jest.fn();
+
+const getLastSectionsData = (): string => {
+  const lastCall = mockLogViewer.mock.calls[mockLogViewer.mock.calls.length - 1][0];
+  return (lastCall.sections || []).map((s: { data: string }) => s.data).join('\n');
+};
+
 jest.mock('../LogViewer', () => {
   return function MockLogViewer(props: {
-    data: string;
+    sections: Array<{ containerName: string; data: string }>;
     allowAutoScroll: boolean;
     isLoading?: boolean;
     onScroll?: () => void;
@@ -136,7 +142,7 @@ describe('Logs', () => {
 
       expect(mockLogViewer).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: expect.any(String),
+          sections: expect.any(Array),
           allowAutoScroll: true,
           onScroll: undefined,
         }),
@@ -169,94 +175,168 @@ describe('Logs', () => {
         expect(screen.getByTestId('mock-log-viewer')).toBeInTheDocument();
         expect(mockLogViewer).toHaveBeenCalledWith(
           expect.objectContaining({
-            data: '',
+            sections: [],
           }),
         );
       });
     });
   });
 
-  describe('processLogs function', () => {
-    it('should format logs with container headers and indentation', () => {
-      const logSources = {
-        container1: 'log line 1\nlog line 2',
-        container2: 'log line 3\nlog line 4',
+  describe('sections prop', () => {
+    it('should pass sections with correct container names and pre-split lines', async () => {
+      const terminatedContainer1: ContainerStatus = {
+        name: 'container1',
+        state: { terminated: { exitCode: 0 } },
+        ready: false,
+        restartCount: 0,
+        image: 'test-image',
+        imageID: 'test-image-id',
       };
-      const containers: ContainerSpec[] = [{ name: 'container1' }, { name: 'container2' }];
-
-      const result = processLogs(logSources, containers);
-
-      // should contain container headers and indented logs
-      expect(result).toContain('CONTAINER1'); // Header should be uppercase
-      expect(result).toContain('CONTAINER2');
-      expect(result).toContain('  log line 1'); // Logs should be indented
-      expect(result).toContain('  log line 2');
-      expect(result).toContain('  log line 3');
-      expect(result).toContain('  log line 4');
-    });
-
-    it('should handle containers with no logs', () => {
-      const logSources = {};
-      const containers: ContainerSpec[] = [{ name: 'container1' }];
-
-      const result = processLogs(logSources, containers);
-
-      expect(result).toBe('');
-    });
-
-    it('should handle empty containers array', () => {
-      const logSources = { container1: 'some logs' };
-      const containers: ContainerSpec[] = [];
-
-      const result = processLogs(logSources, containers);
-
-      expect(result).toBe('');
-    });
-
-    it('should process containers in specific order', () => {
-      const logSources = {
-        container1: 'first container logs',
-        container2: 'second container logs',
+      const terminatedContainer2: ContainerStatus = {
+        name: 'container2',
+        state: { terminated: { exitCode: 0 } },
+        ready: false,
+        restartCount: 0,
+        image: 'test-image',
+        imageID: 'test-image-id',
       };
-      const containers: ContainerSpec[] = [{ name: 'container2' }, { name: 'container1' }];
 
-      const result = processLogs(logSources, containers);
+      const resourceWithStatus: PodKind = {
+        ...mockResource,
+        status: {
+          phase: 'Succeeded',
+          containerStatuses: [terminatedContainer1, terminatedContainer2],
+        },
+      };
 
-      const container2Index = result.indexOf('CONTAINER2');
-      const container1Index = result.indexOf('CONTAINER1');
+      (containerToLogSourceStatus as jest.Mock).mockReturnValue('terminated');
+      (commonFetchText as jest.Mock)
+        .mockResolvedValueOnce('log line 1\nlog line 2')
+        .mockResolvedValueOnce('log line 3\nlog line 4');
 
-      // container2 should appear first since it's first in the containers array
-      expect(container2Index).toBeLessThan(container1Index);
-      expect(container2Index).toBeGreaterThanOrEqual(0);
-      expect(container1Index).toBeGreaterThanOrEqual(0);
+      render(
+        <Logs
+          {...defaultProps}
+          resource={resourceWithStatus}
+          containers={[{ name: 'container1' }, { name: 'container2' }]}
+        />,
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockLogViewer).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          sections: expect.arrayContaining([
+            { containerName: 'CONTAINER1', data: 'log line 1\nlog line 2' },
+            { containerName: 'CONTAINER2', data: 'log line 3\nlog line 4' },
+          ]),
+        }),
+      );
     });
 
-    it('should skip containers without log sources', () => {
-      const logSources = {
-        container1: 'has logs',
-        // container2 has no logs
+    it('should preserve container ordering from containers prop', async () => {
+      const terminatedContainer1: ContainerStatus = {
+        name: 'container1',
+        state: { terminated: { exitCode: 0 } },
+        ready: false,
+        restartCount: 0,
+        image: 'test-image',
+        imageID: 'test-image-id',
       };
-      const containers: ContainerSpec[] = [{ name: 'container1' }, { name: 'container2' }];
+      const terminatedContainer2: ContainerStatus = {
+        name: 'container2',
+        state: { terminated: { exitCode: 0 } },
+        ready: false,
+        restartCount: 0,
+        image: 'test-image',
+        imageID: 'test-image-id',
+      };
 
-      const result = processLogs(logSources, containers);
+      const resourceWithStatus: PodKind = {
+        ...mockResource,
+        status: {
+          phase: 'Succeeded',
+          containerStatuses: [terminatedContainer1, terminatedContainer2],
+        },
+      };
 
-      expect(result).toContain('CONTAINER1');
-      expect(result).not.toContain('CONTAINER2');
-      expect(result).toContain('  has logs');
+      (containerToLogSourceStatus as jest.Mock).mockReturnValue('terminated');
+      (commonFetchText as jest.Mock).mockResolvedValueOnce('first').mockResolvedValueOnce('second');
+
+      render(
+        <Logs
+          {...defaultProps}
+          resource={resourceWithStatus}
+          containers={[{ name: 'container2' }, { name: 'container1' }]}
+        />,
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      const lastCall = mockLogViewer.mock.calls[mockLogViewer.mock.calls.length - 1][0];
+      expect(lastCall.sections[0].containerName).toBe('CONTAINER2');
+      expect(lastCall.sections[1].containerName).toBe('CONTAINER1');
     });
 
-    it('should handle multi-line logs with proper indentation', () => {
-      const logSources = {
-        'test-container': 'line 1\nline 2\nline 3',
+    it('should skip containers without log sources', async () => {
+      const terminatedContainer1: ContainerStatus = {
+        name: 'container1',
+        state: { terminated: { exitCode: 0 } },
+        ready: false,
+        restartCount: 0,
+        image: 'test-image',
+        imageID: 'test-image-id',
       };
-      const containers: ContainerSpec[] = [{ name: 'test-container' }];
+      const terminatedContainer2: ContainerStatus = {
+        name: 'container2',
+        state: { terminated: { exitCode: 0 } },
+        ready: false,
+        restartCount: 0,
+        image: 'test-image',
+        imageID: 'test-image-id',
+      };
 
-      const result = processLogs(logSources, containers);
+      const resourceWithStatus: PodKind = {
+        ...mockResource,
+        status: {
+          phase: 'Succeeded',
+          containerStatuses: [terminatedContainer1, terminatedContainer2],
+        },
+      };
 
-      expect(result).toContain('TEST-CONTAINER');
-      expect(result).toContain('  line 1');
-      expect(result).toContain('  line 2');
-      expect(result).toContain('  line 3');
+      (containerToLogSourceStatus as jest.Mock).mockReturnValue('terminated');
+      (commonFetchText as jest.Mock).mockResolvedValueOnce('has logs').mockResolvedValueOnce(''); // container2 returns empty string (no logs)
+
+      render(
+        <Logs
+          {...defaultProps}
+          resource={resourceWithStatus}
+          containers={[{ name: 'container1' }, { name: 'container2' }]}
+        />,
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // container2 has empty logs, so it should be filtered out by the sections memo
+      const lastCall = mockLogViewer.mock.calls[mockLogViewer.mock.calls.length - 1][0];
+      expect(lastCall.sections).toHaveLength(1);
+      expect(lastCall.sections[0].containerName).toBe('CONTAINER1');
+    });
+
+    it('should pass empty sections when no containers have logs', () => {
+      render(<Logs {...defaultProps} containers={[]} />);
+
+      expect(mockLogViewer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sections: [],
+        }),
+      );
     });
   });
 
@@ -385,11 +465,7 @@ describe('Logs', () => {
 
       // Should show error message in LogViewer
       await waitFor(() => {
-        expect(mockLogViewer).toHaveBeenCalledWith(
-          expect.objectContaining({
-            data: expect.stringContaining('LOG FETCH ERROR'),
-          }),
-        );
+        expect(getLastSectionsData()).toContain('LOG FETCH ERROR');
       });
     });
 
@@ -427,11 +503,7 @@ describe('Logs', () => {
 
       // Should NOT show error message for 404 (missing logs) - should remain empty
       await waitFor(() => {
-        expect(mockLogViewer).toHaveBeenCalledWith(
-          expect.objectContaining({
-            data: expect.not.stringContaining('LOG FETCH ERROR'),
-          }),
-        );
+        expect(getLastSectionsData()).not.toContain('LOG FETCH ERROR');
       });
     });
 
@@ -523,11 +595,7 @@ describe('Logs', () => {
       });
 
       await waitFor(() => {
-        expect(mockLogViewer).toHaveBeenCalledWith(
-          expect.objectContaining({
-            data: expect.stringContaining('decoded-aGVsbG8gd29ybGQ='),
-          }),
-        );
+        expect(getLastSectionsData()).toContain('decoded-aGVsbG8gd29ybGQ=');
       });
     });
   });
@@ -802,9 +870,7 @@ describe('Logs', () => {
   });
 
   describe('loading indicator while processing logs', () => {
-    it('should show loading while logs are being debounced', async () => {
-      jest.useFakeTimers();
-
+    it('should not add processingLogs to isLoading', () => {
       const terminatedContainer: ContainerStatus = {
         name: 'container1',
         state: { terminated: { exitCode: 0 } },
@@ -833,30 +899,12 @@ describe('Logs', () => {
         />,
       );
 
-      // After fetch resolves but before debounce fires, isLoading should be true
-      await act(async () => {
-        await Promise.resolve(); // let fetch resolve
-      });
-
+      // isLoading should only reflect the prop, not internal processing
       expect(mockLogViewer).toHaveBeenCalledWith(
         expect.objectContaining({
-          isLoading: true,
-        }),
-      );
-
-      // After debounce fires, isLoading should be false
-      act(() => {
-        jest.advanceTimersByTime(300);
-      });
-
-      expect(mockLogViewer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
           isLoading: false,
-          data: expect.stringContaining('some log output'),
         }),
       );
-
-      jest.useRealTimers();
     });
 
     it('should not show loading when there are no log sources', () => {
@@ -865,7 +913,7 @@ describe('Logs', () => {
       expect(mockLogViewer).toHaveBeenCalledWith(
         expect.objectContaining({
           isLoading: false,
-          data: '',
+          sections: [],
         }),
       );
     });

--- a/src/shared/components/virtualized-log-viewer/VirtualizedLogContent.scss
+++ b/src/shared/components/virtualized-log-viewer/VirtualizedLogContent.scss
@@ -26,6 +26,10 @@
   position: relative;
 }
 
+.log-content__line--indented {
+  padding-left: var(--pf-v5-global--spacer--md);
+}
+
 .log-content__line--highlighted {
   background-color: var(--pf-v5-global--palette--gold-50);
 

--- a/src/shared/components/virtualized-log-viewer/VirtualizedLogContent.tsx
+++ b/src/shared/components/virtualized-log-viewer/VirtualizedLogContent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { LineNumberGutter } from './LineNumberGutter';
-import type { SearchedWord } from './types';
+import type { SearchedWord, LogSection } from './types';
 import { useKeyboardNavigation } from './useKeyboardNavigation';
 import { useLineNumberNavigation } from './useLineNumberNavigation';
 import { useLineRenderer } from './useLineRenderer';
@@ -19,6 +19,27 @@ import {
 
 import './VirtualizedLogContent.scss';
 
+type LogVirtualItem =
+  | {
+      type: 'header';
+      containerName: string;
+    }
+  | {
+      type: 'line';
+      text: string;
+    };
+
+const buildFlatItems = (sections: LogSection[]): LogVirtualItem[] => {
+  const items: LogVirtualItem[] = [];
+  for (const section of sections) {
+    items.push({ type: 'header', containerName: section.containerName });
+    for (const line of section.lines) {
+      items.push({ type: 'line', text: line });
+    }
+  }
+  return items;
+};
+
 export interface VirtualizedLogContentProps {
   data: string;
   height: number;
@@ -31,6 +52,7 @@ export interface VirtualizedLogContentProps {
   }) => void;
   searchText?: string;
   currentSearchMatch?: SearchedWord;
+  sections?: LogSection[];
 }
 
 export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
@@ -41,6 +63,7 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
   onScroll,
   searchText = '',
   currentSearchMatch,
+  sections,
 }) => {
   const parentRef = React.useRef<HTMLDivElement>(null);
   const [itemSize, setItemSize] = React.useState(VIRTUALIZATION_CONFIG.FALLBACK_LINE_HEIGHT);
@@ -48,8 +71,18 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
   const avgCharWidthRef = React.useRef(VIRTUALIZATION_CONFIG.FALLBACK_CHAR_WIDTH);
   const charsPerLineRef = React.useRef(VIRTUALIZATION_CONFIG.FALLBACK_CHARS_PER_LINE);
 
-  // Split data into lines
-  const lines = React.useMemo(() => data.split('\n'), [data]);
+  const flatItems = React.useMemo(
+    () => (sections ? buildFlatItems(sections) : undefined),
+    [sections],
+  );
+
+  // Lines for the virtualizer: either from sections' flat items or from splitting data
+  const lines = React.useMemo(() => {
+    if (flatItems) {
+      return flatItems.map((item) => (item.type === 'header' ? item.containerName : item.text));
+    }
+    return data.split('\n');
+  }, [data, flatItems]);
 
   // Suppress harmless ResizeObserver errors from virtualizer
   useResizeObserverFix();

--- a/src/shared/components/virtualized-log-viewer/VirtualizedLogContent.tsx
+++ b/src/shared/components/virtualized-log-viewer/VirtualizedLogContent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { LineNumberGutter } from './LineNumberGutter';
-import type { SearchedWord } from './types';
+import type { SearchedWord, LogSection } from './types';
 import { useKeyboardNavigation } from './useKeyboardNavigation';
 import { useLineNumberNavigation } from './useLineNumberNavigation';
 import { useLineRenderer } from './useLineRenderer';
@@ -19,8 +19,14 @@ import {
 
 import './VirtualizedLogContent.scss';
 
+// ANSI escape code regex for removing color codes from terminal output
+// ESC character (\u001b) is a control character but necessary for ANSI escape sequences
+// eslint-disable-next-line no-control-regex
+const ANSI_ESCAPE_REGEX = /\u001b\[[0-9;]*m/g;
+const normalizeLineEndings = (value: string): string => value.replace(/\r\n?/g, '\n');
+
 export interface VirtualizedLogContentProps {
-  data: string;
+  sections: LogSection[];
   height: number;
   width: string | number;
   scrollToRow?: number;
@@ -34,7 +40,7 @@ export interface VirtualizedLogContentProps {
 }
 
 export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
-  data,
+  sections,
   height,
   width,
   scrollToRow,
@@ -48,8 +54,21 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
   const avgCharWidthRef = React.useRef(VIRTUALIZATION_CONFIG.FALLBACK_CHAR_WIDTH);
   const charsPerLineRef = React.useRef(VIRTUALIZATION_CONFIG.FALLBACK_CHARS_PER_LINE);
 
-  // Split data into lines
-  const lines = React.useMemo(() => data.split('\n'), [data]);
+  const { lines, headerIndices } = React.useMemo(() => {
+    const result: string[] = [];
+    const headers = new Set<number>();
+    for (const section of sections) {
+      if (section.containerName) {
+        headers.add(result.length);
+        result.push(section.containerName);
+      }
+      if (section.data) {
+        const cleaned = normalizeLineEndings(section.data).replace(ANSI_ESCAPE_REGEX, '');
+        result.push(...cleaned.split('\n'));
+      }
+    }
+    return { lines: result, headerIndices: headers };
+  }, [sections]);
 
   // Suppress harmless ResizeObserver errors from virtualizer
   useResizeObserverFix();
@@ -255,12 +274,14 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
             {virtualItems.map((virtualItem) => {
               const lineNumber: number = virtualItem.index + 1;
               const isHighlighted = isLineHighlighted(lineNumber);
+              const isHeader = headerIndices.has(virtualItem.index);
+              const hasHeaders = headerIndices.size > 0;
               return (
                 <div
                   key={virtualItem.key}
                   data-index={virtualItem.index}
                   ref={virtualizer.measureElement}
-                  className={`pf-v5-c-log-viewer__list-item ${isHighlighted ? 'log-content__line--highlighted' : ''}`}
+                  className={`pf-v5-c-log-viewer__list-item ${isHighlighted ? 'log-content__line--highlighted' : ''} ${hasHeaders && !isHeader ? 'log-content__line--indented' : ''}`}
                   style={{
                     position: 'absolute',
                     top: 0,

--- a/src/shared/components/virtualized-log-viewer/VirtualizedLogContent.tsx
+++ b/src/shared/components/virtualized-log-viewer/VirtualizedLogContent.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { LineNumberGutter } from './LineNumberGutter';
+import { normalizeLineEndings, stripAnsiCodes } from './log-viewer-utils';
 import type { SearchedWord, LogSection } from './types';
 import { useKeyboardNavigation } from './useKeyboardNavigation';
 import { useLineNumberNavigation } from './useLineNumberNavigation';
@@ -18,12 +19,6 @@ import {
 } from './virtualization-utils';
 
 import './VirtualizedLogContent.scss';
-
-// ANSI escape code regex for removing color codes from terminal output
-// ESC character (\u001b) is a control character but necessary for ANSI escape sequences
-// eslint-disable-next-line no-control-regex
-const ANSI_ESCAPE_REGEX = /\u001b\[[0-9;]*m/g;
-const normalizeLineEndings = (value: string): string => value.replace(/\r\n?/g, '\n');
 
 export interface VirtualizedLogContentProps {
   sections: LogSection[];
@@ -63,7 +58,7 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
         result.push(section.containerName);
       }
       if (section.data) {
-        const cleaned = normalizeLineEndings(section.data).replace(ANSI_ESCAPE_REGEX, '');
+        const cleaned = stripAnsiCodes(normalizeLineEndings(section.data));
         result.push(...cleaned.split('\n'));
       }
     }

--- a/src/shared/components/virtualized-log-viewer/VirtualizedLogViewer.tsx
+++ b/src/shared/components/virtualized-log-viewer/VirtualizedLogViewer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { LogViewerToolbarContext } from '@patternfly/react-log-viewer';
+import type { LogSection } from './types';
 import { VirtualizedLogContent } from './VirtualizedLogContent';
 import '@patternfly/react-styles/css/components/LogViewer/log-viewer.css';
 
@@ -7,6 +8,7 @@ import './VirtualizedLogViewer.scss';
 
 export interface VirtualizedLogViewerProps {
   data: string;
+  sections?: LogSection[];
   height: number; // Required: height in pixels for virtualization
   width?: string | number;
   scrollToRow?: number;
@@ -27,6 +29,7 @@ export interface VirtualizedLogViewerProps {
  */
 export const VirtualizedLogViewer: React.FC<VirtualizedLogViewerProps> = ({
   data,
+  sections,
   height,
   width = '100%',
   scrollToRow,
@@ -57,6 +60,7 @@ export const VirtualizedLogViewer: React.FC<VirtualizedLogViewerProps> = ({
     <div className="pf-v5-c-log-viewer__main">
       <VirtualizedLogContent
         data={data}
+        sections={sections}
         height={height}
         width={width}
         scrollToRow={effectiveScrollToRow}

--- a/src/shared/components/virtualized-log-viewer/VirtualizedLogViewer.tsx
+++ b/src/shared/components/virtualized-log-viewer/VirtualizedLogViewer.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { LogViewerToolbarContext } from '@patternfly/react-log-viewer';
+import type { LogSection } from './types';
 import { VirtualizedLogContent } from './VirtualizedLogContent';
 import '@patternfly/react-styles/css/components/LogViewer/log-viewer.css';
 
 import './VirtualizedLogViewer.scss';
 
 export interface VirtualizedLogViewerProps {
-  data: string;
+  sections: LogSection[];
   height: number; // Required: height in pixels for virtualization
   width?: string | number;
   scrollToRow?: number;
@@ -26,7 +27,7 @@ export interface VirtualizedLogViewerProps {
  * - Drop-in replacement for PatternFly LogViewer
  */
 export const VirtualizedLogViewer: React.FC<VirtualizedLogViewerProps> = ({
-  data,
+  sections,
   height,
   width = '100%',
   scrollToRow,
@@ -56,7 +57,7 @@ export const VirtualizedLogViewer: React.FC<VirtualizedLogViewerProps> = ({
   return (
     <div className="pf-v5-c-log-viewer__main">
       <VirtualizedLogContent
-        data={data}
+        sections={sections}
         height={height}
         width={width}
         scrollToRow={effectiveScrollToRow}

--- a/src/shared/components/virtualized-log-viewer/__tests__/VirtualizedLogContent.spec.tsx
+++ b/src/shared/components/virtualized-log-viewer/__tests__/VirtualizedLogContent.spec.tsx
@@ -697,4 +697,68 @@ Another short line`;
       window.requestAnimationFrame = originalRAF;
     });
   });
+
+  describe('Sections support', () => {
+    const sectionProps = {
+      data: '',
+      sections: [
+        { containerName: 'step-build', lines: ['building...', 'done'] },
+        { containerName: 'step-test', lines: ['testing...', 'passed'] },
+      ],
+      height: 600,
+      width: '100%' as string | number,
+    };
+
+    it('should render container names as log lines', () => {
+      const { container } = renderWithQueryClientAndRouter(
+        <VirtualizedLogContent {...sectionProps} />,
+      );
+
+      const logContent = container.querySelector('.log-content__content-column');
+      expect(logContent?.textContent).toContain('step-build');
+      expect(logContent?.textContent).toContain('step-test');
+    });
+
+    it('should render log lines from all sections', () => {
+      const { container } = renderWithQueryClientAndRouter(
+        <VirtualizedLogContent {...sectionProps} />,
+      );
+
+      const logContent = container.querySelector('.log-content__content-column');
+      expect(logContent?.textContent).toContain('building...');
+      expect(logContent?.textContent).toContain('done');
+      expect(logContent?.textContent).toContain('testing...');
+      expect(logContent?.textContent).toContain('passed');
+    });
+
+    it('should use continuous line numbering across sections including headers', () => {
+      renderWithQueryClientAndRouter(<VirtualizedLogContent {...sectionProps} />);
+
+      const lineNumbers = document.querySelectorAll('.line-number__line-number');
+      const numbers = Array.from(lineNumbers).map((el) => Number(el.textContent));
+      // 2 headers + 4 log lines = 6 sequential line numbers
+      expect(numbers).toEqual([1, 2, 3, 4, 5, 6]);
+    });
+
+    it('should highlight search matches across sections', () => {
+      const searchSectionProps = {
+        ...sectionProps,
+        searchText: 'done',
+      };
+
+      renderWithQueryClientAndRouter(<VirtualizedLogContent {...searchSectionProps} />);
+
+      const marks = document.querySelectorAll('mark.pf-v5-c-log-viewer__string.pf-m-match');
+      expect(marks.length).toBe(1);
+    });
+
+    it('should fall back to data prop when sections is not provided', () => {
+      const { container } = renderWithQueryClientAndRouter(
+        <VirtualizedLogContent data="fallback line" height={600} width="100%" />,
+      );
+
+      const logContent = container.querySelector('.log-content__content-column');
+      expect(logContent?.textContent).toContain('fallback line');
+    });
+  });
 });

--- a/src/shared/components/virtualized-log-viewer/__tests__/VirtualizedLogContent.spec.tsx
+++ b/src/shared/components/virtualized-log-viewer/__tests__/VirtualizedLogContent.spec.tsx
@@ -37,7 +37,7 @@ jest.mock('lodash-es', () => ({
 describe('VirtualizedLogContent Integration Tests', () => {
   const mockData = 'line 1\nline 2\nline 3';
   const defaultProps = {
-    data: mockData,
+    sections: [{ containerName: '', data: mockData }],
     height: 600,
     width: '100%',
   };
@@ -116,7 +116,12 @@ describe('VirtualizedLogContent Integration Tests', () => {
 
     it('should efficiently handle large datasets with virtualization', () => {
       const longData = Array.from({ length: 1000 }, (_, i) => `line ${i + 1}`).join('\n');
-      renderWithQueryClientAndRouter(<VirtualizedLogContent {...defaultProps} data={longData} />);
+      renderWithQueryClientAndRouter(
+        <VirtualizedLogContent
+          {...defaultProps}
+          sections={[{ containerName: '', data: longData }]}
+        />,
+      );
 
       const items = document.querySelectorAll('.pf-v5-c-log-viewer__list-item');
       // Should only render visible items, not all 1000
@@ -159,7 +164,10 @@ describe('VirtualizedLogContent Integration Tests', () => {
 
       const testData = 'This line should still be visible even when tokenization fails';
       const { container } = renderWithQueryClientAndRouter(
-        <VirtualizedLogContent {...defaultProps} data={testData} />,
+        <VirtualizedLogContent
+          {...defaultProps}
+          sections={[{ containerName: '', data: testData }]}
+        />,
       );
 
       // Verify the raw text is displayed
@@ -173,7 +181,10 @@ describe('VirtualizedLogContent Integration Tests', () => {
     it('should display non-breaking space for truly empty lines', () => {
       const dataWithEmptyLine = 'line 1\n\nline 3';
       const { container } = renderWithQueryClientAndRouter(
-        <VirtualizedLogContent {...defaultProps} data={dataWithEmptyLine} />,
+        <VirtualizedLogContent
+          {...defaultProps}
+          sections={[{ containerName: '', data: dataWithEmptyLine }]}
+        />,
       );
 
       const textElements = container.querySelectorAll('.pf-v5-c-log-viewer__text');
@@ -193,7 +204,11 @@ describe('VirtualizedLogContent Integration Tests', () => {
 
     it('should highlight search matches in log content', () => {
       renderWithQueryClientAndRouter(
-        <VirtualizedLogContent {...defaultProps} data="error on line 1" searchText="error" />,
+        <VirtualizedLogContent
+          {...defaultProps}
+          sections={[{ containerName: '', data: 'error on line 1' }]}
+          searchText="error"
+        />,
       );
 
       const marks = document.querySelectorAll('mark.pf-v5-c-log-viewer__string.pf-m-match');
@@ -204,7 +219,7 @@ describe('VirtualizedLogContent Integration Tests', () => {
       renderWithQueryClientAndRouter(
         <VirtualizedLogContent
           {...defaultProps}
-          data="error on line 1"
+          sections={[{ containerName: '', data: 'error on line 1' }]}
           searchText="error"
           currentSearchMatch={{ rowIndex: 0, matchIndex: 1 }}
         />,
@@ -216,7 +231,11 @@ describe('VirtualizedLogContent Integration Tests', () => {
 
     it('should handle multiple matches in single line', () => {
       renderWithQueryClientAndRouter(
-        <VirtualizedLogContent {...defaultProps} data="error error error" searchText="error" />,
+        <VirtualizedLogContent
+          {...defaultProps}
+          sections={[{ containerName: '', data: 'error error error' }]}
+          searchText="error"
+        />,
       );
 
       const marks = document.querySelectorAll('mark.pf-v5-c-log-viewer__string.pf-m-match');
@@ -227,7 +246,7 @@ describe('VirtualizedLogContent Integration Tests', () => {
       const { container } = renderWithQueryClientAndRouter(
         <VirtualizedLogContent
           {...defaultProps}
-          data="[error] normal error"
+          sections={[{ containerName: '', data: '[error] normal error' }]}
           searchText="[error]"
         />,
       );
@@ -253,7 +272,11 @@ describe('VirtualizedLogContent Integration Tests', () => {
 
     it('should be case insensitive in search', () => {
       renderWithQueryClientAndRouter(
-        <VirtualizedLogContent {...defaultProps} data="ERROR Warning error" searchText="error" />,
+        <VirtualizedLogContent
+          {...defaultProps}
+          sections={[{ containerName: '', data: 'ERROR Warning error' }]}
+          searchText="error"
+        />,
       );
 
       const marks = document.querySelectorAll('mark.pf-v5-c-log-viewer__string.pf-m-match');
@@ -291,7 +314,9 @@ describe('VirtualizedLogContent Integration Tests', () => {
 
   describe('Edge Cases and Data Handling', () => {
     it('should handle empty data gracefully', () => {
-      renderWithQueryClientAndRouter(<VirtualizedLogContent {...defaultProps} data="" />);
+      renderWithQueryClientAndRouter(
+        <VirtualizedLogContent {...defaultProps} sections={[{ containerName: '', data: '' }]} />,
+      );
 
       const listElement = document.querySelector('.log-content__list');
       expect(listElement).toBeInTheDocument();
@@ -299,7 +324,10 @@ describe('VirtualizedLogContent Integration Tests', () => {
 
     it('should handle single line data', () => {
       renderWithQueryClientAndRouter(
-        <VirtualizedLogContent {...defaultProps} data="single line" />,
+        <VirtualizedLogContent
+          {...defaultProps}
+          sections={[{ containerName: '', data: 'single line' }]}
+        />,
       );
 
       expect(screen.getByText('single line')).toBeInTheDocument();
@@ -307,7 +335,12 @@ describe('VirtualizedLogContent Integration Tests', () => {
 
     it('should handle very long lines without breaking', () => {
       const longLine = 'a'.repeat(5000);
-      renderWithQueryClientAndRouter(<VirtualizedLogContent {...defaultProps} data={longLine} />);
+      renderWithQueryClientAndRouter(
+        <VirtualizedLogContent
+          {...defaultProps}
+          sections={[{ containerName: '', data: longLine }]}
+        />,
+      );
 
       const textElement = document.querySelector('.pf-v5-c-log-viewer__text');
       expect(textElement).toBeInTheDocument();
@@ -317,7 +350,10 @@ describe('VirtualizedLogContent Integration Tests', () => {
       const dataWithNewlines = 'line 1\nline 2\n\n';
 
       const { container } = renderWithQueryClientAndRouter(
-        <VirtualizedLogContent {...defaultProps} data={dataWithNewlines} />,
+        <VirtualizedLogContent
+          {...defaultProps}
+          sections={[{ containerName: '', data: dataWithNewlines }]}
+        />,
       );
 
       const listElement = document.querySelector('.log-content__list');
@@ -332,7 +368,10 @@ describe('VirtualizedLogContent Integration Tests', () => {
     it('should handle special characters in log content', () => {
       const specialData = 'line with <html> tags\nline with & ampersand\nline with "quotes"';
       renderWithQueryClientAndRouter(
-        <VirtualizedLogContent {...defaultProps} data={specialData} />,
+        <VirtualizedLogContent
+          {...defaultProps}
+          sections={[{ containerName: '', data: specialData }]}
+        />,
       );
 
       const listElement = document.querySelector('.log-content__list');
@@ -344,7 +383,10 @@ describe('VirtualizedLogContent Integration Tests', () => {
     it('should preserve empty lines with non-breaking space', () => {
       const dataWithEmptyLines = 'line 1\n\nline 3\n\n\nline 6';
       const { container } = renderWithQueryClientAndRouter(
-        <VirtualizedLogContent {...defaultProps} data={dataWithEmptyLines} />,
+        <VirtualizedLogContent
+          {...defaultProps}
+          sections={[{ containerName: '', data: dataWithEmptyLines }]}
+        />,
       );
 
       const textElements = container.querySelectorAll('.pf-v5-c-log-viewer__text');
@@ -364,7 +406,11 @@ describe('VirtualizedLogContent Integration Tests', () => {
     it('should preserve empty lines when searching', () => {
       const dataWithEmptyLines = 'error\n\nerror';
       const { container } = renderWithQueryClientAndRouter(
-        <VirtualizedLogContent {...defaultProps} data={dataWithEmptyLines} searchText="error" />,
+        <VirtualizedLogContent
+          {...defaultProps}
+          sections={[{ containerName: '', data: dataWithEmptyLines }]}
+          searchText="error"
+        />,
       );
 
       const textElements = container.querySelectorAll('.pf-v5-c-log-viewer__text');
@@ -384,7 +430,10 @@ describe('VirtualizedLogContent Integration Tests', () => {
       // Create a very long line that would normally overflow
       const longLine = `ERROR: ${'A'.repeat(500)} - this is a very long error message`;
       const { container } = renderWithQueryClientAndRouter(
-        <VirtualizedLogContent {...defaultProps} data={longLine} />,
+        <VirtualizedLogContent
+          {...defaultProps}
+          sections={[{ containerName: '', data: longLine }]}
+        />,
       );
 
       const logText = container.querySelector('.pf-v5-c-log-viewer__text');
@@ -398,7 +447,10 @@ describe('VirtualizedLogContent Integration Tests', () => {
       // Create a line with a very long unbreakable URL
       const longUrl = `https://example.com/very-long-path/${'segment/'.repeat(50)}endpoint`;
       const { container } = renderWithQueryClientAndRouter(
-        <VirtualizedLogContent {...defaultProps} data={longUrl} />,
+        <VirtualizedLogContent
+          {...defaultProps}
+          sections={[{ containerName: '', data: longUrl }]}
+        />,
       );
 
       // Query the log list content (not the hidden measurement element)
@@ -410,7 +462,10 @@ describe('VirtualizedLogContent Integration Tests', () => {
     it('should preserve whitespace and line breaks with pre-wrap', () => {
       const dataWithSpaces = 'Line 1    with    spaces\n  Line 2 indented\nLine 3';
       const { container } = renderWithQueryClientAndRouter(
-        <VirtualizedLogContent {...defaultProps} data={dataWithSpaces} />,
+        <VirtualizedLogContent
+          {...defaultProps}
+          sections={[{ containerName: '', data: dataWithSpaces }]}
+        />,
       );
 
       const logText = container.querySelector('.log-content__list');
@@ -427,7 +482,10 @@ ${'Very long line that will wrap: '.repeat(10)}
 Another short line`;
 
       const { container } = renderWithQueryClientAndRouter(
-        <VirtualizedLogContent {...defaultProps} data={mixedData} />,
+        <VirtualizedLogContent
+          {...defaultProps}
+          sections={[{ containerName: '', data: mixedData }]}
+        />,
       );
 
       // Query the actual virtualized list items (excluding the hidden measurement element)
@@ -593,7 +651,12 @@ Another short line`;
       window.location.hash = '#L100';
       const shortData = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join('\n');
 
-      renderWithQueryClientAndRouter(<VirtualizedLogContent {...defaultProps} data={shortData} />);
+      renderWithQueryClientAndRouter(
+        <VirtualizedLogContent
+          {...defaultProps}
+          sections={[{ containerName: '', data: shortData }]}
+        />,
+      );
 
       // Component should render without errors
       const listElement = document.querySelector('.log-content__list');
@@ -607,7 +670,12 @@ Another short line`;
       window.location.hash = '#L50-L100';
       const shortData = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join('\n');
 
-      renderWithQueryClientAndRouter(<VirtualizedLogContent {...defaultProps} data={shortData} />);
+      renderWithQueryClientAndRouter(
+        <VirtualizedLogContent
+          {...defaultProps}
+          sections={[{ containerName: '', data: shortData }]}
+        />,
+      );
 
       // Component should render without errors even with out-of-range hash
       const listElement = document.querySelector('.log-content__list');
@@ -619,7 +687,7 @@ Another short line`;
 
       // Start with empty data
       const { rerender } = renderWithQueryClientAndRouter(
-        <VirtualizedLogContent {...defaultProps} data="" />,
+        <VirtualizedLogContent {...defaultProps} sections={[{ containerName: '', data: '' }]} />,
       );
 
       let listElement = document.querySelector('.log-content__list');
@@ -627,7 +695,12 @@ Another short line`;
 
       // Update with actual data
       const dataWithLines = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join('\n');
-      rerender(<VirtualizedLogContent {...defaultProps} data={dataWithLines} />);
+      rerender(
+        <VirtualizedLogContent
+          {...defaultProps}
+          sections={[{ containerName: '', data: dataWithLines }]}
+        />,
+      );
 
       // Should now have content and handle the hash
       listElement = document.querySelector('.log-content__list');
@@ -642,7 +715,12 @@ Another short line`;
       window.location.hash = '#L500';
       const longData = Array.from({ length: 1000 }, (_, i) => `line ${i + 1}`).join('\n');
 
-      renderWithQueryClientAndRouter(<VirtualizedLogContent {...defaultProps} data={longData} />);
+      renderWithQueryClientAndRouter(
+        <VirtualizedLogContent
+          {...defaultProps}
+          sections={[{ containerName: '', data: longData }]}
+        />,
+      );
 
       // Should render without performance issues
       const listElement = document.querySelector('.log-content__list');
@@ -695,6 +773,73 @@ Another short line`;
       // Cleanup
       scrollToIndexSpy = null;
       window.requestAnimationFrame = originalRAF;
+    });
+  });
+
+  describe('Sections support', () => {
+    const sectionProps = {
+      sections: [
+        { containerName: 'step-build', data: 'building...\ndone' },
+        { containerName: 'step-test', data: 'testing...\npassed' },
+      ],
+      height: 600,
+      width: '100%' as string | number,
+    };
+
+    it('should render container names as log lines', () => {
+      const { container } = renderWithQueryClientAndRouter(
+        <VirtualizedLogContent {...sectionProps} />,
+      );
+
+      const logContent = container.querySelector('.log-content__content-column');
+      expect(logContent?.textContent).toContain('step-build');
+      expect(logContent?.textContent).toContain('step-test');
+    });
+
+    it('should render log lines from all sections', () => {
+      const { container } = renderWithQueryClientAndRouter(
+        <VirtualizedLogContent {...sectionProps} />,
+      );
+
+      const logContent = container.querySelector('.log-content__content-column');
+      expect(logContent?.textContent).toContain('building...');
+      expect(logContent?.textContent).toContain('done');
+      expect(logContent?.textContent).toContain('testing...');
+      expect(logContent?.textContent).toContain('passed');
+    });
+
+    it('should use continuous line numbering across sections including headers', () => {
+      renderWithQueryClientAndRouter(<VirtualizedLogContent {...sectionProps} />);
+
+      const lineNumbers = document.querySelectorAll('.line-number__line-number');
+      const numbers = Array.from(lineNumbers).map((el) => Number(el.textContent));
+      // 2 headers + 4 log lines = 6 sequential line numbers
+      expect(numbers).toEqual([1, 2, 3, 4, 5, 6]);
+    });
+
+    it('should highlight search matches across sections', () => {
+      const searchSectionProps = {
+        ...sectionProps,
+        searchText: 'done',
+      };
+
+      renderWithQueryClientAndRouter(<VirtualizedLogContent {...searchSectionProps} />);
+
+      const marks = document.querySelectorAll('mark.pf-v5-c-log-viewer__string.pf-m-match');
+      expect(marks.length).toBe(1);
+    });
+
+    it('should render single section without container name', () => {
+      const { container } = renderWithQueryClientAndRouter(
+        <VirtualizedLogContent
+          sections={[{ containerName: '', data: 'fallback line' }]}
+          height={600}
+          width="100%"
+        />,
+      );
+
+      const logContent = container.querySelector('.log-content__content-column');
+      expect(logContent?.textContent).toContain('fallback line');
     });
   });
 });

--- a/src/shared/components/virtualized-log-viewer/__tests__/VirtualizedLogViewer.spec.tsx
+++ b/src/shared/components/virtualized-log-viewer/__tests__/VirtualizedLogViewer.spec.tsx
@@ -16,7 +16,7 @@ jest.mock('lodash-es', () => ({
 describe('VirtualizedLogViewer Integration Tests', () => {
   const mockData = 'line 1\nline 2\nline 3';
   const defaultProps = {
-    data: mockData,
+    sections: [{ containerName: '', data: mockData }],
     height: 600,
   };
 
@@ -75,7 +75,10 @@ describe('VirtualizedLogViewer Integration Tests', () => {
   describe('Data Handling and Integration', () => {
     it('should render custom data through VirtualizedLogContent', () => {
       const { container } = renderWithQueryClientAndRouter(
-        <VirtualizedLogViewer {...defaultProps} data="test data" />,
+        <VirtualizedLogViewer
+          {...defaultProps}
+          sections={[{ containerName: '', data: 'test data' }]}
+        />,
       );
 
       expect(container.textContent).toContain('test data');
@@ -83,7 +86,7 @@ describe('VirtualizedLogViewer Integration Tests', () => {
 
     it('should handle empty data gracefully', () => {
       const { container } = renderWithQueryClientAndRouter(
-        <VirtualizedLogViewer {...defaultProps} data="" />,
+        <VirtualizedLogViewer {...defaultProps} sections={[{ containerName: '', data: '' }]} />,
       );
 
       const logList = container.querySelector('.log-content__list');
@@ -93,7 +96,10 @@ describe('VirtualizedLogViewer Integration Tests', () => {
     it('should render multiline data correctly', () => {
       const multilineData = 'line 1\nline 2\nline 3\nline 4';
       const { container } = renderWithQueryClientAndRouter(
-        <VirtualizedLogViewer {...defaultProps} data={multilineData} />,
+        <VirtualizedLogViewer
+          {...defaultProps}
+          sections={[{ containerName: '', data: multilineData }]}
+        />,
       );
 
       expect(container.textContent).toContain('line 1');
@@ -233,7 +239,10 @@ describe('VirtualizedLogViewer Integration Tests', () => {
     it('should handle very long data efficiently with virtualization', () => {
       const longData = Array.from({ length: 1000 }, (_, i) => `line ${i + 1}`).join('\n');
       const { container } = renderWithQueryClientAndRouter(
-        <VirtualizedLogViewer {...defaultProps} data={longData} />,
+        <VirtualizedLogViewer
+          {...defaultProps}
+          sections={[{ containerName: '', data: longData }]}
+        />,
       );
 
       const logList = container.querySelector('.log-content__list');
@@ -247,7 +256,10 @@ describe('VirtualizedLogViewer Integration Tests', () => {
     it('should handle data with special characters', () => {
       const specialData = 'line with <html> tags\nline with & ampersand\nline with "quotes"';
       const { container } = renderWithQueryClientAndRouter(
-        <VirtualizedLogViewer {...defaultProps} data={specialData} />,
+        <VirtualizedLogViewer
+          {...defaultProps}
+          sections={[{ containerName: '', data: specialData }]}
+        />,
       );
 
       expect(container.textContent).toContain('<html>');

--- a/src/shared/components/virtualized-log-viewer/index.ts
+++ b/src/shared/components/virtualized-log-viewer/index.ts
@@ -2,7 +2,7 @@ export { VirtualizedLogViewer } from './VirtualizedLogViewer';
 export type { VirtualizedLogViewerProps } from './VirtualizedLogViewer';
 export { VirtualizedLogContent } from './VirtualizedLogContent';
 export type { VirtualizedLogContentProps } from './VirtualizedLogContent';
-export type { SearchedWord } from './types';
+export type { SearchedWord, LogSection } from './types';
 export { LineNumberGutter } from './LineNumberGutter';
 export type { LineNumberGutterProps } from './LineNumberGutter';
 export { useLineNumberNavigation } from './useLineNumberNavigation';

--- a/src/shared/components/virtualized-log-viewer/log-viewer-utils.ts
+++ b/src/shared/components/virtualized-log-viewer/log-viewer-utils.ts
@@ -1,5 +1,27 @@
 import Prism from 'prismjs';
-import type { MatchRange } from './types';
+import type { LogSection, MatchRange } from './types';
+
+// ANSI escape code regex for removing color codes from terminal output
+// ESC character (\u001b) is a control character but necessary for ANSI escape sequences
+// eslint-disable-next-line no-control-regex
+const ANSI_ESCAPE_REGEX = /\u001b\[[0-9;]*m/g;
+
+export const normalizeLineEndings = (value: string): string => value.replace(/\r\n?/g, '\n');
+
+export const stripAnsiCodes = (value: string): string => value.replace(ANSI_ESCAPE_REGEX, '');
+
+export const buildLines = (sections: LogSection[]): string[] => {
+  const result: string[] = [];
+  for (const section of sections) {
+    if (section.containerName) {
+      result.push(section.containerName);
+    }
+    if (section.data) {
+      result.push(...stripAnsiCodes(normalizeLineEndings(section.data)).split('\n'));
+    }
+  }
+  return result;
+};
 
 /** Recursively flattens nested Prism tokens into plain text */
 export function flattenTokenText(token: string | Prism.Token): string {

--- a/src/shared/components/virtualized-log-viewer/types.ts
+++ b/src/shared/components/virtualized-log-viewer/types.ts
@@ -16,3 +16,9 @@ export type TokenizedLine = {
 
 /** Range representing start and end positions of a match */
 export type MatchRange = { start: number; end: number };
+
+/** A section of log output from a single container */
+export interface LogSection {
+  containerName: string;
+  lines: string[];
+}

--- a/src/shared/components/virtualized-log-viewer/types.ts
+++ b/src/shared/components/virtualized-log-viewer/types.ts
@@ -16,3 +16,9 @@ export type TokenizedLine = {
 
 /** Range representing start and end positions of a match */
 export type MatchRange = { start: number; end: number };
+
+/** A section of log output from a single container */
+export interface LogSection {
+  containerName: string;
+  data: string;
+}


### PR DESCRIPTION
## Fixes
Fixes: https://issues.redhat.com/browse/KFLUXUI-1277

## Description

Replace the flat string log pipeline with a structured `LogSection[]` type that preserves per-container structure through the component tree.

**Before:** `processLogs()` in `Logs.tsx` split each container's logs by `\n`, added string indentation (`'  ' + line`), and joined everything into a single string — which `LogViewer` and `VirtualizedLogContent` then split again (3 redundant split operations per render cycle).

**After:** `Logs.tsx` builds a `LogSection[]` via `useMemo` (one entry per container with raw `data: string`). `VirtualizedLogContent` handles all processing in a single pass (normalize line endings, strip ANSI codes, split into lines), and uses CSS `padding-left` for indentation instead of string manipulation.

- Add `LogSection` type (`{ containerName: string; data: string }`)
- Remove `processLogs()`, its debounce wrapper, and related state (`formattedLogs`, `processingLogs`, `containersRef`)
- `LogViewer` accepts `sections: LogSection[]` as the single data API
- `TektonTaskRunLog` wraps its pre-aggregated string as a single-element `LogSection[]`
- ANSI stripping and line-ending normalization applied once in the render layer
- `VirtualizedLogContent` builds a flat line list from sections, tracking container headers via index set for CSS indentation

## Type of change

- [x] Refactoring (no functional changes, no api changes)

## Screen shots / Gifs for design review

### KubeArchive (sections path) — rendered logs, search, download

https://github.com/user-attachments/assets/df5ba026-caa9-42e5-aba5-e5ea3d72d5d1

### Tekton Results (data string path) — rendered logs, search

https://github.com/user-attachments/assets/f5a02827-67dc-4ab3-99d2-c206c715208c

### Live log streaming — WebSocket fetch, auto-scroll

https://github.com/user-attachments/assets/5f0e2e2c-e08b-4390-ac09-779fc3719c30

## How to test or reproduce?

- [ ] Open a pipeline run with multiple task steps — logs should display per-container with container names visible
- [ ] Search for text spanning multiple containers — matches should highlight correctly
- [ ] Search for a container name — should match and highlight
- [ ] Verify auto-scroll works during streaming (running pipeline)
- [ ] Download logs — file should contain all container logs
- [ ] Open a Tekton Results log (completed pipeline via Tekton Results API) — should still render correctly

## Browser conformance:
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured log viewer to organize logs by container sections for improved clarity and organization.
  * Updated download functionality to generate log files from organized container sections.
  * Enhanced handling of multi-container log display with better visual separation.

* **Tests**
  * Updated test suite to validate new container section-based log structure and rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konflux-ci/konflux-ui/pull/849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->