### PR TITLE
chore(KFLUXUI-1361): add renovate config to limit concurrent PRs to 5

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "prConcurrentLimit": 5
+}


### PR DESCRIPTION
## Fixes
<!-- No Jira ticket associated -->
https://redhat.atlassian.net/browse/KFLUXUI-1361

## Description

The MintMaker (Renovate) bot currently uses the default `prConcurrentLimit` of 20, which results in too many open dependency update PRs at once. This adds a `renovate.json` configuration file to limit concurrent open PRs to 5.

## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review
<!-- No UI changes -->

## How to test or reproduce?

- Verify `renovate.json` is valid by checking against the [Renovate JSON schema](https://docs.renovatebot.com/renovate-schema.json)
- After merge, MintMaker should limit open dependency PRs to 5 at a time on subsequent runs

## Browser conformance:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured dependency update automation with a maximum concurrent pull request limit of 5, optimizing the development workflow for managing dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->