### PR TITLE
fix(KFLUXUI-1329): migrate MultiSelect filter from deprecated to composable Select API

### DIFF
--- a/src/components/Filter/generic/MultiSelect.tsx
+++ b/src/components/Filter/generic/MultiSelect.tsx
@@ -1,11 +1,14 @@
 import { useState } from 'react';
-import { Divider, ToolbarFilter } from '@patternfly/react-core';
 import {
+  Badge,
+  Divider,
+  MenuToggle,
   Select,
   SelectGroup,
+  SelectList,
   SelectOption,
-  SelectVariant,
-} from '@patternfly/react-core/deprecated';
+  ToolbarFilter,
+} from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 
 export const MENU_DIVIDER = '--divider--';
@@ -54,41 +57,47 @@ export const MultiSelect = ({
       categoryName={label}
     >
       <Select
-        placeholderText={placeholderText ?? label}
-        toggleIcon={<FilterIcon />}
-        toggleAriaLabel={toggleAriaLabel ?? `${label} filter menu`}
-        variant={SelectVariant.checkbox}
+        role="menu"
         isOpen={expanded}
-        onToggle={(_, exp: boolean) => setExpanded(exp)}
-        onSelect={(event, selection) => {
-          const checked = (event.target as HTMLInputElement).checked;
+        selected={values}
+        onSelect={(_, selection) => {
+          const value = String(selection);
           setValues(
-            checked
-              ? [...values, String(selection)]
-              : values.filter((value) => value !== selection),
+            values.includes(value) ? values.filter((v) => v !== value) : [...values, value],
           );
         }}
-        selections={values}
-        isGrouped
+        onOpenChange={setExpanded}
+        toggle={(toggleRef) => (
+          <MenuToggle
+            ref={toggleRef}
+            onClick={() => setExpanded(!expanded)}
+            isExpanded={expanded}
+            icon={<FilterIcon />}
+            aria-label={toggleAriaLabel ?? `${label} filter menu`}
+          >
+            {placeholderText ?? label}
+            {values.length > 0 && <Badge isRead>{values.length}</Badge>}
+          </MenuToggle>
+        )}
       >
-        {[
-          <SelectGroup label={label} key={filterKey}>
+        <SelectGroup label={label} key={filterKey}>
+          <SelectList>
             {Object.keys(options).map((filter) =>
               filter.startsWith(MENU_DIVIDER) ? (
                 <Divider key={filter} />
               ) : (
                 <SelectOption
+                  hasCheckbox
                   key={filter}
                   value={filter}
-                  isChecked={values.includes(filter)}
-                  // TODO: remove the item count from other components, it is not accurate anyway as it only counts fetched resources
+                  isSelected={values.includes(filter)}
                 >
                   {optionLabels?.[filter] ?? filter}
                 </SelectOption>
               ),
             )}
-          </SelectGroup>,
-        ]}
+          </SelectList>
+        </SelectGroup>
       </Select>
     </ToolbarFilter>
   );

--- a/src/components/Filter/generic/MultiSelect.tsx
+++ b/src/components/Filter/generic/MultiSelect.tsx
@@ -84,7 +84,7 @@ export const MultiSelect = ({
           <SelectList>
             {Object.keys(options).map((filter) =>
               filter.startsWith(MENU_DIVIDER) ? (
-                <Divider key={filter} />
+                <Divider component="li" key={filter} />
               ) : (
                 <SelectOption
                   hasCheckbox


### PR DESCRIPTION
## Fixes
Fixes: https://issues.redhat.com/browse/KFLUXUI-1329

## Description

Migrate the `MultiSelect` filter component from the deprecated PF5 Select API (`@patternfly/react-core/deprecated`) to the current composable Select API (`@patternfly/react-core`).

Changes:
- **Toggle**: implicit toggle props → `MenuToggle` with render function
- **Variant**: `SelectVariant.checkbox` → `role="menu"` + `hasCheckbox` on each `SelectOption`
- **Selection**: `selections` → `selected`; `isChecked` → `isSelected`
- **Layout**: implicit children → explicit `SelectList` wrapper
- **onSelect**: `event.target.checked` → toggle logic (add/remove by value)
- **Badge**: added `Badge` in `MenuToggle` to show selected count
- **onToggle**: `onToggle` → `onOpenChange` + `onClick` on `MenuToggle`

## Type of change

- [x] Refactoring (no functional changes, no api changes)

## Screen shots / Gifs for design review

No visual changes expected — the filter dropdowns should look and behave the same as before.

https://github.com/user-attachments/assets/97e4ade8-ccd6-400f-ab4c-1b2ad3356982

## How to test or reproduce?

- Navigate to any page with filter dropdowns (e.g. Pipeline Runs, Commits, Components)
- Click a filter toggle → verify checkbox options render correctly
- Select/deselect options → verify chips appear/disappear and selections persist
- Clear chips → verify filters reset

## Browser conformance
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Multi-select filter migrated to a modern menu-style control with a custom toggle (icon, accessible label, and optional selected-count badge).
  * Options now render as grouped lists with visual dividers and checkbox-style selection indicators for clarity.
  * Selection and menu state handling improved: clicking toggles items in/out and open/close behavior is more consistent for keyboard and assistive tech.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konflux-ci/konflux-ui/pull/883?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->