### PR TITLE
feat(KFLUXUI-1350): closing relesed jira tickets

### DIFF
--- a/.github/scripts/close-jira-issues.sh
+++ b/.github/scripts/close-jira-issues.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Print all Jira issue URLs from a changelog (or any markdown file).
+# Usage: ./print-jira-urls.sh [path/to/changelog.md]
+
+set -euo pipefail
+
+CHANGELOG="${1:-/tmp/changelog.md}"
+SKIPPED=() #issues that were already closed
+CLOSED=()
+#TODO - get USER and TOKEN
+TOKEN=""
+USER=""
+
+if [[ ! -f "$CHANGELOG" ]]; then
+  echo "File not found: $CHANGELOG" >&2
+  exit 1
+fi
+
+mapfile -t JIRA_ISSUES < <(
+  grep -oE 'https://issues\.redhat\.com/browse/[A-Z]+-[0-9]+' "$CHANGELOG" \
+    | sed 's|.*/||' \
+    | sort -u
+)
+
+if [[ ${#JIRA_ISSUES[@]} -eq 0 ]]; then
+  echo "No Jira issues found in $CHANGELOG" >&2
+  exit 0
+fi
+
+for issue_key in "${JIRA_ISSUES[@]}"; do
+  status="$(curl -s -u "${USER}:${TOKEN}" \
+    -H 'Accept: application/json' \
+    "https://redhat.atlassian.net/rest/api/2/issue/${issue_key}" \
+    | jq -r '.fields.status.name // empty')"
+
+  if [[ "$status" == *"Closed"* ]]; then
+    SKIPPED+=("$issue_key")
+    continue
+  fi
+
+  #close the issue
+  curl --request POST \
+  --url "https://redhat.atlassian.net/rest/api/2/issue/${issue_key}/transitions" \
+  --user "${USER}":"${TOKEN}" \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --data '{
+  "resolution": {
+    "name": "Closed"
+  },
+  "transition": {
+    "id": "51"
+  }
+}'
+  CLOSED+=("$issue_key")
+done
+
+echo "Skipped issues: ${SKIPPED[@]}"
+echo "Closed issues: ${CLOSED[@]}"

--- a/.github/scripts/close-jira-issues.sh
+++ b/.github/scripts/close-jira-issues.sh
@@ -28,18 +28,44 @@ if [[ -z "$USER" || -z "$TOKEN" ]]; then
   exit 1
 fi
 
-get_close_transition_id() {
+build_close_transition_payload() {
   local issue_key="$1"
-  local transitions_response
+  local transitions_response payload
   if ! transitions_response="$(
     curl -sS --fail-with-body -u "${USER}:${TOKEN}" \
       -H 'Accept: application/json' \
-      "${JIRA_API_URL}/issue/${issue_key}/transitions"
+      "${JIRA_API_URL}/issue/${issue_key}/transitions?expand=transitions.fields"
   )"; then
     echo "Failed to fetch transitions for ${issue_key}: ${transitions_response:-curl request failed}" >&2
     return 1
   fi
-  jq -r '[.transitions[] | select(.to.name == "Closed") | .id][0] // empty' <<<"$transitions_response"
+
+  payload="$(jq -c '
+    [.transitions[] | select(.to.name == "Closed")] | first | if . == null then empty else
+      { transition: { id: .id } }
+      + if .fields.resolution then {
+          fields: {
+            resolution: {
+              name: (
+                [.fields.resolution.allowedValues[]?.name] as $names
+                | if ($names | index("Closed")) then "Closed"
+                  elif ($names | index("Done")) then "Done"
+                  elif ($names | length) > 0 then $names[0]
+                  else "Closed"
+                  end
+              )
+            }
+          }
+        } else {} end
+    end
+  ' <<<"$transitions_response")"
+
+  if [[ -z "$payload" ]]; then
+    echo "No Close transition available for ${issue_key}" >&2
+    return 1
+  fi
+
+  echo "$payload"
 }
 
 if [[ ! -f "$CHANGELOG" ]]; then
@@ -77,23 +103,11 @@ for issue_key in "${JIRA_ISSUES[@]}"; do
     continue
   fi
 
-  transition_id=""
-  if ! transition_id="$(get_close_transition_id "$issue_key")"; then
+  transition_payload=""
+  if ! transition_payload="$(build_close_transition_payload "$issue_key")"; then
     FAILED+=("$issue_key")
     continue
   fi
-  if [[ -z "$transition_id" ]]; then
-    echo "No Close transition available for ${issue_key} (status: ${status:-unknown})" >&2
-    FAILED+=("$issue_key")
-    continue
-  fi
-
-  transition_payload="$(jq -n \
-    --arg transition_id "$transition_id" \
-    '{
-      "resolution": { "name": "Closed" },
-      "transition": { "id": $transition_id }
-    }')"
 
   if ! transition_response="$(
     curl -sS -w $'\n%{http_code}' -u "${USER}:${TOKEN}" \

--- a/.github/scripts/close-jira-issues.sh
+++ b/.github/scripts/close-jira-issues.sh
@@ -1,15 +1,36 @@
 #!/usr/bin/env bash
-# Print all Jira issue URLs from a changelog (or any markdown file).
-# Usage: ./print-jira-urls.sh [path/to/changelog.md]
+# Close Jira issues referenced in a changelog (or any markdown file).
+# Requires JIRA_USER and JIRA_TOKEN environment variables.
+# Usage: ./close-jira-issues.sh [path/to/changelog.md]
 
 set -euo pipefail
 
 CHANGELOG="${1:-/tmp/changelog.md}"
 SKIPPED=() #issues that were already closed
 CLOSED=()
-#TODO - get USER and TOKEN
-TOKEN=""
-USER=""
+FAILED=()
+USER="${JIRA_USER:-}"
+TOKEN="${JIRA_TOKEN:-}"
+JIRA_API_BASE="https://redhat.atlassian.net/rest/api/2"
+
+if [[ -z "$USER" || -z "$TOKEN" ]]; then
+  echo "JIRA_USER and JIRA_TOKEN must be set" >&2
+  exit 1
+fi
+
+get_close_transition_id() {
+  local issue_key="$1"
+  local transitions_response
+  if ! transitions_response="$(
+    curl -sS --fail-with-body -u "${USER}:${TOKEN}" \
+      -H 'Accept: application/json' \
+      "${JIRA_API_BASE}/issue/${issue_key}/transitions"
+  )"; then
+    echo "Failed to fetch transitions for ${issue_key}: ${transitions_response:-curl request failed}" >&2
+    return 1
+  fi
+  jq -r '[.transitions[] | select(.to.name == "Closed") | .id][0] // empty' <<<"$transitions_response"
+}
 
 if [[ ! -f "$CHANGELOG" ]]; then
   echo "File not found: $CHANGELOG" >&2
@@ -28,32 +49,70 @@ if [[ ${#JIRA_ISSUES[@]} -eq 0 ]]; then
 fi
 
 for issue_key in "${JIRA_ISSUES[@]}"; do
-  status="$(curl -s -u "${USER}:${TOKEN}" \
-    -H 'Accept: application/json' \
-    "https://redhat.atlassian.net/rest/api/2/issue/${issue_key}" \
-    | jq -r '.fields.status.name // empty')"
+  issue_response=""
+  if ! issue_response="$(
+    curl -sS --fail-with-body -u "${USER}:${TOKEN}" \
+      -H 'Accept: application/json' \
+      "${JIRA_API_BASE}/issue/${issue_key}"
+  )"; then
+    echo "Failed to fetch status for ${issue_key}: ${issue_response:-curl request failed}" >&2
+    FAILED+=("$issue_key")
+    continue
+  fi
+
+  status="$(jq -r '.fields.status.name // empty' <<<"$issue_response")"
 
   if [[ "$status" == *"Closed"* ]]; then
     SKIPPED+=("$issue_key")
     continue
   fi
 
-  #close the issue
-  curl --request POST \
-  --url "https://redhat.atlassian.net/rest/api/2/issue/${issue_key}/transitions" \
-  --user "${USER}":"${TOKEN}" \
-  --header 'Accept: application/json' \
-  --header 'Content-Type: application/json' \
-  --data '{
-  "resolution": {
-    "name": "Closed"
-  },
-  "transition": {
-    "id": "51"
-  }
-}'
-  CLOSED+=("$issue_key")
+  transition_id=""
+  if ! transition_id="$(get_close_transition_id "$issue_key")"; then
+    FAILED+=("$issue_key")
+    continue
+  fi
+  if [[ -z "$transition_id" ]]; then
+    echo "No Close transition available for ${issue_key} (status: ${status:-unknown})" >&2
+    FAILED+=("$issue_key")
+    continue
+  fi
+
+  transition_payload="$(jq -n \
+    --arg transition_id "$transition_id" \
+    '{
+      "resolution": { "name": "Closed" },
+      "transition": { "id": $transition_id }
+    }')"
+
+  if ! transition_response="$(
+    curl -sS -w $'\n%{http_code}' -u "${USER}:${TOKEN}" \
+      -H 'Accept: application/json' \
+      -H 'Content-Type: application/json' \
+      -X POST \
+      "${JIRA_API_BASE}/issue/${issue_key}/transitions" \
+      -d "$transition_payload"
+  )"; then
+    echo "Failed to close ${issue_key}: curl request failed" >&2
+    FAILED+=("$issue_key")
+    continue
+  fi
+
+  http_code="${transition_response##*$'\n'}"
+  response_body="${transition_response%$'\n'*}"
+
+  if [[ "$http_code" =~ ^2[0-9]{2}$ ]]; then
+    CLOSED+=("$issue_key")
+  else
+    echo "Failed to close ${issue_key} (HTTP ${http_code}): ${response_body:-empty response}" >&2
+    FAILED+=("$issue_key")
+  fi
 done
 
-echo "Skipped issues: ${SKIPPED[@]}"
-echo "Closed issues: ${CLOSED[@]}"
+echo "Skipped issues: ${SKIPPED[*]:-none}"
+echo "Closed issues: ${CLOSED[*]:-none}"
+echo "Failed issues: ${FAILED[*]:-none}"
+
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+  exit 1
+fi

--- a/.github/scripts/close-jira-issues.sh
+++ b/.github/scripts/close-jira-issues.sh
@@ -3,15 +3,16 @@
 #
 # Requires JIRA_USER and JIRA_TOKEN environment variables.
 # Optional:
-#   JIRA_BASE_URL - browse URL for issue links (default: https://issues.redhat.com)
-#   JIRA_API_URL  - REST API base URL (default: https://redhat.atlassian.net/rest/api/2)
+#   CHANGELOG_PATH - changelog file path (default: /tmp/changelog.md)
+#   JIRA_BASE_URL  - browse URL for issue links (default: https://issues.redhat.com)
+#   JIRA_API_URL   - REST API base URL (default: https://redhat.atlassian.net/rest/api/2)
 # issues.redhat.com is the browse alias for the redhat.atlassian.net Jira instance.
 #
 # Usage: ./close-jira-issues.sh [path/to/changelog.md]
 
 set -euo pipefail
 
-CHANGELOG="${1:-/tmp/changelog.md}"
+CHANGELOG="${1:-${CHANGELOG_PATH:-/tmp/changelog.md}}"
 SKIPPED=() #issues that were already closed
 CLOSED=()
 FAILED=()

--- a/.github/scripts/close-jira-issues.sh
+++ b/.github/scripts/close-jira-issues.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 # Close Jira issues referenced in a changelog (or any markdown file).
+#
 # Requires JIRA_USER and JIRA_TOKEN environment variables.
+# Optional:
+#   JIRA_BASE_URL - browse URL for issue links (default: https://issues.redhat.com)
+#   JIRA_API_URL  - REST API base URL (default: https://redhat.atlassian.net/rest/api/2)
+# issues.redhat.com is the browse alias for the redhat.atlassian.net Jira instance.
+#
 # Usage: ./close-jira-issues.sh [path/to/changelog.md]
 
 set -euo pipefail
@@ -11,7 +17,11 @@ CLOSED=()
 FAILED=()
 USER="${JIRA_USER:-}"
 TOKEN="${JIRA_TOKEN:-}"
-JIRA_API_BASE="https://redhat.atlassian.net/rest/api/2"
+JIRA_BASE_URL="${JIRA_BASE_URL:-https://issues.redhat.com}"
+JIRA_BASE_URL="${JIRA_BASE_URL%/}"
+JIRA_BASE_URL_PATTERN="${JIRA_BASE_URL//./\\.}"
+JIRA_API_URL="${JIRA_API_URL:-https://redhat.atlassian.net/rest/api/2}"
+JIRA_API_URL="${JIRA_API_URL%/}"
 
 if [[ -z "$USER" || -z "$TOKEN" ]]; then
   echo "JIRA_USER and JIRA_TOKEN must be set" >&2
@@ -24,7 +34,7 @@ get_close_transition_id() {
   if ! transitions_response="$(
     curl -sS --fail-with-body -u "${USER}:${TOKEN}" \
       -H 'Accept: application/json' \
-      "${JIRA_API_BASE}/issue/${issue_key}/transitions"
+      "${JIRA_API_URL}/issue/${issue_key}/transitions"
   )"; then
     echo "Failed to fetch transitions for ${issue_key}: ${transitions_response:-curl request failed}" >&2
     return 1
@@ -38,7 +48,7 @@ if [[ ! -f "$CHANGELOG" ]]; then
 fi
 
 mapfile -t JIRA_ISSUES < <(
-  grep -oE 'https://issues\.redhat\.com/browse/[A-Z]+-[0-9]+' "$CHANGELOG" \
+  grep -oE "${JIRA_BASE_URL_PATTERN}/browse/[A-Z]+-[0-9]+" "$CHANGELOG" \
     | sed 's|.*/||' \
     | sort -u
 )
@@ -53,7 +63,7 @@ for issue_key in "${JIRA_ISSUES[@]}"; do
   if ! issue_response="$(
     curl -sS --fail-with-body -u "${USER}:${TOKEN}" \
       -H 'Accept: application/json' \
-      "${JIRA_API_BASE}/issue/${issue_key}"
+      "${JIRA_API_URL}/issue/${issue_key}"
   )"; then
     echo "Failed to fetch status for ${issue_key}: ${issue_response:-curl request failed}" >&2
     FAILED+=("$issue_key")
@@ -90,7 +100,7 @@ for issue_key in "${JIRA_ISSUES[@]}"; do
       -H 'Accept: application/json' \
       -H 'Content-Type: application/json' \
       -X POST \
-      "${JIRA_API_BASE}/issue/${issue_key}/transitions" \
+      "${JIRA_API_URL}/issue/${issue_key}/transitions" \
       -d "$transition_payload"
   )"; then
     echo "Failed to close ${issue_key}: curl request failed" >&2

--- a/.github/scripts/generate-release-changelog.sh
+++ b/.github/scripts/generate-release-changelog.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 #   -b  Base SHA (older commit)
 #   -t  Target SHA (newer commit)
 #   -d  Optional: existing git repository directory
-#   -o  Output file path for changelog
+#   -o  Output file path for changelog (defaults to CHANGELOG_PATH env var)
 
 # --- Helper Functions ---
 log_info() { echo "[INFO] $(date '+%Y-%m-%d %H:%M:%S') $*"; }
@@ -24,14 +24,14 @@ log_warn() { echo "[WARN] $(date '+%Y-%m-%d %H:%M:%S') $*" >&2; }
 
 usage() {
   cat >&2 << 'USAGE'
-Usage: generate-release-changelog.sh -r <owner/repo> -b <base_sha> -t <target_sha> [-d <repo_dir>] -o <out_file>
+Usage: generate-release-changelog.sh -r <owner/repo> -b <base_sha> -t <target_sha> [-d <repo_dir>] [-o <out_file>]
 
 Arguments:
   -r  Repository in owner/repo format (e.g., konflux-ci/konflux-ui)
   -b  Base SHA (older commit, production)
   -t  Target SHA (newer commit, staging)
   -d  Optional: existing git repository directory (skips clone)
-  -o  Output file path for changelog
+  -o  Output file path for changelog (defaults to CHANGELOG_PATH env var)
 USAGE
 }
 
@@ -70,6 +70,10 @@ while getopts ":r:b:t:d:o:h" opt; do
     *) log_error "Unknown option: -$OPTARG"; usage; exit 2 ;;
   esac
 done
+
+if [[ -z "$OUT_FILE" ]]; then
+  OUT_FILE="${CHANGELOG_PATH:-}"
+fi
 
 # --- Validate Inputs ---
 if [[ -z "$REPO" || -z "$BASE_SHA" || -z "$TARGET_SHA" || -z "$OUT_FILE" ]]; then

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -157,6 +157,7 @@ jobs:
       OLD_SHA: ${{ needs.preflight.outputs.old_sha }}
       NEW_SHA: ${{ needs.preflight.outputs.new_sha }}
       RELEASE_DATE: ${{ needs.preflight.outputs.release_date }}
+      CHANGELOG_PATH: /tmp/changelog.md
 
     steps:
       - name: Checkout
@@ -171,7 +172,7 @@ jobs:
             -b "$OLD_SHA" \
             -t "$NEW_SHA" \
             -d "$(pwd)" \
-            -o /tmp/changelog.md
+            -o "$CHANGELOG_PATH"
 
       # --- Create tracking issue (before infra PR so we can include Fixes link) ---
       - name: Create tracking issue
@@ -254,7 +255,7 @@ jobs:
           <details>
           <summary>What's in this release</summary>
 
-          $(cat /tmp/changelog.md)
+          $(cat "$CHANGELOG_PATH")
 
           </details>
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -137,32 +137,6 @@ jobs:
 
           CHANGELOG=$(cat /tmp/changelog.md)
 
-          - name: Close Jira tickets
-            env:
-              TAG: ${{ steps.tag.outputs.tag }}
-              RELEASE_DATE: ${{ steps.meta.outputs.release_date }}
-              NEW_SHA: ${{ steps.meta.outputs.new_sha }}
-              OLD_SHA: ${{ steps.meta.outputs.old_sha }}
-            run: |
-              # Generate changelog using the release script
-              chmod +x .github/scripts/generate-release-changelog.sh
-              .github/scripts/generate-release-changelog.sh \
-                -r "$KONFLUX_UI_REPO" \
-                -b "$OLD_SHA" \
-                -t "$NEW_SHA" \
-                -d "$(pwd)" \
-                -o /tmp/changelog.md
-
-              CHANGELOG=$(cat /tmp/changelog.md)
-              chmod +x .github/scripts/close-jira-tickets.sh
-              .github/scripts/close-jira-tickets.sh \
-                -t "$TAG" \
-                -d "$CHANGELOG"
-
-              echo "Jira tickets closed"
-
-
-
           # Idempotency: skip if release already exists
           if gh release view "$TAG" --repo "$KONFLUX_UI_REPO" >/dev/null 2>&1; then
             echo "Release $TAG already exists — skipping creation."
@@ -172,6 +146,14 @@ jobs:
               --title "Production release ${RELEASE_DATE}" \
               --notes "$CHANGELOG"
           fi
+
+      - name: Close Jira issues
+        env:
+          JIRA_USER: ${{ secrets.JIRA_USER }}
+          JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+        run: |
+          chmod +x .github/scripts/close-jira-issues.sh
+          .github/scripts/close-jira-issues.sh /tmp/changelog.md
 
       # --- Update tracking issue with completion status ---
       - name: Update tracking issue

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -19,6 +19,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       KONFLUX_UI_REPO: konflux-ci/konflux-ui
       INFRA_REPO: redhat-appstudio/infra-deployments
+      CHANGELOG_PATH: /tmp/changelog.md
 
     steps:
       # --- Parse tracking issue metadata ---
@@ -133,9 +134,9 @@ jobs:
             -b "$OLD_SHA" \
             -t "$NEW_SHA" \
             -d "$(pwd)" \
-            -o /tmp/changelog.md
+            -o "$CHANGELOG_PATH"
 
-          CHANGELOG=$(cat /tmp/changelog.md)
+          CHANGELOG=$(cat "$CHANGELOG_PATH")
 
           # Idempotency: skip if release already exists
           if gh release view "$TAG" --repo "$KONFLUX_UI_REPO" >/dev/null 2>&1; then
@@ -153,7 +154,7 @@ jobs:
           JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
         run: |
           chmod +x .github/scripts/close-jira-issues.sh
-          .github/scripts/close-jira-issues.sh /tmp/changelog.md
+          .github/scripts/close-jira-issues.sh
 
       # --- Update tracking issue with completion status ---
       - name: Update tracking issue

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -137,6 +137,32 @@ jobs:
 
           CHANGELOG=$(cat /tmp/changelog.md)
 
+          - name: Close Jira tickets
+            env:
+              TAG: ${{ steps.tag.outputs.tag }}
+              RELEASE_DATE: ${{ steps.meta.outputs.release_date }}
+              NEW_SHA: ${{ steps.meta.outputs.new_sha }}
+              OLD_SHA: ${{ steps.meta.outputs.old_sha }}
+            run: |
+              # Generate changelog using the release script
+              chmod +x .github/scripts/generate-release-changelog.sh
+              .github/scripts/generate-release-changelog.sh \
+                -r "$KONFLUX_UI_REPO" \
+                -b "$OLD_SHA" \
+                -t "$NEW_SHA" \
+                -d "$(pwd)" \
+                -o /tmp/changelog.md
+
+              CHANGELOG=$(cat /tmp/changelog.md)
+              chmod +x .github/scripts/close-jira-tickets.sh
+              .github/scripts/close-jira-tickets.sh \
+                -t "$TAG" \
+                -d "$CHANGELOG"
+
+              echo "Jira tickets closed"
+
+
+
           # Idempotency: skip if release already exists
           if gh release view "$TAG" --repo "$KONFLUX_UI_REPO" >/dev/null 2>&1; then
             echo "Release $TAG already exists — skipping creation."


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release process now attempts to automatically close Jira issues referenced in the generated changelog.
  * The workflow reports skipped (already-closed), successfully closed, and failed issues for manual review.
  * The changelog output path is centralized and can be configured via an environment variable used by release steps.
  * CI must have Jira API credentials configured for the automated closure step to run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->