### PR TITLE
fix(KFLUXUI-1352): replace invalid aria-role with role on ComponentPACStateLabel

### DIFF
--- a/src/components/CustomizedPipeline/ComponentPACStateLabel.tsx
+++ b/src/components/CustomizedPipeline/ComponentPACStateLabel.tsx
@@ -61,11 +61,12 @@ const ComponentPACStateLabelInner: React.FC<
   );
 
   const style = customizePipeline ? { cursor: 'pointer' } : undefined;
+  const role = customizePipeline ? 'button' : undefined;
   switch (pacState) {
     case PACState.sample:
       return (
         <Tooltip content="This component currently uses our sample build pipeline. To enable automatic rebuild on commits to your main branch and pull requests, fork this sample and upgrade to a custom build pipeline.">
-          <Label onClick={customizePipeline} role="button" style={style}>
+          <Label onClick={customizePipeline} role={role} style={style}>
             Sample
           </Label>
         </Tooltip>
@@ -73,7 +74,7 @@ const ComponentPACStateLabelInner: React.FC<
     case PACState.disabled:
       return (
         <Tooltip content="This component currently uses our default build pipeline. To enable automatic rebuild on commits to your main branch and pull requests, upgrade to a custom build pipeline.">
-          <Label color="blue" onClick={customizePipeline} role="button" style={style}>
+          <Label color="blue" onClick={customizePipeline} role={role} style={style}>
             Default
           </Label>
         </Tooltip>
@@ -81,7 +82,7 @@ const ComponentPACStateLabelInner: React.FC<
     case PACState.pending:
       return (
         <Tooltip content="No build pipeline is set for this component. To set a build pipeline for this component, merge the pull request containing the build pipeline we sent to your repository.">
-          <Label color="gold" onClick={customizePipeline} role="button" style={style}>
+          <Label color="gold" onClick={customizePipeline} role={role} style={style}>
             Merge pull request
           </Label>
         </Tooltip>
@@ -90,7 +91,7 @@ const ComponentPACStateLabelInner: React.FC<
     case PACState.unconfigureRequested:
       return (
         <Tooltip content="We sent a pull request to your repository containing the default build pipeline for you to customize. Merge the pull request to set a build pipeline for this component.">
-          <Label color="gold" onClick={customizePipeline} role="button" style={style}>
+          <Label color="gold" onClick={customizePipeline} role={role} style={style}>
             {pacState === PACState.configureRequested ? 'Sending pull request' : 'Rolling back'}
           </Label>
         </Tooltip>
@@ -98,12 +99,7 @@ const ComponentPACStateLabelInner: React.FC<
     case PACState.ready:
       return (
         <Tooltip content="This component currently uses our custom build pipeline. Commits to your main branch and pull requests will automatically rebuild.">
-          <Label
-            color="green"
-            onClick={customizePipeline}
-            role="button"
-            style={{ cursor: 'pointer' }}
-          >
+          <Label color="green" onClick={customizePipeline} role={role} style={style}>
             Custom
           </Label>
         </Tooltip>
@@ -112,7 +108,7 @@ const ComponentPACStateLabelInner: React.FC<
     case PACState.error:
       return (
         <Tooltip content={pacError}>
-          <Label color="red" onClick={customizePipeline} role="button" style={style}>
+          <Label color="red" onClick={customizePipeline} role={role} style={style}>
             Pull request failed
           </Label>
         </Tooltip>

--- a/src/components/CustomizedPipeline/ComponentPACStateLabel.tsx
+++ b/src/components/CustomizedPipeline/ComponentPACStateLabel.tsx
@@ -65,7 +65,7 @@ const ComponentPACStateLabelInner: React.FC<
     case PACState.sample:
       return (
         <Tooltip content="This component currently uses our sample build pipeline. To enable automatic rebuild on commits to your main branch and pull requests, fork this sample and upgrade to a custom build pipeline.">
-          <Label onClick={customizePipeline} aria-role="button" style={style}>
+          <Label onClick={customizePipeline} role="button" style={style}>
             Sample
           </Label>
         </Tooltip>
@@ -73,7 +73,7 @@ const ComponentPACStateLabelInner: React.FC<
     case PACState.disabled:
       return (
         <Tooltip content="This component currently uses our default build pipeline. To enable automatic rebuild on commits to your main branch and pull requests, upgrade to a custom build pipeline.">
-          <Label color="blue" onClick={customizePipeline} aria-role="button" style={style}>
+          <Label color="blue" onClick={customizePipeline} role="button" style={style}>
             Default
           </Label>
         </Tooltip>
@@ -81,7 +81,7 @@ const ComponentPACStateLabelInner: React.FC<
     case PACState.pending:
       return (
         <Tooltip content="No build pipeline is set for this component. To set a build pipeline for this component, merge the pull request containing the build pipeline we sent to your repository.">
-          <Label color="gold" onClick={customizePipeline} aria-role="button" style={style}>
+          <Label color="gold" onClick={customizePipeline} role="button" style={style}>
             Merge pull request
           </Label>
         </Tooltip>
@@ -90,7 +90,7 @@ const ComponentPACStateLabelInner: React.FC<
     case PACState.unconfigureRequested:
       return (
         <Tooltip content="We sent a pull request to your repository containing the default build pipeline for you to customize. Merge the pull request to set a build pipeline for this component.">
-          <Label color="gold" onClick={customizePipeline} aria-role="button" style={style}>
+          <Label color="gold" onClick={customizePipeline} role="button" style={style}>
             {pacState === PACState.configureRequested ? 'Sending pull request' : 'Rolling back'}
           </Label>
         </Tooltip>
@@ -101,7 +101,7 @@ const ComponentPACStateLabelInner: React.FC<
           <Label
             color="green"
             onClick={customizePipeline}
-            aria-role="button"
+            role="button"
             style={{ cursor: 'pointer' }}
           >
             Custom
@@ -112,7 +112,7 @@ const ComponentPACStateLabelInner: React.FC<
     case PACState.error:
       return (
         <Tooltip content={pacError}>
-          <Label color="red" onClick={customizePipeline} aria-role="button" style={style}>
+          <Label color="red" onClick={customizePipeline} role="button" style={style}>
             Pull request failed
           </Label>
         </Tooltip>

--- a/src/components/CustomizedPipeline/__tests__/CustomizePipeline.spec.tsx
+++ b/src/components/CustomizedPipeline/__tests__/CustomizePipeline.spec.tsx
@@ -91,8 +91,8 @@ describe('CustomizePipeline', () => {
         modalProps={{ isOpen: true }}
       />,
     );
-    const button = result.getByRole('button', { name: /Sending pull request/ });
-    expect(button).toBeInTheDocument();
+    const buttons = result.getAllByRole('button', { name: /Sending pull request/ });
+    expect(buttons.length).toBeGreaterThanOrEqual(1);
   });
 
   it('should render rolling back', () => {
@@ -104,8 +104,8 @@ describe('CustomizePipeline', () => {
         modalProps={{ isOpen: true }}
       />,
     );
-    const button = result.getByRole('button', { name: /Rolling back/ });
-    expect(button).toBeInTheDocument();
+    const buttons = result.getAllByRole('button', { name: /Rolling back/ });
+    expect(buttons.length).toBeGreaterThanOrEqual(1);
   });
 
   it('should render pull request sent', () => {

--- a/src/components/CustomizedPipeline/__tests__/CustomizePipeline.spec.tsx
+++ b/src/components/CustomizedPipeline/__tests__/CustomizePipeline.spec.tsx
@@ -91,8 +91,8 @@ describe('CustomizePipeline', () => {
         modalProps={{ isOpen: true }}
       />,
     );
-    const buttons = result.getAllByRole('button', { name: /Sending pull request/ });
-    expect(buttons).toHaveLength(2);
+    result.getByRole('button', { name: /Sending pull request/ });
+    expect(result.getAllByText(/Sending pull request/)).toHaveLength(2);
   });
 
   it('should render rolling back', () => {
@@ -104,8 +104,8 @@ describe('CustomizePipeline', () => {
         modalProps={{ isOpen: true }}
       />,
     );
-    const buttons = result.getAllByRole('button', { name: /Rolling back/ });
-    expect(buttons).toHaveLength(2);
+    result.getByRole('button', { name: /Rolling back/ });
+    expect(result.getAllByText(/Rolling back/)).toHaveLength(2);
   });
 
   it('should render pull request sent', () => {

--- a/src/components/CustomizedPipeline/__tests__/CustomizePipeline.spec.tsx
+++ b/src/components/CustomizedPipeline/__tests__/CustomizePipeline.spec.tsx
@@ -92,7 +92,7 @@ describe('CustomizePipeline', () => {
       />,
     );
     const buttons = result.getAllByRole('button', { name: /Sending pull request/ });
-    expect(buttons.length).toBeGreaterThanOrEqual(1);
+    expect(buttons).toHaveLength(2);
   });
 
   it('should render rolling back', () => {
@@ -105,7 +105,7 @@ describe('CustomizePipeline', () => {
       />,
     );
     const buttons = result.getAllByRole('button', { name: /Rolling back/ });
-    expect(buttons.length).toBeGreaterThanOrEqual(1);
+    expect(buttons).toHaveLength(2);
   });
 
   it('should render pull request sent', () => {


### PR DESCRIPTION
## Fixes
Fixes: https://issues.redhat.com/browse/KFLUXUI-1352

## Description
The `ComponentPACStateLabel` component used `aria-role="button"` in 6 places, which is not a valid ARIA attribute. Browsers silently ignore it, so screen readers could not identify these elements as clickable.

This PR:
- Replaces all 6 instances of `aria-role="button"` with the correct `role="button"`
- Fixes the `pacState` falsy check (`PACState.sample` is enum value `0`, which is falsy) so passing `pacState={PACState.sample}` no longer falls through to the fetcher path
- Updates existing tests that broke due to the now-valid `role="button"` causing duplicate role matches

## Type of change
- [x] Bugfix

## How to test or reproduce?
- Run `yarn test --testPathPattern="CustomizePipeline.spec"` — all 13 tests pass
- Inspect rendered DOM for any `ComponentPACStateLabel` — labels now have `role="button"` instead of the invalid `aria-role="button"`
- Verify screen readers correctly announce labels as buttons

## Browser conformance:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for pipeline state labels by ensuring they are announced and operable as buttons for screen readers and keyboard users.

* **Tests**
  * Adjusted UI tests to account for duplicated status text/buttons, making test expectations match the visible interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konflux-ci/konflux-ui/pull/948?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->