### PR TITLE
[WIP] chore: debug e2e test to find a root cause of the EC failure

### DIFF
--- a/e2e-tests/tests/basic-happy-path.spec.ts
+++ b/e2e-tests/tests/basic-happy-path.spec.ts
@@ -43,7 +43,9 @@ describe('Basic Happy Path', () => {
   const pipeline: string = Cypress.env('PIPELINE');
   const pipelineConfig = pipelineConfigs[pipeline];
   if (!pipelineConfig) {
-    throw new Error(`Unknown pipeline "${pipeline}". Supported: ${Object.keys(pipelineConfigs).join(', ')}`);
+    throw new Error(
+      `Unknown pipeline "${pipeline}". Supported: ${Object.keys(pipelineConfigs).join(', ')}`,
+    );
   }
   const piplinerunlogsTasks = pipelineConfig.tasks;
 
@@ -173,6 +175,12 @@ describe('Basic Happy Path', () => {
     it('Verify Enterprise contract Test pipeline run Details', () => {
       UIhelper.clickRowCellInTable('Pipeline run List', 'Test', `${applicationName}-`);
       DetailsTab.waitForPLRAndDownloadAllLogs(false);
+    });
+
+    it('Debug enterprise contract test pipeline run', () => {
+      DetailsTab.clickOnNode('verify');
+      DetailsTab.clickOnDrawerPanelLogsTab();
+      DetailsTab.verifyLogs('Error');
     });
 
     it('Verify vulnerabilities column exists in Pipeline runs table', () => {


### PR DESCRIPTION
## Description
Debug a reason for E2E failures during a CI run against the local backend deployment.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced error validation for unsupported pipeline configurations.
  * Added test case for enterprise contract pipeline runs to verify error state logging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konflux-ci/konflux-ui/pull/957?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->