### PR TITLE
feat(RHTAP-6170): Adjust konflux UI tests for TSF

### DIFF
--- a/e2e-tests/cypress.config.ts
+++ b/e2e-tests/cypress.config.ts
@@ -117,7 +117,11 @@ export default defineConfig({
         KUBECONFIG: '~/.kube/appstudio-config',
         CLEAN_NAMESPACE: 'false',
         LOCAL_CLUSTER: false,
+        LOGIN_PROVIDER: '',
         PERIODIC_RUN_STAGE: false,
+        PIPELINE: 'docker-build-oci-ta',
+        SOURCE_REPO_OWNER: 'hac-test',
+        SOURCE_REPO_NAME: 'devfile-sample-code-with-quarkus',
         resolution: 'high',
         REMOVE_APP_ON_FAIL: false,
         SNYK_TOKEN: '',
@@ -135,10 +139,12 @@ export default defineConfig({
       }
 
       config.env.HAC_WORKSPACE = config.env.USERNAME.toLowerCase();
-      if (config.env.LOCAL_CLUSTER === true) {
-        config.env.HAC_NAMESPACE = `user-ns2`;
-      } else {
-        config.env.HAC_NAMESPACE = `${config.env.HAC_WORKSPACE}-tenant`;
+      if (!config.env.HAC_NAMESPACE) {
+        if (config.env.LOCAL_CLUSTER === true) {
+          config.env.HAC_NAMESPACE = `user-ns2`;
+        } else {
+          config.env.HAC_NAMESPACE = `${config.env.HAC_WORKSPACE}-tenant`;
+        }
       }
 
       require('cypress-high-resolution')(on, config);

--- a/e2e-tests/support/commands/hooks.ts
+++ b/e2e-tests/support/commands/hooks.ts
@@ -18,7 +18,9 @@ before(() => {
     JSON.stringify({ 'application-list-getting-started-modal': true }),
   );
 
-  if (Cypress.env('LOCAL_CLUSTER')) {
+  if (Cypress.env('LOGIN_PROVIDER') === 'openshift') {
+    Login.openshiftLogin();
+  } else if (Cypress.env('LOCAL_CLUSTER')) {
     Login.localKonfluxLogin();
   } else if (Cypress.env('PERIODIC_RUN_STAGE')) {
     Login.stageKonfluxLogin();

--- a/e2e-tests/support/pageObjects/login-po.ts
+++ b/e2e-tests/support/pageObjects/login-po.ts
@@ -13,3 +13,11 @@ export const localKonfluxLoginPO = {
   grantAccessClass: `.dex-btn-text`,
   grantAccessText: 'Grant Access',
 };
+
+export const openshiftLoginPO = {
+  username: '#inputUsername',
+  password: '#inputPassword',
+  loginButton: 'button[type="submit"]',
+  approveButton: 'input[name="approve"]',
+  sidebar: '[id="page-sidebar"]',
+};

--- a/e2e-tests/tests/basic-happy-path.spec.ts
+++ b/e2e-tests/tests/basic-happy-path.spec.ts
@@ -22,20 +22,30 @@ describe('Basic Happy Path', () => {
   const integrationTestsTab = new IntegrationTestsTabPage();
   const componentPage = new ComponentPage();
 
-  const sourceOwner = 'hac-test';
-  const sourceRepo = 'devfile-sample-code-with-quarkus';
+  const sourceOwner = Cypress.env('SOURCE_REPO_OWNER');
+  const sourceRepo = Cypress.env('SOURCE_REPO_NAME');
   const repoName = Common.generateAppName(sourceRepo);
   const repoOwner = Cypress.env('GH_REPO_OWNER');
   const publicRepo = `https://github.com/${repoOwner}/${repoName}`;
   const componentName: string = Common.generateAppName('java-quarkus');
-  const piplinerunlogsTasks = [
-    'init',
-    'clone-repository',
-    'build-container',
-    'apply-tags',
-    'push-dockerfile',
-  ];
-  const pipeline = 'docker-build-oci-ta';
+
+  const pipelineConfigs: Record<string, { tasks: string[]; logCheckTask: string }> = {
+    'docker-build-oci-ta': {
+      tasks: ['init', 'clone-repository', 'build-container', 'apply-tags', 'push-dockerfile'],
+      logCheckTask: 'push-dockerfile',
+    },
+    'docker-build-oci-ta-min': {
+      tasks: ['init', 'clone-repository', 'build-container', 'build-image-index'],
+      logCheckTask: 'build-container',
+    },
+  };
+
+  const pipeline: string = Cypress.env('PIPELINE');
+  const pipelineConfig = pipelineConfigs[pipeline];
+  if (!pipelineConfig) {
+    throw new Error(`Unknown pipeline "${pipeline}". Supported: ${Object.keys(pipelineConfigs).join(', ')}`);
+  }
+  const piplinerunlogsTasks = pipelineConfig.tasks;
 
   // Track if any test has failed - used to skip deletion on failure
   let hasTestFailed = false;
@@ -200,7 +210,7 @@ describe('Basic Happy Path', () => {
       applicationDetailPage.openBuildLog(componentName);
       applicationDetailPage.verifyBuildLogTaskslist(piplinerunlogsTasks); //TO DO : Fetch the piplinerunlogsTasks from cluster using api At runtime.
       applicationDetailPage.verifyFailedLogTasksNotExists();
-      applicationDetailPage.checkBuildLog('push-dockerfile', 'Using token for quay.io');
+      applicationDetailPage.checkBuildLog(pipelineConfig.logCheckTask, 'Using token for quay.io');
       applicationDetailPage.closeBuildLog();
     });
   });

--- a/e2e-tests/utils/Login.ts
+++ b/e2e-tests/utils/Login.ts
@@ -1,6 +1,10 @@
 import common = require('mocha/lib/interfaces/common');
 import { NavItem, pageTitles } from '../support/constants/PageTitle';
-import { localKonfluxLoginPO, stageLoginPO } from '../support/pageObjects/login-po';
+import {
+  localKonfluxLoginPO,
+  openshiftLoginPO,
+  stageLoginPO,
+} from '../support/pageObjects/login-po';
 import { GetStartedPage, GetAppStartedPage } from '../support/pages/GetStartedPage';
 import { Common } from './Common';
 import { goToApplicationsPagePo, namespacesPagePO } from '../support/pageObjects/pages-po';
@@ -32,6 +36,30 @@ export class Login {
     cy.get(localKonfluxLoginPO.password).type(password, { log: false });
     cy.get(localKonfluxLoginPO.loginButton).click();
     cy.contains(localKonfluxLoginPO.grantAccessClass, localKonfluxLoginPO.grantAccessText).click();
+    this.waitForApps();
+  }
+
+  static openshiftLogin(
+    username: string = Cypress.env('USERNAME'),
+    password: string = Cypress.env('PASSWORD'),
+  ) {
+    cy.visit(Cypress.env('KONFLUX_BASE_URL'));
+    // Wait for either the login form (not authenticated) or the app sidebar (already authenticated)
+    cy.get(`${openshiftLoginPO.username}, ${openshiftLoginPO.sidebar}`, { timeout: 30000 }).should('exist');
+    cy.get('body').then(($body) => {
+      if ($body.find(openshiftLoginPO.username).length > 0) {
+        cy.get(openshiftLoginPO.username).type(username);
+        cy.get(openshiftLoginPO.password).type(password, { log: false });
+        cy.get(openshiftLoginPO.loginButton).should('be.enabled').click();
+        // Click through OAuth consent page if it appears
+        cy.get(`${openshiftLoginPO.approveButton}, ${openshiftLoginPO.sidebar}`, { timeout: 60000 }).first().then(($el) => {
+          if ($el.is(openshiftLoginPO.approveButton)) {
+            cy.wrap($el).click();
+          }
+        });
+        cy.get(openshiftLoginPO.sidebar, { timeout: 60000 }).should('exist');
+      }
+    });
     this.waitForApps();
   }
 


### PR DESCRIPTION
Assisted-by: Claude

## Fixes 
https://redhat.atlassian.net/browse/RHTAP-6170


## Description
Makes konflux UI tests configurable:
 - adds OpenShift login support (LOGIN_PROVIDER=openshift)
 - adds configurable template source repo via `SOURCE_REPO_OWNER` and `SOURCE_REPO_NAME` env vars
 - adds configurable build pipeline via `PIPELINE` env var 
 - allows `HAC_NAMESPACE` to be set specifically


## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end tests with OpenShift authentication support and automated OpenShift login.
  * Made repository and pipeline settings configurable via test environment variables with sensible defaults.
  * Test setup now preserves an explicitly set namespace instead of always overriding it.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konflux-ci/konflux-ui/pull/887)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->