### PR TITLE
fix(KFLUXUI-1294): whitelist konflux-ci-coder bot in pr-check workflow

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -20,6 +20,20 @@ on:
     types: [opened, synchronize, ready_for_review]
 
 jobs:
+  add-fullsend-label:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request_target'
+      && github.event.action == 'opened'
+      && github.event.pull_request.user.login == 'konflux-ci-coder[bot]'
+    steps:
+      - name: Add fullsend label
+        run: gh pr edit "$PR_NUMBER" --add-label "fullsend"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+
   dispatch-triage:
     runs-on: ubuntu-latest
     concurrency:

--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -21,6 +21,8 @@ on:
 
 jobs:
   add-fullsend-label:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'pull_request_target'

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -23,17 +23,19 @@ jobs:
             exit 0
           fi
 
-          WHITELISTED_BOT_NAME="red-hat-konflux[bot]"
+          WHITELISTED_BOTS=("red-hat-konflux[bot]" "konflux-ci-coder[bot]")
           REQUIRED_LABEL_NAME="ok-to-test"
 
           ORG="${{ github.repository_owner }}"
           PR_AUTHOR=$(jq --raw-output .pull_request.user.login $GITHUB_EVENT_PATH)
           PR_LABELS=$(jq --raw-output .pull_request.labels[].name $GITHUB_EVENT_PATH)
 
-          if [ "$PR_AUTHOR" == "$WHITELISTED_BOT_NAME" ]; then
-            echo "PR author is "$WHITELISTED_BOT_NAME", skipping further checks."
-            exit 0
-          fi
+          for BOT in "${WHITELISTED_BOTS[@]}"; do
+            if [ "$PR_AUTHOR" == "$BOT" ]; then
+              echo "PR author is $BOT, skipping further checks."
+              exit 0
+            fi
+          done
 
           if [[ "$PR_LABELS" == *$REQUIRED_LABEL_NAME* ]]; then
             echo "PR has '$REQUIRED_LABEL_NAME' label, skipping further checks."
@@ -51,7 +53,7 @@ jobs:
           ERROR_SUMMARY=$(cat <<EOF
 
           ### ❌ Cannot run E2E tests - at least one of the following conditions must be met:
-          * PR author is '$WHITELISTED_BOT_NAME'
+          * PR author is a whitelisted bot (${WHITELISTED_BOTS[*]})
           * PR has label '$REQUIRED_LABEL_NAME'
           * PR author is a konflux-ui developer (listed in ALLOWED_USERS in this script)
           EOF


### PR DESCRIPTION
## Fixes
Fixes: https://redhat.atlassian.net/browse/KFLUXUI-1294
Fixes https://github.com/konflux-ci/konflux-ui/issues/860

## Description
PRs raised by `konflux-ci-coder[bot]` currently don't trigger e2e tests because the bot isn't whitelisted in the org membership check. This PR:

1. Converts `WHITELISTED_BOT_NAME` to a `WHITELISTED_BOTS` array in `pr-check.yaml` and adds `konflux-ci-coder[bot]` alongside `red-hat-konflux[bot]`
2. Adds an `add-fullsend-label` job in `fullsend.yaml` to automatically apply the `fullsend` label when `konflux-ci-coder[bot]` opens a PR

## Type of change

- [x] Bugfix

## Screen shots / Gifs for design review
N/A — CI workflow changes only.

## How to test or reproduce?
1. Verify that a PR opened by `konflux-ci-coder[bot]` passes the org membership check
2. Verify that the `fullsend` label is automatically added to such PRs
3. Verify that PRs from `red-hat-konflux[bot]` still pass as before
4. Verify that PRs from unknown authors without `ok-to-test` still fail

## Browser conformance:
N/A — no UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows: expanded pull-request triggers so review dispatch runs more broadly and an automated job now adds a "fullsend" label for PRs opened by a trusted automation bot.
  * CI validation: improved bot handling by supporting a whitelisted-bots list to skip membership checks and updated failure messaging accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->