### PR TITLE
fix(KONFLUX-13601): always display git options in components form

### DIFF
--- a/src/components/ImportForm/ComponentSection/SourceSection.tsx
+++ b/src/components/ImportForm/ComponentSection/SourceSection.tsx
@@ -79,12 +79,8 @@ export const SourceSection = () => {
         data-testid="enter-source"
         onChange={handleChange}
       />
-      {validated === ValidatedOptions.success ? (
-        <SwitchField name="isPrivateRepo" label="Should the image produced be private?" />
-      ) : null}
-      {validated === ValidatedOptions.success ? (
-        <GitOptions isGitAdvancedOpen={isGitAdvancedOpen} setGitAdvancedOpen={setGitAdvancedOpen} />
-      ) : null}
+      <SwitchField name="isPrivateRepo" label="Should the image produced be private?" />
+      <GitOptions isGitAdvancedOpen={isGitAdvancedOpen} setGitAdvancedOpen={setGitAdvancedOpen} />
     </>
   );
 };

--- a/src/components/ImportForm/ComponentSection/__tests__/ComponentSection.spec.tsx
+++ b/src/components/ImportForm/ComponentSection/__tests__/ComponentSection.spec.tsx
@@ -69,16 +69,14 @@ describe('ComponentSection', () => {
 
     await user.type(source, 'https://code.forgejo.org/abcd/repo.git');
     await user.tab();
-    await waitFor(() =>
+    await waitFor(() => {
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       expect((screen.getByLabelText(/git url annotation/i) as HTMLInputElement).value).toBe(
         'https://code.forgejo.org',
-      ),
-    );
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    expect((screen.getByLabelText(/git provider annotation/i) as HTMLInputElement).value).toBe(
-      'forgejo',
-    );
+      );
+      // Git provider is a Select/MenuToggle; PF FormGroup does not associate the label for getByLabelText.
+      expect(screen.getByTestId('dropdown-toggle')).toHaveTextContent('forgejo');
+    });
   });
 
   it('should render helper text for component name', () => {

--- a/src/components/ImportForm/ComponentSection/__tests__/ComponentSection.spec.tsx
+++ b/src/components/ImportForm/ComponentSection/__tests__/ComponentSection.spec.tsx
@@ -15,7 +15,8 @@ describe('ComponentSection', () => {
     expect(
       screen.getByText('Supports GitHub, GitLab, and Forgejo repositories'),
     ).toBeInTheDocument();
-    expect(screen.getByTestId('git-reference')).toBeInTheDocument();
+    expect(screen.getByLabelText(/git reference/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/should the image produced be private\?/i)).toBeInTheDocument();
   });
 
   it('should render git options by default', async () => {
@@ -53,7 +54,7 @@ describe('ComponentSection', () => {
     await user.tab();
     await waitFor(() =>
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-      expect((screen.getByTestId('url-annotation') as HTMLInputElement).value).toBe(
+      expect((screen.getByLabelText(/git url annotation/i) as HTMLInputElement).value).toBe(
         'https://gitlab.com',
       ),
     );
@@ -70,9 +71,13 @@ describe('ComponentSection', () => {
     await user.tab();
     await waitFor(() =>
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-      expect((screen.getByTestId('url-annotation') as HTMLInputElement).value).toBe(
+      expect((screen.getByLabelText(/git url annotation/i) as HTMLInputElement).value).toBe(
         'https://code.forgejo.org',
       ),
+    );
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+    expect((screen.getByLabelText(/git provider annotation/i) as HTMLInputElement).value).toBe(
+      'forgejo',
     );
   });
 

--- a/src/components/ImportForm/ComponentSection/__tests__/ComponentSection.spec.tsx
+++ b/src/components/ImportForm/ComponentSection/__tests__/ComponentSection.spec.tsx
@@ -11,8 +11,11 @@ describe('ComponentSection', () => {
     formikRenderer(<ComponentSection />, {
       source: { git: { url: '' } },
     });
-    screen.getByPlaceholderText('Enter a Git repository URL');
-    expect(screen.queryByTestId('git-reference')).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Enter a Git repository URL')).toBeInTheDocument();
+    expect(
+      screen.getByText('Supports GitHub, GitLab, and Forgejo repositories'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('git-reference')).toBeInTheDocument();
   });
 
   it('should render git options by default', async () => {
@@ -52,6 +55,23 @@ describe('ComponentSection', () => {
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       expect((screen.getByTestId('url-annotation') as HTMLInputElement).value).toBe(
         'https://gitlab.com',
+      ),
+    );
+  });
+
+  it('should populate annotation fields for Forgejo URLs', async () => {
+    formikRenderer(<ComponentSection />, {
+      source: { git: { url: '' } },
+    });
+    const user = userEvent.setup();
+    const source = screen.getByPlaceholderText('Enter a Git repository URL');
+
+    await user.type(source, 'https://code.forgejo.org/abcd/repo.git');
+    await user.tab();
+    await waitFor(() =>
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+      expect((screen.getByTestId('url-annotation') as HTMLInputElement).value).toBe(
+        'https://code.forgejo.org',
       ),
     );
   });


### PR DESCRIPTION
Assisted-by: Cursor

## Fixes 
Fixes: https://redhat.atlassian.net/browse/KONFLUX-13601

## Description
The add-component import form previously showed the private-image switch and advanced Git options only after the repository URL field reached a successful validation state. That hid useful fields until the URL looked valid. This change always renders those controls so users can see and use Git configuration (reference, context, annotations, etc.) and the private-image toggle as soon as they open the form. Values still update from the URL `onChange` handler as before.

Unit tests were updated so the initial render expects advanced Git fields (e.g. Git reference) to be present, asserts the Git URL helper copy, and adds coverage for Forgejo URLs populating the Git URL annotation field.

## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

Before:
<img width="1176" height="766" alt="image" src="https://github.com/user-attachments/assets/05134f8d-acf5-4425-9795-df6a0a33bffa" />


After:
<img width="1176" height="766" alt="image" src="https://github.com/user-attachments/assets/a222f0aa-3141-4f6f-94c0-030c236962b8" />


## How to test or reproduce?

- In the UI: open **Add component** (or equivalent import flow), confirm **advanced Git options** and the **private image** switch appear without entering a URL first; enter GitHub, GitLab, and Forgejo URLs and confirm annotations still populate as expected.

**Test configuration(s):** Local Jest; optional manual smoke on import form.

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The private-repository toggle and Git options now display immediately during repository import instead of waiting for prior validation, improving discoverability and workflow continuity.
  * The Git reference input is consistently available during import.

* **Tests**
  * Expanded tests for Git URL input, messaging, and annotations; added coverage to ensure Forgejo URLs correctly populate provider and URL annotation fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->