### PR TITLE
chore(KFLUXUI-1373): merge main into patternfly-v6 (v2)

### DIFF
--- a/.github/actions/konflux-ui-deploy-test/action.yaml
+++ b/.github/actions/konflux-ui-deploy-test/action.yaml
@@ -19,7 +19,7 @@ runs:
     # konflux-ci is cloned to /home/runner/work/konflux-ui/konflux-ui
     # as it have to be at home folder to use helm/kind-action@v1 action
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: 'konflux-ci/konflux-ci'
         path: 'konflux-ci'

--- a/.github/workflows/base-test-image.yaml
+++ b/.github/workflows/base-test-image.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build and Push Base Image
         env:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,7 +10,7 @@ on:
     types: [checks_requested]
   # Triggers the workflow on manual dispatch
   workflow_dispatch:
-  
+
 # Cancel in-progress runs when new commits are pushed
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -83,9 +83,9 @@ jobs:
           CI: true
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
-          file: ./coverage/lcov.info
+          files: ./coverage/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: shard-${{ matrix.shard }}
           fail_ci_if_error: true

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Enable Corepack 📦
         run: corepack enable
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Enable Corepack 📦
         run: corepack enable

--- a/.github/workflows/periodic-cleanup.yaml
+++ b/.github/workflows/periodic-cleanup.yaml
@@ -37,7 +37,7 @@ jobs:
       JOB_TYPE: 'periodic-cleanup'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         # Checkout specific branch
         with:
           ref: ${{ github.event.inputs.ref }}

--- a/.github/workflows/periodic-job-local.yaml
+++ b/.github/workflows/periodic-job-local.yaml
@@ -31,7 +31,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       JOB_TYPE: 'periodic-local'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: ${{ github.repository }}
           ref: "${{ env.HEAD_SHA }}"

--- a/.github/workflows/periodic-job-stage-features.yaml
+++ b/.github/workflows/periodic-job-stage-features.yaml
@@ -28,7 +28,7 @@ jobs:
       JOB_TYPE: 'periodic-stage'
       SUITE: 'features'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: ${{ github.repository }}
           ref: "${{ env.HEAD_SHA }}"

--- a/.github/workflows/periodic-job-stage.yaml
+++ b/.github/workflows/periodic-job-stage.yaml
@@ -26,7 +26,7 @@ jobs:
       CYPRESS_KONFLUX_BASE_URL: "https://konflux-ui.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com"
       JOB_TYPE: 'periodic-stage'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: ${{ github.repository }}
           ref: "${{ env.HEAD_SHA }}"

--- a/.github/workflows/periodic-watch-changes.yaml
+++ b/.github/workflows/periodic-watch-changes.yaml
@@ -19,7 +19,7 @@ jobs:
       JOB_TYPE: 'periodic-watch'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check files for change
         id: check-files

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -42,9 +42,9 @@ jobs:
           CI: true
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
-          file: ./coverage/lcov.info
+          files: ./coverage/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests
           fail_ci_if_error: true

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Enable Corepack 📦
         run: corepack enable
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build E2E Test Image
         env:

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -96,7 +96,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       JOB_TYPE: 'on-pr'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: ${{ github.repository }}
           ref: '${{ github.event.pull_request.head.sha }}'

--- a/.github/workflows/pr-report.yaml
+++ b/.github/workflows/pr-report.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Enable Corepack 📦
         run: corepack enable

--- a/.github/workflows/pr-title-check.yaml
+++ b/.github/workflows/pr-title-check.yaml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Validate PR title
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -160,7 +160,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # --- Generate changelog ---
       - name: Generate changelog

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -82,7 +82,7 @@ jobs:
 
       # --- Checkout and create tag ---
       - name: Checkout konflux-ui
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY aliases.config.js aliases.config.js
 RUN yarn install --immutable
 RUN yarn build
 
-FROM registry.access.redhat.com/ubi9/nginx-120@sha256:c5fdf1b976571cf1f058b8f2dd955a94d80ced7a43756362d7e87d99e9c92337
+FROM registry.access.redhat.com/ubi9/nginx-120@sha256:aea08753a83bc509c8abf72866a8a69ffcf824a640bd3c3257887fdd515b3aa3
 
 COPY --from=builder /opt/app-root/src/dist/* /opt/app-root/src/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/nodejs-24@sha256:3ffbe2cf5ff14d8fdca014a125753ca59a077215383e7319edcab61e889366dc AS builder
+FROM registry.access.redhat.com/ubi9/nodejs-24@sha256:1a996f1d6422b12eef84bb217e9b107609a2055eabb58f73b3094ccf4387215a AS builder
 
 # Run as root in builder stage (final image uses non-root USER 1001)
 USER 0

--- a/Dockerfile.instrumented
+++ b/Dockerfile.instrumented
@@ -9,7 +9,7 @@
 # can be collected by Cypress tests using @cypress/code-coverage plugin.
 ##
 
-FROM registry.access.redhat.com/ubi9/nodejs-24@sha256:3ffbe2cf5ff14d8fdca014a125753ca59a077215383e7319edcab61e889366dc AS builder
+FROM registry.access.redhat.com/ubi9/nodejs-24@sha256:1a996f1d6422b12eef84bb217e9b107609a2055eabb58f73b3094ccf4387215a AS builder
 
 # Run as root in builder stage (final image uses non-root USER 1001)
 USER 0

--- a/Dockerfile.instrumented
+++ b/Dockerfile.instrumented
@@ -41,7 +41,7 @@ COPY aliases.config.js aliases.config.js
 RUN yarn install --immutable
 RUN yarn build:instrumented
 
-FROM registry.access.redhat.com/ubi9/nginx-120@sha256:c5fdf1b976571cf1f058b8f2dd955a94d80ced7a43756362d7e87d99e9c92337
+FROM registry.access.redhat.com/ubi9/nginx-120@sha256:aea08753a83bc509c8abf72866a8a69ffcf824a640bd3c3257887fdd515b3aa3
 
 COPY --from=builder /opt/app-root/src/dist/* /opt/app-root/src/
 

--- a/docs/guidelines/patternfly-guidelines.md
+++ b/docs/guidelines/patternfly-guidelines.md
@@ -461,6 +461,52 @@ These deprecated APIs exist in the codebase but should not be used in new code:
 | `Select` from `@patternfly/react-core/deprecated` | `BasicDropdown` from `~/shared/components/dropdown/` or PF5 `Select` |
 | `DropdownToggle` from `@patternfly/react-core/deprecated` | PF5 `MenuToggle` |
 
+## Common Pitfalls — Composable Component DOM Semantics
+
+When migrating from deprecated PF APIs to the composable equivalents (`Select`, `Menu`, `Dropdown`), pay attention to DOM semantics. The composable API gives you full control over the markup, which means you are responsible for valid HTML nesting.
+
+### Divider inside list containers
+
+`SelectList`, `MenuList`, and `DropdownList` render a `<ul>` element. A `<Divider />` renders `<hr>` by default, which is not a valid child of `<ul>`. Always set `component="li"`:
+
+```tsx
+// ✅ Correct — valid inside <ul>
+<SelectList>
+  <SelectOption value="option-1">Option 1</SelectOption>
+  <Divider component="li" />
+  <SelectOption value="option-2">Option 2</SelectOption>
+</SelectList>
+
+// ❌ Wrong — <hr> is invalid inside <ul>
+<SelectList>
+  <SelectOption value="option-1">Option 1</SelectOption>
+  <Divider />
+  <SelectOption value="option-2">Option 2</SelectOption>
+</SelectList>
+```
+
+The same rule applies to `MenuList` and `DropdownList`.
+
+### MenuToggle ref forwarding
+
+The composable `Select`, `Menu`, and `Dropdown` require a `toggle` render function that receives a `ref`. You **must** forward this ref to `MenuToggle` — without it, Popper positioning and outside-click detection break silently:
+
+```tsx
+<Select
+  toggle={(toggleRef) => (
+    <MenuToggle ref={toggleRef} onClick={onToggle}>
+      {selected || 'Select an option'}
+    </MenuToggle>
+  )}
+>
+  <SelectList>{/* options */}</SelectList>
+</Select>
+```
+
+### SelectOption and value types
+
+In the composable `Select`, `SelectOption` requires an explicit `value` prop. If you omit it, click handlers receive `undefined`. When using object values, provide a `toString()` method or use `itemId` for identification.
+
 ## Component Wrapping Decision Guide
 
 | Need | Use |

--- a/e2e-tests/yarn.lock
+++ b/e2e-tests/yarn.lock
@@ -640,9 +640,9 @@ __metadata:
   linkType: hard
 
 "axe-core@npm:^4.10.2":
-  version: 4.11.1
-  resolution: "axe-core@npm:4.11.1"
-  checksum: 10/bbc8e8959258a229b92fbaa73437050825579815051cac7b0fdbb6752946fea226e403bfeeef3d60d712477bdd4c01afdc8455f27c3d85e4251df88b032b6250
+  version: 4.11.4
+  resolution: "axe-core@npm:4.11.4"
+  checksum: 10/49095daa422d05d99a90b39301a3b5c971e234a4593403dfd6701df637a3e550bcfd7bd096709c5643564dd069208513247791f367790e0605d15386fb2a7bfe
   languageName: node
   linkType: hard
 

--- a/src/components/PipelineRun/PipelineRunListView/__tests__/pipelinerun-actions.spec.tsx
+++ b/src/components/PipelineRun/PipelineRunListView/__tests__/pipelinerun-actions.spec.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { renderHook, act } from '@testing-library/react-hooks';
+import { DataState, testPipelineRuns } from '~/__data__/pipelinerun-data';
 import { downloadYaml } from '~/utils/common-utils';
 import { PipelineRunEventType, PipelineRunLabel, runStatus } from '../../../../consts/pipelinerun';
 import { useComponent } from '../../../../hooks/useComponents';
@@ -322,6 +323,33 @@ describe('usePipelinerunActions', () => {
         disabled: true,
         disabledTooltip:
           'To rerun the build pipeline for the latest commit in this PR, comment `/retest` on the pull request',
+      }),
+    );
+  });
+
+  it('should contain disabled rerun actions for cancelling pipeline', () => {
+    const testPipelineRun = testPipelineRuns[DataState.PIPELINE_RUN_CANCELLING];
+    useAccessReviewForModelMock.mockReturnValueOnce([true, true]);
+    const { result } = renderHook(() =>
+      usePipelinerunActions({
+        metadata: {
+          labels: {
+            'pipelines.appstudio.openshift.io/type': 'test',
+            [PipelineRunLabel.SNAPSHOT]: 'snp1',
+            [PipelineRunLabel.TEST_SERVICE_SCENARIO]: 'scn1',
+          },
+        },
+        spec: testPipelineRun.spec,
+        status: testPipelineRun.status,
+      } as unknown as PipelineRunKind),
+    );
+    const actions = result.current;
+
+    expect(actions[0]).toEqual(
+      expect.objectContaining({
+        label: 'Rerun',
+        disabled: true,
+        disabledTooltip: 'Cannot rerun while the pipeline run is being cancelled',
       }),
     );
   });
@@ -1136,7 +1164,7 @@ describe('useRerunActionLazy', () => {
       expect(actions[0]).toEqual(
         expect.objectContaining({
           disabled: false,
-          disabledTooltip: undefined,
+          disabledTooltip: null,
         }),
       );
 
@@ -1253,7 +1281,7 @@ describe('useRerunActionLazy', () => {
       expect(actions[0]).toEqual(
         expect.objectContaining({
           disabled: false,
-          disabledTooltip: undefined,
+          disabledTooltip: null,
         }),
       );
 

--- a/src/components/PipelineRun/PipelineRunListView/pipelinerun-actions.tsx
+++ b/src/components/PipelineRun/PipelineRunListView/pipelinerun-actions.tsx
@@ -23,6 +23,7 @@ import { pipelineRunStatus } from '../../../utils/pipeline-utils';
 import { useAccessReviewForModel } from '../../../utils/rbac';
 
 export const BUILD_REQUEST_LABEL = 'test.appstudio.openshift.io/run';
+const PIPELINE_RUN_CANCELLING_MESSAGE = 'Cannot rerun while the pipeline run is being cancelled';
 
 // [TODO]: remove this once Snapshot details page is added
 
@@ -74,6 +75,7 @@ export const usePipelinererunAction = (pipelineRun: PipelineRunKind): RerunActio
   );
 
   const snapShotLabel = pipelineRun?.metadata?.labels?.[PipelineRunLabel.SNAPSHOT];
+  const status = pipelineRunStatus(pipelineRun);
 
   const [snapshot, , snapshotError] = useSnapshot(namespace, snapShotLabel);
 
@@ -85,6 +87,7 @@ export const usePipelinererunAction = (pipelineRun: PipelineRunKind): RerunActio
   const runType = pipelineRun?.metadata?.labels[PipelineRunLabel.PIPELINE_TYPE];
 
   const scenario = pipelineRun?.metadata?.labels?.[PipelineRunLabel.TEST_SERVICE_SCENARIO];
+  const isCancelling = status === runStatus.Cancelling;
 
   const eventType = pipelineRun?.metadata?.labels?.[
     PipelineRunLabel.COMMIT_EVENT_TYPE_LABEL
@@ -126,8 +129,8 @@ export const usePipelinererunAction = (pipelineRun: PipelineRunKind): RerunActio
                 }),
               );
             }),
-          isDisabled: false,
-          disabledTooltip: null,
+          isDisabled: isCancelling,
+          disabledTooltip: isCancelling ? PIPELINE_RUN_CANCELLING_MESSAGE : null,
         };
       }
 
@@ -151,8 +154,8 @@ export const usePipelinererunAction = (pipelineRun: PipelineRunKind): RerunActio
                 }),
               );
             }),
-          isDisabled: false,
-          disabledTooltip: null,
+          isDisabled: isCancelling,
+          disabledTooltip: isCancelling ? PIPELINE_RUN_CANCELLING_MESSAGE : null,
         };
       }
 
@@ -186,6 +189,7 @@ export const usePipelinererunAction = (pipelineRun: PipelineRunKind): RerunActio
     isIntegrationTestsPage,
     isSnapshotsPage,
     isPR,
+    isCancelling,
   ]);
 };
 
@@ -250,6 +254,8 @@ export const useRerunActionLazy = (pipelineRun: PipelineRunKind): LazyActionHook
   const isPR = eventType === PipelineRunEventType.PULL;
   const isPushBuildType =
     eventType === PipelineRunEventType.PUSH || eventType === PipelineRunEventType.INCOMING;
+  const status = pipelineRunStatus(pipelineRun);
+  const isCancelling = status === runStatus.Cancelling;
 
   return useLazyActionMenu({
     loadContext: async () => {
@@ -336,8 +342,8 @@ export const useRerunActionLazy = (pipelineRun: PipelineRunKind): LazyActionHook
                     }),
                   );
                 }),
-              disabled: false,
-              disabledTooltip: undefined,
+              disabled: isCancelling,
+              disabledTooltip: isCancelling ? PIPELINE_RUN_CANCELLING_MESSAGE : null,
             },
           ];
         }
@@ -367,8 +373,9 @@ export const useRerunActionLazy = (pipelineRun: PipelineRunKind): LazyActionHook
                     }),
                   );
                 }),
-              disabled: false,
-              disabledTooltip: undefined,
+              disabled: isCancelling,
+              disabledTooltip:
+                status === runStatus.Cancelling ? PIPELINE_RUN_CANCELLING_MESSAGE : null,
             },
           ];
         }

--- a/src/components/UserAccess/UserAccessForm/PermissionsTable.scss
+++ b/src/components/UserAccess/UserAccessForm/PermissionsTable.scss
@@ -1,5 +1,10 @@
 .permissions-table {
   border: var(--pf-v5-c-table--border-width--base) solid var(--pf-v5-c-table--BorderColor);
+  table-layout: fixed;
+
+  &__cell {
+    width: 50%;
+  }
 
   @media (min-width: 769px) {
     max-width: 740px;

--- a/src/components/UserAccess/UserAccessForm/PermissionsTable.tsx
+++ b/src/components/UserAccess/UserAccessForm/PermissionsTable.tsx
@@ -82,8 +82,8 @@ export const PermissionsTable = React.memo<{ role: NamespaceRole }>(({ role }) =
     <Table aria-label="List of permissions" variant="compact" className="permissions-table">
       <Thead>
         <Tr>
-          <Th>Permissions for</Th>
-          <Th>Access type</Th>
+          <Th className="permissions-table__cell">Permissions for</Th>
+          <Th className="permissions-table__cell">Access type</Th>
         </Tr>
       </Thead>
       <Tbody>
@@ -91,11 +91,11 @@ export const PermissionsTable = React.memo<{ role: NamespaceRole }>(({ role }) =
           const perms = rolePermissions[key];
           return (
             <Tr key={key}>
-              <Td>{key}</Td>
+              <Td className="permissions-table__cell">{key}</Td>
               {perms.length === 1 ? (
-                <Td>{perms[0]}</Td>
+                <Td className="permissions-table__cell">{perms[0]}</Td>
               ) : (
-                <Td>{`${perms.slice(0, perms.length - 1).join(', ')} and ${
+                <Td className="permissions-table__cell">{`${perms.slice(0, perms.length - 1).join(', ')} and ${
                   perms[perms.length - 1]
                 }`}</Td>
               )}

--- a/src/feature-flags/FeatureFlagIndicator.tsx
+++ b/src/feature-flags/FeatureFlagIndicator.tsx
@@ -63,15 +63,6 @@ export const FeatureFlagIndicator: React.FC<FeatureFlagIndicatorProps> = ({
 
   const trigger = fullLabel ? (
     <Button
-      icon={
-        <Label
-          icon={<FlaskIcon style={{ color: warningColor }} />}
-          color={labelColor}
-          variant="outline"
-        >
-          {statusText}
-        </Label>
-      }
       isInline
       variant="plain"
       aria-label="Feature flag information"
@@ -83,7 +74,6 @@ export const FeatureFlagIndicator: React.FC<FeatureFlagIndicatorProps> = ({
     </Button>
   ) : (
     <Button
-      icon={<FlaskIcon style={{ color: warningColor }} />}
       isInline
       variant="plain"
       aria-label="Feature flag information"

--- a/src/feature-flags/FeatureFlagIndicator.tsx
+++ b/src/feature-flags/FeatureFlagIndicator.tsx
@@ -21,6 +21,7 @@ type FeatureFlagIndicatorProps = {
 };
 
 const warningColor = 'var(--pf-v5-global--warning-color--100)';
+const readyColor = 'var(--pf-v5-global--success-color--100)';
 
 export const FeatureFlagIndicator: React.FC<FeatureFlagIndicatorProps> = ({
   flags,
@@ -30,16 +31,19 @@ export const FeatureFlagIndicator: React.FC<FeatureFlagIndicatorProps> = ({
   const [allFlags] = useFeatureFlags();
   const activeFlags = flags.filter((f) => allFlags[f]);
   const metas = activeFlags.map((f) => FLAGS[f]).filter(Boolean);
+  const anyWip = metas.some((m) => m.status === 'wip');
+  const iconColor = anyWip ? warningColor : readyColor;
+  const iconStyle = React.useMemo(() => ({ color: iconColor }), [iconColor]);
+
   if (metas.length === 0) return null;
 
-  const anyWip = metas.some((m) => m.status === 'wip');
   const statusText = anyWip ? FLAGS_STATUS.wip : FLAGS_STATUS.ready;
   const labelColor = anyWip ? 'orange' : 'green';
 
   const header = (
     <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
       <FlexItem>
-        <FlaskIcon style={{ color: warningColor }} />
+        <FlaskIcon style={iconStyle} />
       </FlexItem>
       <FlexItem>
         <Text component={TextVariants.h6}>Experimental feature</Text>
@@ -64,10 +68,7 @@ export const FeatureFlagIndicator: React.FC<FeatureFlagIndicatorProps> = ({
       aria-label="Feature flag information"
       data-test={dataTest ?? `ff-indicator-${flags.join('-')}`}
     >
-      <Label
-        icon={<FlaskIcon style={{ color: warningColor }} />}
-        color={labelColor}
-      >
+      <Label icon={<FlaskIcon style={iconStyle} />} color={labelColor}>
         {statusText}
       </Label>
     </Button>
@@ -78,16 +79,12 @@ export const FeatureFlagIndicator: React.FC<FeatureFlagIndicatorProps> = ({
       aria-label="Feature flag information"
       data-test={dataTest ?? `ff-indicator-${flags.join('-')}`}
     >
-      <FlaskIcon style={{ color: warningColor }} />
+      <FlaskIcon style={iconStyle} />
     </Button>
   );
 
   return (
-    <Popover
-      position="right"
-      headerContent={header}
-      bodyContent={body}
-    >
+    <Popover position="right" headerContent={header} bodyContent={body}>
       {trigger}
     </Popover>
   );

--- a/src/feature-flags/__tests__/FeatureFlagIndicator.spec.tsx
+++ b/src/feature-flags/__tests__/FeatureFlagIndicator.spec.tsx
@@ -1,7 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { FeatureFlagIndicator } from '../FeatureFlagIndicator';
-import { FlagKey, FLAGS } from '../flags';
+import { FlagKey, FLAGS, FLAGS_STATUS } from '../flags';
+import { useFeatureFlags } from '../hooks';
+
+const readyIconColor = 'var(--pf-v5-global--success-color--100)';
+const warningIconColor = 'var(--pf-v5-global--warning-color--100)';
 
 jest.mock('../flags', () => {
   {
@@ -13,7 +17,14 @@ jest.mock('../flags', () => {
           description:
             'Enable the theme switcher in the header to toggle between light and dark modes.',
         },
+        'stable-feature': {
+          key: 'stable-feature',
+          description: 'A stable feature flag',
+          defaultEnabled: true,
+          status: 'ready',
+        },
         'column-management': {
+          key: 'column-management',
           description: 'Enable the column management',
           defaultEnabled: false,
           status: 'wip',
@@ -27,12 +38,35 @@ jest.mock('../hooks', () => ({
   useFeatureFlags: jest.fn(() => [
     {
       'dark-theme': true,
+      'stable-feature': true,
       'column-management': true,
     },
   ]),
 }));
 
+const useFeatureFlagsMock = useFeatureFlags as jest.Mock;
+
+const getTriggerButton = () => screen.getByRole('button', { name: 'Feature flag information' });
+
+const getTriggerIcon = () => {
+  const icon = getTriggerButton().querySelector('svg');
+  if (!icon) {
+    throw new Error('Expected icon inside feature flag trigger button');
+  }
+  return icon;
+};
+
 describe('FeatureFlagIndicator', () => {
+  afterEach(() => {
+    useFeatureFlagsMock.mockReturnValue([
+      {
+        'dark-theme': true,
+        'stable-feature': true,
+        'column-management': true,
+      },
+    ]);
+  });
+
   it('renders nothing when unknown flags are provided', () => {
     const { container } = render(
       <FeatureFlagIndicator flags={['__unknown__'] as unknown as FlagKey[]} />,
@@ -41,33 +75,54 @@ describe('FeatureFlagIndicator', () => {
   });
 
   it('renders icon-only trigger by default', () => {
-    render(
-      <FeatureFlagIndicator flags={['dark-theme'] as unknown as FlagKey[]} data-test="ff-icon" />,
-    );
-    expect(screen.getByTestId('ff-icon')).toBeInTheDocument();
+    render(<FeatureFlagIndicator flags={['dark-theme'] as unknown as FlagKey[]} />);
+
+    expect(getTriggerButton()).toBeInTheDocument();
+    expect(getTriggerIcon()).toBeInTheDocument();
   });
 
   it('renders full label when fullLabel is true', () => {
-    render(
-      <FeatureFlagIndicator
-        flags={['dark-theme'] as unknown as FlagKey[]}
-        fullLabel
-        data-test="ff-label"
-      />,
-    );
-    expect(screen.getByTestId('ff-label')).toBeInTheDocument();
+    render(<FeatureFlagIndicator flags={['dark-theme'] as unknown as FlagKey[]} fullLabel />);
+
+    expect(getTriggerButton()).toBeInTheDocument();
+    expect(screen.getByText(FLAGS_STATUS.ready)).toBeInTheDocument();
   });
 
   it('shows popover with descriptions for all flags on click', async () => {
     render(
-      <FeatureFlagIndicator
-        flags={['dark-theme', 'column-management'] as unknown as FlagKey[]}
-        data-test="ff-pop"
-      />,
+      <FeatureFlagIndicator flags={['dark-theme', 'column-management'] as unknown as FlagKey[]} />,
     );
-    await userEvent.click(screen.getByTestId('ff-pop'));
+    await userEvent.click(getTriggerButton());
 
     expect(screen.getByText(FLAGS['dark-theme' as FlagKey].description)).toBeInTheDocument();
     expect(screen.getByText(FLAGS['column-management' as FlagKey].description)).toBeInTheDocument();
+  });
+
+  it('uses success icon color when all active flags are ready', () => {
+    useFeatureFlagsMock.mockReturnValue([{ 'stable-feature': true }]);
+
+    render(<FeatureFlagIndicator flags={['stable-feature'] as unknown as FlagKey[]} />);
+
+    expect(getTriggerIcon()).toHaveStyle({ color: readyIconColor });
+  });
+
+  it('uses warning icon color when any active flag is wip', () => {
+    useFeatureFlagsMock.mockReturnValue([{ 'column-management': true }]);
+
+    render(<FeatureFlagIndicator flags={['column-management'] as unknown as FlagKey[]} />);
+
+    expect(getTriggerIcon()).toHaveStyle({ color: warningIconColor });
+  });
+
+  it('uses warning icon color when mixing ready and wip flags', () => {
+    useFeatureFlagsMock.mockReturnValue([{ 'stable-feature': true, 'column-management': true }]);
+
+    render(
+      <FeatureFlagIndicator
+        flags={['stable-feature', 'column-management'] as unknown as FlagKey[]}
+      />,
+    );
+
+    expect(getTriggerIcon()).toHaveStyle({ color: warningIconColor });
   });
 });

--- a/src/feature-flags/__tests__/FeatureFlagIndicator.spec.tsx
+++ b/src/feature-flags/__tests__/FeatureFlagIndicator.spec.tsx
@@ -4,8 +4,8 @@ import { FeatureFlagIndicator } from '../FeatureFlagIndicator';
 import { FlagKey, FLAGS, FLAGS_STATUS } from '../flags';
 import { useFeatureFlags } from '../hooks';
 
-const readyIconColor = 'var(--pf-v5-global--success-color--100)';
-const warningIconColor = 'var(--pf-v5-global--warning-color--100)';
+const readyIconColor = 'var(--pf-t--global--color--status--success--default)';
+const warningIconColor = 'var(--pf-t--global--color--status--warning--default)';
 
 jest.mock('../flags', () => {
   {

--- a/src/shared/components/formik-fields/SelectInputField.tsx
+++ b/src/shared/components/formik-fields/SelectInputField.tsx
@@ -153,8 +153,12 @@ const SelectInputField: React.FC<React.PropsWithChildren<SelectInputFieldProps>>
 
   const onTextInputChange = (_event: React.FormEvent<HTMLInputElement>, value: string) => {
     setFilterValue(value);
-    if (!isMulti && field.value) {
-      void setFieldValue(name, '', false);
+    if (!isMulti) {
+      if (isCreatable) {
+        void setFieldValue(name, value, false);
+      } else if (field.value) {
+        void setFieldValue(name, '', false);
+      }
     }
     if (!isOpen) {
       setIsOpen(true);

--- a/src/shared/components/formik-fields/__tests__/SelectInputField.spec.tsx
+++ b/src/shared/components/formik-fields/__tests__/SelectInputField.spec.tsx
@@ -295,6 +295,38 @@ describe('SelectInputField', () => {
       });
     });
 
+    it('syncs typed value to formik', async () => {
+      const ValueIndicator = () => {
+        const { values } = useFormikContext<Record<string, unknown>>();
+        return <span data-test="field-value">{String(values[fieldName] ?? '')}</span>;
+      };
+
+      const user = setupUser();
+      formikRenderer(
+        <>
+          <SelectInputField
+            name={fieldName}
+            label="Test Label"
+            options={options}
+            toggleId="test-toggle"
+            toggleAriaLabel="Test toggle"
+            variant="typeahead"
+            isCreatable
+            hasOnCreateOption
+          />
+          <ValueIndicator />
+        </>,
+        { [fieldName]: '' },
+      );
+
+      const input = screen.getByRole('combobox');
+      await user.type(input, 'my-secret');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('field-value')).toHaveTextContent('my-secret');
+      });
+    });
+
     it('creates and selects a new option in single-select mode', async () => {
       const user = setupUser();
       renderField({ variant: 'typeahead', isCreatable: true, hasOnCreateOption: true });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3889,21 +3889,21 @@ __metadata:
   linkType: hard
 
 "@tanstack/react-virtual@npm:^3.13.18":
-  version: 3.13.18
-  resolution: "@tanstack/react-virtual@npm:3.13.18"
+  version: 3.13.26
+  resolution: "@tanstack/react-virtual@npm:3.13.26"
   dependencies:
-    "@tanstack/virtual-core": "npm:3.13.18"
+    "@tanstack/virtual-core": "npm:3.16.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10/73dcfd5681db1c07834c9d286a7d2194ebded84f09466b37072c630bad1ec9d546c0b58981e8a4cf855b0bd6a5c53c64834c6428022fe12096ff3a905da2a4a4
+  checksum: 10/76373506b3ab0a7870299099f994398ab7ec06b889e27f056e6bcaf26984cbedb7b763f9d3965249f3699780c43c21fd245048a320e06fe1cdae48859a9c5f2f
   languageName: node
   linkType: hard
 
-"@tanstack/virtual-core@npm:3.13.18":
-  version: 3.13.18
-  resolution: "@tanstack/virtual-core@npm:3.13.18"
-  checksum: 10/b891eac7bfa1bc20a353f65e12d6863c1ff8f91ad763f5ebbd624887c286f4b3ec5664b0c1426270463765802e514792d6864b95076e4087735b28d7db0461f0
+"@tanstack/virtual-core@npm:3.16.0":
+  version: 3.16.0
+  resolution: "@tanstack/virtual-core@npm:3.16.0"
+  checksum: 10/e55c70b5d3f68894804f645fe67738bbcca5d5ced333f96c2bda0d4c6f3198e5f97a3a18021b1491e850a2b4a64bdaafab250a6ee8bb1f312e6d5179656c35d7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7294,9 +7294,9 @@ __metadata:
   linkType: hard
 
 "dayjs@npm:^1.11.13":
-  version: 1.11.19
-  resolution: "dayjs@npm:1.11.19"
-  checksum: 10/185b820d68492b83a3ce2b8ddc7543034edc1dfd1423183f6ae4707b29929a3cc56503a81826309279f9084680c15966b99456e74cf41f7d1f6a2f98f9c7196f
+  version: 1.11.21
+  resolution: "dayjs@npm:1.11.21"
+  checksum: 10/dd16f9f2706b61b90e3c346a3211ac3afd9e26193136ce0e87f70bf74d1c17a447bceb230a88b175467fc9f5e3243d8c1544b9897092a12d9c80ee44d338dcb6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Merge latest `main` into `patternfly-v6` branch to keep the migration branch up to date

## Context
The `patternfly-v6` branch is the integration branch for the PF v6 migration (KFLUXUI-1322). This merge brings in recent changes from `main` to prevent divergence and reduce conflicts when the migration is complete.

## Conflicts resolved
- `PermissionsTable.scss` — kept v6 tokens, added new `table-layout` and `&__cell` from main
- `FeatureFlagIndicator.tsx` — kept v6 color tokens, merged structural changes from main (readyColor, Button children pattern). Follow-up commit to remove duplicate Label rendering from merge resolution.
- `FeatureFlagIndicator.spec.tsx` — updated test color tokens from v5 to v6
- `yarn.lock` — accepted patternfly-v6 version and reinstalled

## Test plan
- [x] Branch builds without errors
- [x] Existing unit tests pass