### PR TITLE
chore(KFLUXUI-1367): migrate from Node.js 22 to Node.js 24

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -1,10 +1,10 @@
 FROM quay.io/fedora/fedora:44
 
-# Install Node.js 22 and development tools
+# Install Node.js 24 and development tools
 RUN dnf update -y && \
     dnf install -y \
-    nodejs \
-    npm \
+    nodejs24 \
+    yarnpkg \
     git \
     gh \
     curl \
@@ -29,9 +29,6 @@ RUN groupadd --gid 1000 vscode \
 RUN echo vscode ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/vscode \
     && chmod 0440 /etc/sudoers.d/vscode
 
-# Enable Yarn Berry via corepack
-RUN corepack enable
-
 # Create directories for git configuration
 RUN mkdir -p /home/vscode/.ssh \
     && chown -R vscode:vscode /home/vscode/.ssh \
@@ -45,13 +42,8 @@ COPY --chown=vscode:vscode container-files /container-files/
 RUN node --version && \
     npm --version && \
     gh --version && \
-    git --version
-
-# Set up the working directory
-WORKDIR /workspaces/konflux-ui
-
-# Change ownership to vscode user
-RUN chown -R vscode:vscode /workspaces
+    git --version && \
+    yarn --version
 
 # Switch to vscode user
 USER vscode

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -64,8 +64,8 @@ While this documentation highlights the installation process for VS Code and oth
 
 ## What's Included
 
-- **Node.js 22**: Latest LTS version as required by the project
-- **Yarn 1.22.22**: Package manager as specified in the project requirements
+- **Node.js 24**: Fedora 44 `nodejs24` package (`/usr/bin/node` → `node-24`)
+- **Yarn Berry (4.12.0)**: Committed release at `.yarn/releases/yarn-4.12.0.cjs` (see `yarnPath` in `.yarnrc.yml`); no Corepack or global Yarn install
 - **VS Code Extensions**: Pre-configured with useful extensions for React/TypeScript development
 - **Development Tools**: ESLint, Prettier, Stylelint, and more
 
@@ -243,6 +243,7 @@ After making changes to the pipeline selection feature:
 
 ### General Issues
 
+- **Build fails with `corepack: command not found`**: This devcontainer does not use Corepack; Yarn comes from `.yarn/releases/`. Rebuild after pulling `.devcontainer` changes.
 - **Dependencies not installing**: Try rebuilding the container (`F1` → "Dev Containers: Rebuild Container")
 - **Port conflicts**: Check that ports 3000 and 9000 aren't already in use on your host machine
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -53,11 +53,10 @@
     "NODE_ENV": "development"
   },
 
-  // Run arguments for the container - compatible with both Docker and Podman
-  "runArgs": ["--init", "--userns=keep-id"],
+  // Run arguments for the container
+  "runArgs": ["--init"],
 
-  // Mount the project directory
-  "workspaceFolder": "/workspaces/konflux-ui",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
 
   // Lifecycle scripts
   "initializeCommand": "echo 'Initializing Konflux UI devcontainer...' && echo 'Copying git configuration files...' && mkdir -p .devcontainer/.gitconfig-dir && cp ~/.gitconfig* .devcontainer/.gitconfig-dir/ 2>/dev/null || echo 'No gitconfig files found in home directory'",

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup ⚙️ Node.js 🔰
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: 'yarn'
 
       # e2e-tests install is needed because eslint resolves eslint-plugin-cypress from e2e-tests/.eslintrc.cjs
@@ -71,7 +71,7 @@ jobs:
       - name: Setup ⚙️ Node.js 🔰
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: 'yarn'
 
       - name: Install Dependencies 🥁

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -19,10 +19,6 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [20.x, 22.x] # can support multiple versions ex: [18.x, 20.x]
-
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout 🛎️
@@ -34,7 +30,7 @@ jobs:
       - name: Setup ⚙️ Node.js ${{ matrix.node-version }} 🔰
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 24.x
           cache: 'yarn'
 
       - name: Install Dependencies 🥁

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Enable Corepack 📦
         run: corepack enable
 
-      - name: Setup ⚙️ Node.js ${{ matrix.node-version }} 🔰
+      - name: Setup ⚙️ Node.js 🔰
         uses: actions/setup-node@v4
         with:
           node-version: 24.x

--- a/.github/workflows/pr-report.yaml
+++ b/.github/workflows/pr-report.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Install dependencies
         run: yarn add @octokit/rest dayjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,11 +12,11 @@
 | Type check | `yarn type-checks` |
 | Start dev server| `yarn start` |
 
-CI runs two parallel jobs on Node 22: **lint** (`yarn lint` -> `yarn lint:restricted-imports` -> `yarn type-checks`) and **test** (`yarn test`).
+CI runs two parallel jobs on Node 24: **lint** (`yarn lint` -> `yarn lint:restricted-imports` -> `yarn type-checks`) and **test** (`yarn test`).
 
 ## Setup
 
-One-command setup: ./setup.sh (checks Node.js >= 20, enables Corepack, installs dependencies, starts dev server)
+One-command setup: ./setup.sh (checks Node.js >= 24, enables Corepack, installs dependencies, starts dev server)
 
 ## Key Conventions
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/nodejs-22@sha256:9efa13178235c940d01e55b64771978773dcb549f523c4c91d67386457bd0672 AS builder
+FROM registry.access.redhat.com/ubi9/nodejs-24@sha256:3ffbe2cf5ff14d8fdca014a125753ca59a077215383e7319edcab61e889366dc AS builder
 
 # Run as root in builder stage (final image uses non-root USER 1001)
 USER 0

--- a/Dockerfile.instrumented
+++ b/Dockerfile.instrumented
@@ -9,7 +9,7 @@
 # can be collected by Cypress tests using @cypress/code-coverage plugin.
 ##
 
-FROM registry.access.redhat.com/ubi9/nodejs-22@sha256:9efa13178235c940d01e55b64771978773dcb549f523c4c91d67386457bd0672 AS builder
+FROM registry.access.redhat.com/ubi9/nodejs-24@sha256:3ffbe2cf5ff14d8fdca014a125753ca59a077215383e7319edcab61e889366dc AS builder
 
 # Run as root in builder stage (final image uses non-root USER 1001)
 USER 0

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you find a bug or want to request a feature, feel free to open an issue as we
 
 ## Quick Start
 
-**Prerequisites:** Node.js >= 20
+**Prerequisites:** Node.js >= 24
 
 ```bash
 git clone https://github.com/konflux-ci/konflux-ui.git && cd konflux-ui
@@ -26,8 +26,8 @@ If you do not want to or cannot use the DevContainer, you can also setup the rep
 
 **Prerequisites:**
 
-- Node.js version >= 20
-- Corepack enabled (included with Node.js 20+)
+- Node.js version >= 24
+- Corepack enabled (included with Node.js 24+)
 
 > **Note:** This project uses [Yarn Berry (v4.x)](https://yarnpkg.com/) as the package manager. The correct Yarn version is automatically managed via the `packageManager` field in `package.json` and Corepack.
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "homepage": "/",
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=24.0.0"
   },
   "scripts": {
     "build": "webpack -c ./webpack.prod.config.js",

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-MIN_NODE_VERSION=22
+MIN_NODE_VERSION=24
 
 if ! command -v node &>/dev/null; then
   echo "Error: Node.js >= ${MIN_NODE_VERSION} is required. Install from https://nodejs.org/"


### PR DESCRIPTION
## Fixes
<!-- No Jira ticket associated -->
https://redhat.atlassian.net/browse/KFLUXUI-1367

## Description

Migrate the project from Node.js 22 to Node.js 24. Updates the UBI9 builder image in both Dockerfiles to `ubi9/nodejs-24` with a pinned SHA digest, bumps the minimum engine version in `package.json`, and updates all CI workflows, setup scripts, devcontainer config, and documentation to reference Node.js 24.

The e2e-tests Containerfiles inherit Node.js from their base images (`cypress/factory`) and require no changes.

## Type of change

- [x] Build related changes
- [x] Documentation content changes

## Screen shots / Gifs for design review
<!-- No UI changes -->

## How to test or reproduce?

- Verify CI passes (lint, type-checks, unit tests) on Node.js 24
- `docker build .` succeeds with the new base image
- `./setup.sh` rejects Node.js < 24

## Browser conformance:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Raised the project’s minimum Node.js requirement from 22.x to 24.x across CI, builds, container images, package metadata, and local setup checks.
  * CI workflows and build images now use Node.js 24; Yarn is installed/verified explicitly (Corepack enable removed).

* **Documentation**
  * Updated setup and container docs to reflect Node.js 24, explicit Yarn usage, Fedora-based devcontainer image, and adjusted devcontainer workspace/runArgs guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->