### PR TITLE
chore(KFLUXUI-1372): switch Slack notifications from webhook to bot token

### DIFF
--- a/.github/scripts/check-infra-deployments-prs.sh
+++ b/.github/scripts/check-infra-deployments-prs.sh
@@ -2,20 +2,21 @@
 # Check for open PRs in infra-deployments repository related to konflux-ui
 #
 # This script queries the infra-deployments repository for PRs that mention
-# konflux-ui in their title and sends a report to Slack to prevent deployment
-# PRs from being forgotten.
+# konflux-ui in their title and writes a message to a file for the GitHub
+# Action workflow to send via Slack bot.
 #
 # Environment Variables (required):
-#   SLACK_WEBHOOK_URL - Slack incoming webhook URL for notifications
 #   GH_TOKEN          - GitHub token for API access
+#   SLACK_CHANNEL_ID  - Slack channel ID to post the report to (unless TEST_MODE)
 #
 # Environment Variables (optional):
+#   OUTPUT_FILE              - Path to write JSON payload (default: /tmp/infra-prs-payload.json)
 #   INFRA_DEPLOYMENTS_REPO - Target repo (default: redhat-appstudio/infra-deployments)
 #   COMPONENT_NAME         - Component to search (default: konflux-ui)
 #   INFRA_PR_LIMIT         - Max PRs to fetch (default: 100)
 #   INFRA_PR_STATE         - PR state: open, closed, merged, all (default: open)
 #   INFRA_BOT_LOGIN        - Bot account name (default: app/rh-tap-build-team)
-#   TEST_MODE              - Set to 'true' to log output instead of sending to Slack
+#   TEST_MODE              - Set to 'true' to log output instead of writing to file
 
 set -euo pipefail
 
@@ -27,6 +28,7 @@ PR_LIMIT="${INFRA_PR_LIMIT:-100}"
 PR_STATE="${INFRA_PR_STATE:-open}"
 BOT_LOGIN="${INFRA_BOT_LOGIN:-app/rh-tap-build-team}"
 TEST_MODE="${TEST_MODE:-false}"
+OUTPUT_FILE="${OUTPUT_FILE:-/tmp/infra-prs-payload.json}"
 
 # Validate required environment variables
 if [ -z "${GH_TOKEN:-}" ]; then
@@ -34,8 +36,8 @@ if [ -z "${GH_TOKEN:-}" ]; then
     exit 1
 fi
 
-if [ "$TEST_MODE" != "true" ] && [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
-    echo "Error: SLACK_WEBHOOK_URL is not set (or set TEST_MODE=true for testing)" >&2
+if [ "$TEST_MODE" != "true" ] && [ -z "${SLACK_CHANNEL_ID:-}" ]; then
+    echo "Error: SLACK_CHANNEL_ID is not set (or set TEST_MODE=true for testing)" >&2
     exit 1
 fi
 
@@ -116,11 +118,7 @@ format_slack_message() {
         local error_msg
         error_msg=$(echo "$prs_json" | jq -r '.error // "Unknown error"')
 
-        cat <<EOF
-{
-  "text": "⚠️ *Failed to fetch infra-deployments PRs*\n${error_msg}"
-}
-EOF
+        printf '⚠️ *Failed to fetch infra-deployments PRs*\n%s' "${error_msg}"
         return 0
     fi
 
@@ -129,11 +127,7 @@ EOF
     pr_count=$(echo "$prs_json" | jq '. | length')
 
     if [ "$pr_count" -eq 0 ]; then
-        cat <<EOF
-{
-  "text": "✅ *No ${state_display} infra-deployments PRs for ${COMPONENT}*"
-}
-EOF
+        printf '✅ *No %s infra-deployments PRs for %s*' "${state_display}" "${COMPONENT}"
         return 0
     fi
 
@@ -162,38 +156,27 @@ EOF
         "• <\(.url)|#\(.number)> " + $includes + "- \(.title) by @\(.author.login) at \(.createdAt | split("T")[0])"
     ' | sed 's/$/\\n/' | tr -d '\n')
 
-    # Build Slack message JSON
-    cat <<EOF
-{
-  "text": "📋 *${state_display} infra-deployments PRs (${pr_count}):*\n${pr_list}"
-}
-EOF
+    # Return plain text message
+    printf '📋 *%s infra-deployments PRs (%s):*\n%s' "${state_display}" "${pr_count}" "${pr_list}"
 }
 
-send_to_slack() {
+write_payload() {
     local message="$1"
 
     if [ "$TEST_MODE" = "true" ]; then
         echo ""
-        echo "=== TEST MODE: Would send to Slack ===" >&2
-        echo "$message" | jq '.' >&2
+        echo "=== TEST MODE: Would write to ${OUTPUT_FILE} ===" >&2
+        echo "$message" >&2
         echo "=====================================" >&2
         return 0
     fi
 
-    # Send to Slack
-    local response
-    response=$(curl -s -X POST \
-        -H "Content-Type: application/json" \
-        -d "$message" \
-        "${SLACK_WEBHOOK_URL}")
-
-    if [ "$response" != "ok" ]; then
-        echo "Warning: Slack API returned: $response" >&2
-        return 1
-    fi
-
-    echo "✅ Report sent to Slack successfully" >&2
+    # Write full Slack API payload to file for the GitHub Action step to send
+    jq -n \
+        --arg channel "$SLACK_CHANNEL_ID" \
+        --arg text "$message" \
+        '{ channel: $channel, text: $text }' > "$OUTPUT_FILE"
+    echo "✅ Infra PR report payload written to ${OUTPUT_FILE}" >&2
 }
 
 # ----- Main Script -----
@@ -209,8 +192,8 @@ main() {
     local slack_message
     slack_message=$(format_slack_message "$prs_json" "$PR_STATE")
 
-    # Send to Slack
-    send_to_slack "$slack_message"
+    # Write payload to file
+    write_payload "$slack_message"
 
     echo "✅ Done!" >&2
 }

--- a/.github/scripts/check-infra-deployments-prs.sh
+++ b/.github/scripts/check-infra-deployments-prs.sh
@@ -154,7 +154,7 @@ format_slack_message() {
             end
         ) as $includes |
         "• <\(.url)|#\(.number)> " + $includes + "- \(.title) by @\(.author.login) at \(.createdAt | split("T")[0])"
-    ' | sed 's/$/\\n/' | tr -d '\n')
+    ')
 
     # Return plain text message
     printf '📋 *%s infra-deployments PRs (%s):*\n%s' "${state_display}" "${pr_count}" "${pr_list}"

--- a/.github/scripts/check-prs.js
+++ b/.github/scripts/check-prs.js
@@ -38,7 +38,7 @@
  * - Only human activity affects the categorization
  *
  * OUTPUT MODES:
- * - Production: Sends formatted report to Slack webhook
+ * - Production: Writes JSON payload to file for GitHub Action to send via Slack bot
  * - TEST_MODE: Logs report to console for validation
  *
  * ENVIRONMENT VARIABLES:
@@ -175,7 +175,7 @@ const getCommits = (prNumber) =>
  * 5. Generate formatted Slack message with all categories
  * 6. Send to Slack (or log if in TEST_MODE)
  *
- * @throws {Error} If GitHub API calls fail or Slack webhook rejects the message
+ * @throws {Error} If GitHub API calls fail
  */
 const checkNeedsAuthorFollowupPRs = async () => {
   try {
@@ -213,7 +213,7 @@ const checkNeedsAuthorFollowupPRs = async () => {
           'github-actions',
           'fullsend-ai-review',
           'red-hat-konflux',
-          'fullsend-ai-coder'
+          'fullsend-ai-coder',
         ].includes(login) || user.type === 'Bot'
       );
     };

--- a/.github/scripts/check-prs.js
+++ b/.github/scripts/check-prs.js
@@ -43,10 +43,12 @@
  *
  * ENVIRONMENT VARIABLES:
  * - GITHUB_TOKEN: Required - GitHub API authentication token
- * - SLACK_WEBHOOK_URL: Required (unless TEST_MODE) - cwf-cue Slack incoming webhook URL
- * - TEST_MODE: Optional - Set to 'true' to log output instead of sending to Slack
+ * - SLACK_CHANNEL_ID: Required (unless TEST_MODE) - Slack channel ID to post the report to
+ * - OUTPUT_FILE: Optional - Path to write JSON payload (default: /tmp/stale-prs-payload.json)
+ * - TEST_MODE: Optional - Set to 'true' to log output instead of writing to file
  */
 
+import { writeFileSync } from 'node:fs';
 import { Octokit } from '@octokit/rest';
 import dayjs from 'dayjs';
 
@@ -58,13 +60,13 @@ const REPO_NAME = 'konflux-ui';
 
 /** Environment variables */
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
-const SLACK_WEBHOOK_URL = process.env.SLACK_WEBHOOK_URL; // Slack webhook for cwf-cue notifications
+const SLACK_CHANNEL_ID = process.env.SLACK_CHANNEL_ID;
+const OUTPUT_FILE = process.env.OUTPUT_FILE || '/tmp/stale-prs-payload.json';
 const TEST_MODE = process.env.TEST_MODE === 'true';
 
 /** Validate required environment variables */
 if (!GITHUB_TOKEN) throw new Error('GITHUB_TOKEN is not set');
-if (!TEST_MODE && !SLACK_WEBHOOK_URL)
-  throw new Error('Set the SLACK_WEBHOOK_URL or TEST_MODE=true.');
+if (!TEST_MODE && !SLACK_CHANNEL_ID) throw new Error('SLACK_CHANNEL_ID is not set');
 
 /** Initialize GitHub API client */
 const octokit = new Octokit({ auth: GITHUB_TOKEN });
@@ -480,30 +482,22 @@ const checkNeedsAuthorFollowupPRs = async () => {
       message += `\n⚡ Please accelerate reviews or merge PRs to keep the repo clean!\n`;
     }
 
-    // ----- Send to Slack or Log -----
+    // ----- Write payload to file or Log -----
     if (TEST_MODE) {
       // In test mode, print the message to console for validation
       console.log('--- TEST_MODE: Slack message (not sent) ---');
       console.log(message);
       console.log('--- End of test output ---');
     } else {
-      // Production mode: Send formatted report to Slack webhook
-      const response = await fetch(SLACK_WEBHOOK_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          text: message,
-          unfurl_links: false, // Don't auto-expand PR links
-          unfurl_media: false, // Don't auto-expand media
-        }),
-      });
-
-      // Fail loudly if Slack rejects the message
-      if (!response.ok) {
-        const text = await response.text();
-        throw new Error(`Slack webhook responded with ${response.status}: ${text}`);
-      }
-      console.log('✅ PR report sent to Slack successfully!');
+      // Write full Slack API payload to file for the GitHub Action step to send
+      const payload = {
+        channel: SLACK_CHANNEL_ID,
+        text: message,
+        unfurl_links: false,
+        unfurl_media: false,
+      };
+      writeFileSync(OUTPUT_FILE, JSON.stringify(payload, null, 2));
+      console.log(`✅ PR report payload written to ${OUTPUT_FILE}`);
     }
   } catch (err) {
     console.error('❌ Error checking PRs:', err);

--- a/.github/workflows/pr-report.yaml
+++ b/.github/workflows/pr-report.yaml
@@ -35,7 +35,7 @@ jobs:
         run: node .github/scripts/check-prs.js
 
       - name: Send stale PR report to Slack
-        uses: slackapi/slack-github-action@v3.0.3
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
         run: ./.github/scripts/check-infra-deployments-prs.sh
 
       - name: Send infra PR report to Slack
-        uses: slackapi/slack-github-action@v3.0.3
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/pr-report.yaml
+++ b/.github/workflows/pr-report.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Enable Corepack 📦
+      - name: Enable Corepack
         run: corepack enable
 
       - name: Setup Node.js
@@ -30,11 +30,27 @@ jobs:
       - name: Run PR checker
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_CHANNEL_ID: ${{ vars.SLACK_CHANNEL_ID }}
+          OUTPUT_FILE: /tmp/stale-prs-payload.json
         run: node .github/scripts/check-prs.js
+
+      - name: Send stale PR report to Slack
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload-file-path: /tmp/stale-prs-payload.json
 
       - name: Check infra-deployments PRs
         env:
           GH_TOKEN: ${{ secrets.HAC_TEST_GH_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_CHANNEL_ID: ${{ vars.SLACK_CHANNEL_ID }}
+          OUTPUT_FILE: /tmp/infra-prs-payload.json
         run: ./.github/scripts/check-infra-deployments-prs.sh
+
+      - name: Send infra PR report to Slack
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload-file-path: /tmp/infra-prs-payload.json

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -120,7 +120,8 @@ jobs:
         if: |
           steps.parity.outputs.is_release_week == 'true' &&
           steps.decide.outputs.should_release == 'false'
-        uses: slackapi/slack-github-action@v3.0.3
+        continue-on-error: true
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -279,7 +280,8 @@ jobs:
 
       # --- Slack notification ---
       - name: Notify Slack — release cut
-        uses: slackapi/slack-github-action@v3.0.3
+        continue-on-error: true
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -290,6 +292,7 @@ jobs:
                 text:
                   type: plain_text
                   text: ":rocket: Release cut — ${{ needs.preflight.outputs.release_date }}"
+                  emoji: true
               - type: section
                 text:
                   type: mrkdwn

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -120,23 +120,13 @@ jobs:
         if: |
           steps.parity.outputs.is_release_week == 'true' &&
           steps.decide.outputs.should_release == 'false'
-        env:
-          RELEASE_DATE: ${{ steps.shas.outputs.release_date }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        run: |
-          curl -sf -X POST "$SLACK_WEBHOOK_URL" \
-            -H 'Content-Type: application/json' \
-            -d "$(jq -n --arg date "$RELEASE_DATE" '{
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ("*Release check — " + $date + "*\nNo new changes between staging and production. Skipping release.")
-                  }
-                }
-              ]
-            }')" || echo "::warning::Failed to send Slack notification"
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ vars.SLACK_CHANNEL_ID }}
+            text: ":information_source: *Release check — ${{ steps.shas.outputs.release_date }}*\nNo new changes between staging and production. Skipping release."
 
   # -------------------------------------------------------------------
   # Release: infra PR, tracking issue, notifications
@@ -289,38 +279,23 @@ jobs:
 
       # --- Slack notification ---
       - name: Notify Slack — release cut
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          INFRA_PR_URL: ${{ steps.infra_pr.outputs.pr_url }}
-          TRACKING_ISSUE_URL: ${{ steps.tracking.outputs.issue_url }}
-        run: |
-          SHORT_SHA="${NEW_SHA:0:7}"
-
-          curl -sf -X POST "$SLACK_WEBHOOK_URL" \
-            -H 'Content-Type: application/json' \
-            -d "$(jq -n \
-              --arg date "$RELEASE_DATE" \
-              --arg sha "$SHORT_SHA" \
-              --arg infra_url "$INFRA_PR_URL" \
-              --arg issue_url "$TRACKING_ISSUE_URL" \
-              '{
-                "blocks": [
-                  {
-                    "type": "header",
-                    "text": { "type": "plain_text", "text": ("Release cut — " + $date) }
-                  },
-                  {
-                    "type": "section",
-                    "text": {
-                      "type": "mrkdwn",
-                      "text": ("*Deploying:* `" + $sha + "`\n\n<" + $infra_url + "|Infra-deployments PR>\n<" + $issue_url + "|Tracking issue>")
-                    }
-                  },
-                  {
-                    "type": "context",
-                    "elements": [
-                      { "type": "mrkdwn", "text": "Review and merge the infra-deployments PR to deploy to production." }
-                    ]
-                  }
-                ]
-              }')" || echo "::warning::Failed to send Slack notification"
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ vars.SLACK_CHANNEL_ID }}
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: ":rocket: Release cut — ${{ needs.preflight.outputs.release_date }}"
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "<!subteam^${{ vars.SLACK_KONFLUX_UI_GROUP_ID }}> A new release has been cut!\n\n:package: *Deploying:* `${{ needs.preflight.outputs.new_sha }}`\n:link: <${{ steps.infra_pr.outputs.pr_url }}|Infra-deployments PR>\n:memo: <${{ steps.tracking.outputs.issue_url }}|Tracking issue>"
+              - type: context
+                elements:
+                  - type: mrkdwn
+                    text: ":point_right: Review and merge the infra-deployments PR to deploy to production. The tracking issue will auto-close once the PR is merged."
+            text: "Release cut — ${{ needs.preflight.outputs.release_date }}: deploying ${{ needs.preflight.outputs.new_sha }}"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -165,34 +165,23 @@ jobs:
 
       # --- Slack shipped notification ---
       - name: Notify Slack — shipped
-        env:
-          RELEASE_DATE: ${{ steps.meta.outputs.release_date }}
-          TAG: ${{ steps.tag.outputs.tag }}
-          NEW_SHA: ${{ steps.meta.outputs.new_sha }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        run: |
-          RELEASE_URL="https://github.com/${KONFLUX_UI_REPO}/releases/tag/${TAG}"
-          SHORT_SHA="${NEW_SHA:0:7}"
-
-          curl -sf -X POST "$SLACK_WEBHOOK_URL" \
-            -H 'Content-Type: application/json' \
-            -d "$(jq -n \
-              --arg date "$RELEASE_DATE" \
-              --arg tag "$TAG" \
-              --arg sha "$SHORT_SHA" \
-              --arg url "$RELEASE_URL" \
-              '{
-                "blocks": [
-                  {
-                    "type": "header",
-                    "text": { "type": "plain_text", "text": ("Shipped to production — " + $date) }
-                  },
-                  {
-                    "type": "section",
-                    "text": {
-                      "type": "mrkdwn",
-                      "text": ("*Tag:* `" + $tag + "`\n*Commit:* `" + $sha + "`\n\n<" + $url + "|View GitHub Release>")
-                    }
-                  }
-                ]
-              }')" || echo "::warning::Failed to send Slack notification"
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ vars.SLACK_CHANNEL_ID }}
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: ":tada: Shipped to production — ${{ steps.meta.outputs.release_date }}"
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "<!subteam^${{ vars.SLACK_KONFLUX_UI_GROUP_ID }}> A new release is live in production!\n\n:label: *Tag:* `${{ steps.tag.outputs.tag }}`\n:package: *Commit:* `${{ steps.meta.outputs.new_sha }}`\n\n:link: <https://github.com/${{ env.KONFLUX_UI_REPO }}/releases/tag/${{ steps.tag.outputs.tag }}|View GitHub Release>"
+              - type: context
+                elements:
+                  - type: mrkdwn
+                    text: ":white_check_mark: The tracking issue has been closed and a GitHub release has been published."
+            text: "Shipped to production — ${{ steps.meta.outputs.release_date }}: ${{ steps.tag.outputs.tag }}"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -165,7 +165,8 @@ jobs:
 
       # --- Slack shipped notification ---
       - name: Notify Slack — shipped
-        uses: slackapi/slack-github-action@v3.0.3
+        continue-on-error: true
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -176,6 +177,7 @@ jobs:
                 text:
                   type: plain_text
                   text: ":tada: Shipped to production — ${{ steps.meta.outputs.release_date }}"
+                  emoji: true
               - type: section
                 text:
                   type: mrkdwn


### PR DESCRIPTION

## Fixes
<!-- No Jira ticket associated yet -->
https://redhat.atlassian.net/browse/KFLUXUI-1372
## Description

Migrate all Slack notifications from incoming webhook (`SLACK_WEBHOOK_URL`) to a Slack app bot using `slackapi/slack-github-action@v3.0.3` with the `chat.postMessage` API.

**PR report:** Scripts (`check-stale-prs.js`, `check-infra-deployments-prs.sh`) now write JSON payloads to temp files instead of sending directly via webhook. The workflow picks up these files and sends them through the Slack GitHub Action with a bot token.

**Release workflows:** Replace `curl` webhook calls with `slack-github-action` steps. Messages are improved with Block Kit formatting, emojis, `@konflux-ui` user group mentions (`<!subteam^ID>`), and context about tracking issue auto-close.

**Required GitHub configuration after merge:**

| Type | Name | Description |
|------|------|-------------|
| Secret | `SLACK_BOT_TOKEN` | Bot token with `chat:write` scope |
| Variable | `SLACK_CHANNEL_ID` | Target Slack channel ID |
| Variable | `SLACK_KONFLUX_UI_GROUP_ID` | Slack user group subteam ID for @konflux-ui |

The `SLACK_WEBHOOK_URL` secret can be removed once verified.

## Type of change

- [x] Build related changes

## Screen shots / Gifs for design review
<!-- N/A — no UI changes, workflow/CI only -->

## How to test or reproduce?

1. Configure the three secrets/variables listed above in the repo settings
2. Trigger a manual run of `PR Report to Slack` workflow — verify both stale PR and infra PR reports post to the channel via bot
3. On a release week, trigger `Release Prod` manually with force=true — verify "release cut" message posts with emojis, @mention, and links
4. Verify "no changes" path by triggering when staging and production SHAs match

## Browser conformance:
<!-- N/A — no UI changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated notification infrastructure to use Slack's official GitHub Action for improved reliability and maintainability.
  * Migrated Slack notifications for infrastructure deployment checks and releases from direct webhook-based delivery to structured file-based payload generation.
  * Enhanced bot activity filtering for more accurate PR status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->