### PR TITLE
ci(KFLUXUI-1320): run workflows on patternfly-v6 branch

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - main
+      - patternfly-v6
   merge_group:
     types: [checks_requested]
 

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - patternfly-v6
 
 # Cancel in-progress runs when new commits are pushed to main
 concurrency:

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -66,7 +66,12 @@ jobs:
           QUAY_BOT_USERNAME: ${{ secrets.QUAY_BOT_USERNAME }}
         run: |
           podman login -u="$QUAY_BOT_USERNAME" -p="$QUAY_BOT_TOKEN" quay.io
-          TEST_IMAGE="quay.io/konflux_ui_qe/konflux-ui-tests:latest"
+
+          TAG="latest"
+          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          TEST_IMAGE="quay.io/konflux_ui_qe/konflux-ui-tests:${TAG}"
 
           cd e2e-tests
           podman build -t ${TEST_IMAGE} -f Containerfile


### PR DESCRIPTION

## Fixes
Fixes: https://redhat.atlassian.net/browse/KFLUXUI-1320

## Description
Enable CI workflows to trigger on the `patternfly-v6` feature branch:
- **main.yaml** (lint & unit tests): added `patternfly-v6` to `pull_request.branches`
- **post-merge.yaml** (coverage): added `patternfly-v6` to `push.branches`
- **pr-check.yaml**: no change needed — uses `pull_request_target` without branch filter, already runs on PRs to any branch

## Type of change

- [x] Build related changes

## Screen shots / Gifs for design review
N/A — CI config only

## How to test or reproduce?
- Open a PR targeting `patternfly-v6` branch and verify `UI Lint & Unit Tests` workflow triggers
- Merge to `patternfly-v6` and verify `Push Coverage Post Merge` workflow triggers

## Browser conformance:
N/A — CI config only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to support an additional branch target for continuous integration and code coverage tracking.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konflux-ci/konflux-ui/pull/878)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->