### PR TITLE
chore(KFLUXUI-1353): whitelist fullsend-ai-coder bot in PR checks

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -23,7 +23,7 @@ jobs:
             exit 0
           fi
 
-          WHITELISTED_BOTS=("red-hat-konflux[bot]" "konflux-ci-coder[bot]")
+          WHITELISTED_BOTS=("red-hat-konflux[bot]" "konflux-ci-coder[bot]" "fullsend-ai-coder[bot]")
           REQUIRED_LABEL_NAME="ok-to-test"
 
           ORG="${{ github.repository_owner }}"


### PR DESCRIPTION
## Fixes
Fixes: https://redhat.atlassian.net/browse/KFLUXUI-1353

## Description
The `check-org-membership` job in the PR check workflow has a `WHITELISTED_BOTS` list that allows
bot accounts to bypass org membership and `ok-to-test` label requirements. Currently only
`red-hat-konflux[bot]` and `konflux-ci-coder[bot]` are whitelisted. This adds `fullsend-ai-coder[bot]`
to that list so PRs authored by this bot can also run CI checks.

## Type of change

- [x] Build related changes

## Screen shots / Gifs for design review
N/A - no UI changes.

## How to test or reproduce?
- Open a PR from the `fullsend-ai-coder[bot]` account and verify the `check-org-membership` job passes without the `ok-to-test` label.

## Browser conformance:
N/A - CI workflow change only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to whitelist an additional bot for PR validation, allowing automated checks to be skipped when triggered by this bot.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konflux-ci/konflux-ui/pull/951?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->