### PR TITLE
fix(KFLUXUI-1392): Fixes inability to create secrets from UI

### DIFF
--- a/src/shared/components/formik-fields/SelectInputField.tsx
+++ b/src/shared/components/formik-fields/SelectInputField.tsx
@@ -153,8 +153,12 @@ const SelectInputField: React.FC<React.PropsWithChildren<SelectInputFieldProps>>
 
   const onTextInputChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
     setFilterValue(value);
-    if (!isMulti && field.value) {
-      void setFieldValue(name, '', false);
+    if (!isMulti) {
+      if (isCreatable) {
+        void setFieldValue(name, value, false);
+      } else if (field.value) {
+        void setFieldValue(name, '', false);
+      }
     }
     if (!isOpen) {
       setIsOpen(true);

--- a/src/shared/components/formik-fields/__tests__/SelectInputField.spec.tsx
+++ b/src/shared/components/formik-fields/__tests__/SelectInputField.spec.tsx
@@ -295,6 +295,38 @@ describe('SelectInputField', () => {
       });
     });
 
+    it('syncs typed value to formik', async () => {
+      const ValueIndicator = () => {
+        const { values } = useFormikContext<Record<string, unknown>>();
+        return <span data-test="field-value">{String(values[fieldName] ?? '')}</span>;
+      };
+
+      const user = setupUser();
+      formikRenderer(
+        <>
+          <SelectInputField
+            name={fieldName}
+            label="Test Label"
+            options={options}
+            toggleId="test-toggle"
+            toggleAriaLabel="Test toggle"
+            variant="typeahead"
+            isCreatable
+            hasOnCreateOption
+          />
+          <ValueIndicator />
+        </>,
+        { [fieldName]: '' },
+      );
+
+      const input = screen.getByRole('combobox');
+      await user.type(input, 'my-secret');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('field-value')).toHaveTextContent('my-secret');
+      });
+    });
+
     it('creates and selects a new option in single-select mode', async () => {
       const user = setupUser();
       renderField({ variant: 'typeahead', isCreatable: true, hasOnCreateOption: true });


### PR DESCRIPTION
Assisted-by: Cursor


## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->
https://redhat.atlassian.net/browse/KFLUXUI-1392

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
The typed value wasn't written into formik field. Fixed and test added

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [X] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved select input field behavior in creatable mode: typed values now properly synchronize to the form field in typeahead configuration, instead of being cleared.

* **Tests**
  * Added test coverage validating that typed values correctly sync with the form field in creatable typeahead select fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->