### PR TITLE
fix(KFLUXUI-1356): Migrate data-testid attributes to data-test

### DIFF
--- a/e2e-tests/support/pageObjects/featureFlags-po.ts
+++ b/e2e-tests/support/pageObjects/featureFlags-po.ts
@@ -5,7 +5,7 @@ export const featureFlagsPO = {
 };
 
 export const featuresPO = {
-  experimentalFeaturesIcon: '[data-testid="experimental-features-icon"]',
-  resetFeatureOverridesButton: '[data-testid="reset-feature-overrides-button"]',
+  experimentalFeaturesIcon: '[data-test="experimental-features-icon"]',
+  resetFeatureOverridesButton: '[data-test="reset-feature-overrides-button"]',
   modalCloseButton: 'button[aria-label="Close"].pf-m-plain',
 };

--- a/src/components/Commits/CommitsListPage/CommitsListRow.tsx
+++ b/src/components/Commits/CommitsListPage/CommitsListRow.tsx
@@ -102,7 +102,7 @@ const CommitsListRow: React.FC<React.PropsWithChildren<CommitsListRowProps>> = (
             header: 'More commit components',
             ariaLabel: 'More commit components',
             moreText: (count: number) => `${count} more`,
-            dataTestIdPrefix: 'more-components-popover',
+            dataTestPrefix: 'more-components-popover',
           }}
         />
       </TableData>

--- a/src/components/Filter/toolbars/__tests__/BaseTextFilterToolbar.spec.tsx
+++ b/src/components/Filter/toolbars/__tests__/BaseTextFilterToolbar.spec.tsx
@@ -110,7 +110,7 @@ describe('BaseTextFilterToolbar', () => {
         setText={mockSetText}
         onClearFilters={mockOnClearFilters}
       >
-        <div data-testid="custom-child">Custom child component</div>
+        <div data-test="custom-child">Custom child component</div>
       </BaseTextFilterToolbar>,
     );
 

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -33,7 +33,7 @@ export const Header: React.FC<HeaderProps> = ({ isDrawerExpanded, toggleDrawer }
                 variant="plain"
                 onClick={() => showModal(createFeatureFlagPanelModal())}
                 aria-label="Experimental Features"
-                data-testid="experimental-features-icon"
+                data-test="experimental-features-icon"
               >
                 <FlaskIcon />
               </Button>

--- a/src/components/ImportForm/ComponentSection/SourceSection.tsx
+++ b/src/components/ImportForm/ComponentSection/SourceSection.tsx
@@ -76,7 +76,7 @@ export const SourceSection = () => {
         helperText="Supports GitHub, GitLab, and Forgejo repositories"
         validated={validated}
         isRequired
-        data-testid="enter-source"
+        data-test="enter-source"
         onChange={handleChange}
       />
       <SwitchField name="isPrivateRepo" label="Should the image produced be private?" />

--- a/src/components/NamespaceList/NamespaceListView.tsx
+++ b/src/components/NamespaceList/NamespaceListView.tsx
@@ -38,7 +38,7 @@ const NamespaceCreateButton = React.memo(() => {
 
   return (
     <Tooltip content={<>Contact your platform engineer to create a new namespace.</>}>
-      <Flex className="pf-v5-u-mt-sm" data-testid="namespace-create-tooltip">
+      <Flex className="pf-v5-u-mt-sm" data-test="namespace-create-tooltip">
         <QuestionCircleIcon />
       </Flex>
     </Tooltip>

--- a/src/components/ReleaseService/ReleasePlanAdmission/ReleasePlanAdmissionListRow.tsx
+++ b/src/components/ReleaseService/ReleasePlanAdmission/ReleasePlanAdmissionListRow.tsx
@@ -48,7 +48,7 @@ const ReleasePlanAdmissionListRow: React.FC<ReleasePlanAdmissionRowProps> = ({
             header: 'More applications',
             ariaLabel: 'More applications',
             moreText: (count: number) => `${count} more`,
-            dataTestIdPrefix: 'more-applications-popover',
+            dataTestPrefix: 'more-applications-popover',
           }}
         />
       </TableData>

--- a/src/components/Snapshots/SnapshotsListView/SnapshotsListRow.tsx
+++ b/src/components/Snapshots/SnapshotsListView/SnapshotsListRow.tsx
@@ -74,7 +74,7 @@ const SnapshotsListRow: React.FC<React.PropsWithChildren<SnapshotsListRowProps>>
             header: 'More snapshot components',
             ariaLabel: 'More snapshot components',
             moreText: (count: number) => `${count} more`,
-            dataTestIdPrefix: 'more-snapshot-components-popover',
+            dataTestPrefix: 'more-snapshot-components-popover',
           }}
         />
       </TableData>

--- a/src/feature-flags/Panel.tsx
+++ b/src/feature-flags/Panel.tsx
@@ -69,7 +69,7 @@ export const createFeatureFlagPanelModal = createModalLauncher(FeatureFlagPanel,
       onClick={() => {
         FeatureFlagsStore.resetAll();
       }}
-      data-testid="reset-feature-overrides-button"
+      data-test="reset-feature-overrides-button"
     >
       Reset to Defaults
     </Button>,

--- a/src/routes/page-routes/__tests__/components-page.spec.tsx
+++ b/src/routes/page-routes/__tests__/components-page.spec.tsx
@@ -29,12 +29,12 @@ type PathRoute = BaseRoute & {
 type ChildRoute = IndexRoute | PathRoute;
 
 jest.mock('../../RouteErrorBoundary', () => ({
-  RouteErrorBoundry: () => <div data-testid="error-boundary">Error Boundary</div>,
+  RouteErrorBoundry: () => <div data-test="error-boundary">Error Boundary</div>,
 }));
 
 jest.mock('~/components/ComponentsPage/ComponentDetails', () => ({
-  ComponentDetailsTab: () => <div data-testid="component-details-tab">Details tab</div>,
-  ComponentDetailsViewLayout: () => <div data-testid="component-details-layout">Layout</div>,
+  ComponentDetailsTab: () => <div data-test="component-details-tab">Details tab</div>,
+  ComponentDetailsViewLayout: () => <div data-test="component-details-layout">Layout</div>,
   componentDetailsViewLoader: jest.fn(() => ({ data: 'test-data' })),
 }));
 

--- a/src/routes/page-routes/__tests__/issues.spec.tsx
+++ b/src/routes/page-routes/__tests__/issues.spec.tsx
@@ -23,7 +23,7 @@ type ChildRoute = IndexRoute | PathRoute;
 
 // Mock the RouteErrorBoundary
 jest.mock('../../RouteErrorBoundary', () => ({
-  RouteErrorBoundry: () => <div data-testid="error-boundary">Error Boundary</div>,
+  RouteErrorBoundry: () => <div data-test="error-boundary">Error Boundary</div>,
 }));
 
 // Mock the issuesPageLoader

--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
@@ -288,7 +288,7 @@ const LogViewer: React.FC<Props> = ({
           </div>
 
           {/* Header */}
-          <Banner data-testid="logs-taskName">
+          <Banner data-test="logs-taskName">
             <Flex gap={{ default: 'gapSm' }}>
               {taskName && (
                 <FlexItem flex={{ default: 'flex_1' }} className="log-viewer__task-name">
@@ -324,7 +324,7 @@ const LogViewer: React.FC<Props> = ({
           {showResumeStreamButton && (
             <div className="log-viewer__resume-stream-button-wrapper">
               <Button
-                data-testid="resume-log-stream"
+                data-test="resume-log-stream"
                 variant="primary"
                 isBlock
                 onClick={handleResumeClick}

--- a/src/shared/components/pipeline-run-logs/logs/__tests__/LogViewer.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/__tests__/LogViewer.spec.tsx
@@ -144,7 +144,7 @@ describe('LogViewer Integration Tests', () => {
     it('should render task name in banner', () => {
       const { container } = render(<LogViewer {...defaultProps} />);
 
-      const banner = container.querySelector('[data-testid="logs-taskName"]');
+      const banner = container.querySelector('[data-test="logs-taskName"]');
       expect(banner).toBeInTheDocument();
       expect(banner).toHaveTextContent('test-task');
     });
@@ -507,8 +507,8 @@ describe('LogViewer Integration Tests', () => {
       }).not.toThrow();
     });
 
-    it('should render resume button with data-testid when visible', () => {
-      // The resume button has data-testid="resume-log-stream" for testing
+    it('should render resume button with data-test when visible', () => {
+      // The resume button has data-test="resume-log-stream" for testing
       // It appears conditionally based on useAutoScrollWithResume hook state
       const { container } = render(<LogViewer {...defaultProps} allowAutoScroll={true} />);
 

--- a/src/shared/components/truncated-link-list-with-popover/TruncatedLinkListWithPopover.tsx
+++ b/src/shared/components/truncated-link-list-with-popover/TruncatedLinkListWithPopover.tsx
@@ -10,7 +10,7 @@ type Props = {
     header: string;
     ariaLabel: string;
     moreText: (count: number) => string;
-    dataTestIdPrefix: string;
+    dataTestPrefix: string;
   };
 };
 
@@ -35,7 +35,7 @@ const TruncatedLinkListWithPopover: React.FC<Props> = ({
           {visibleItems.map((appName) => renderItem(appName))}
           {hiddenItems.length > 0 && (
             <Popover
-              data-testid={popover.dataTestIdPrefix}
+              data-test={popover.dataTestPrefix}
               aria-label={popover.ariaLabel}
               headerContent={popover.header}
               enableFlip

--- a/src/shared/components/truncated-link-list-with-popover/__tests__/TruncatedLinkListWithPopover.spec.tsx
+++ b/src/shared/components/truncated-link-list-with-popover/__tests__/TruncatedLinkListWithPopover.spec.tsx
@@ -7,7 +7,7 @@ describe('TruncatedLinkListWithPopover', () => {
     header: 'More items',
     ariaLabel: 'More items',
     moreText: (count: number) => `${count} more`,
-    dataTestIdPrefix: 'more-items-popover',
+    dataTestPrefix: 'more-items-popover',
   };
 
   it('renders "-" when items are empty', () => {


### PR DESCRIPTION

## Fixes
Fixes: https://issues.redhat.com/browse/KFLUXUI-1356

## Description
Migrate remaining `data-testid` attributes to `data-test` across the codebase for consistency with the project convention.

This is a cherry-pick of work originally authored by @povolnyvojtech.

Changes span 15 files including components, tests, and e2e page objects — all mechanical `data-testid` → `data-test` renames with no functional changes.

## Type of change

- [x] Code style update (formatting, renaming)

## Screen shots / Gifs for design review
N/A — no visual changes, attribute rename only.

## How to test or reproduce?
- [x] `yarn test` — all unit tests pass
- [x] `yarn lint` — no lint errors
- [x] `yarn type-checks` — no type errors
- [x] Grep for remaining `data-testid` usage: `grep -r 'data-testid' src/ e2e-tests/` should return no results

## Browser conformance:
N/A — no runtime behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized test attributes across the app from one test-attribute convention to a unified one.
  * Updated test configuration/property names used by popover-related components to match the new convention.
  * Aligned and updated unit and integration tests to reflect these selector and config naming changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/konflux-ci/konflux-ui/pull/961?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->