### PR TITLE
chore(KFLUXUI-1358): fix e2e tests against stage

### DIFF
--- a/e2e-tests/tests/basic-happy-path.spec.ts
+++ b/e2e-tests/tests/basic-happy-path.spec.ts
@@ -43,7 +43,9 @@ describe('Basic Happy Path', () => {
   const pipeline: string = Cypress.env('PIPELINE');
   const pipelineConfig = pipelineConfigs[pipeline];
   if (!pipelineConfig) {
-    throw new Error(`Unknown pipeline "${pipeline}". Supported: ${Object.keys(pipelineConfigs).join(', ')}`);
+    throw new Error(
+      `Unknown pipeline "${pipeline}". Supported: ${Object.keys(pipelineConfigs).join(', ')}`,
+    );
   }
   const piplinerunlogsTasks = pipelineConfig.tasks;
 
@@ -143,7 +145,11 @@ describe('Basic Happy Path', () => {
           UIhelper.checkTableHasRows('Pipeline run List', componentName, 2);
           UIhelper.clickRowCellInTable('Pipeline run List', pipelinerunName, pipelinerunName);
           UIhelper.verifyLabelAndValue('Namespace', Cypress.env('HAC_NAMESPACE'));
-          UIhelper.verifyLabelAndValue('Pipeline', pipelinerunName);
+          // Use the pipelinerunName excluding the last hyphenated part "-<generated_number>"
+          const lastDashIndex = pipelinerunName.lastIndexOf('-');
+          const shortPipelinerunName =
+            lastDashIndex !== -1 ? pipelinerunName.substring(0, lastDashIndex) : pipelinerunName;
+          UIhelper.verifyLabelAndValue('Pipeline', shortPipelinerunName);
           UIhelper.verifyLabelAndValue('Application', applicationName);
           UIhelper.verifyLabelAndValue('Component', componentName);
           UIhelper.verifyLabelAndValue('Related pipelines', '0 pipelines');

--- a/e2e-tests/utils/UIhelper.ts
+++ b/e2e-tests/utils/UIhelper.ts
@@ -49,7 +49,7 @@ export class UIhelper {
     return cy
       .contains(UIhelperPO.listGroup_dt, new RegExp(`^\\s*${label}\\s*$`))
       .siblings('dd')
-      .contains(new RegExp(`^\\s*${value}\\s*$`))
+      .contains(value)
       .scrollIntoView()
       .should('be.visible');
   }


### PR DESCRIPTION
## Fixes 
-

## Description
Fix a test to run properly on staging.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved error handling and validation messaging for pipeline configuration.
  * Enhanced UI label verification logic for more robust test assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konflux-ci/konflux-ui/pull/959?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->