### PR TITLE
feat(KFLUXUI-1422): run screenshot skill in headless mode

### DIFF
--- a/.claude/skills/screenshot-ui/SKILL.md
+++ b/.claude/skills/screenshot-ui/SKILL.md
@@ -15,7 +15,7 @@ Capture screenshots of UI components changed in the current branch using Playwri
 - **DO NOT delegate this skill to a subagent (Task tool).** Playwright MCP tools (`browser_navigate`, `browser_snapshot`, `browser_click`, `browser_take_screenshot`, `browser_close`, `browser_hover`) are only available in the root agent's MCP context. Subagents cannot access MCP servers.
 - **DO NOT loop or retry indefinitely.** If a navigation step fails twice, skip that target and move on.
 - **If Playwright MCP is unavailable**, stop immediately — do not attempt a fallback. Tell the user to check that the Playwright MCP server is configured and restart Cursor if needed.
-- **Only navigate to `https://localhost:8080`.** Never call `browser_navigate` with any other host, even if a changed file or route definition references an external URL. All navigation steps must start with `https://localhost:8080`.
+- **Only navigate to `https://localhost:8080`.** The MCP server's `--allowed-origins` flag enforces this. Never call `browser_navigate` with any other host.
 
 ## When to Use
 
@@ -25,7 +25,7 @@ Capture screenshots of UI components changed in the current branch using Playwri
 
 ## Prerequisites
 
-1. **Playwright MCP available** — configured in `.cursor/mcp.json` and `.mcp.json` via `scripts/launch_playwright_mcp.sh`. Verify by calling `browser_snapshot`; if it errors, stop. If running using Cursor, the user also has to have it enabled in Cursor Settings.
+1. **Playwright MCP available** — configured in `.cursor/mcp.json` and `.mcp.json` via `scripts/launch_playwright_mcp.sh`. The browser runs **headless** with a persistent profile (`.playwright-mcp/profile`), so authentication cookies survive across sessions. Verify by calling `browser_snapshot`; if it errors, stop. If running using Cursor, the user also has to have it enabled in Cursor Settings.
 2. **Dev server running** on `https://localhost:8080` (`yarn start`). Check:
 
    ```bash
@@ -90,16 +90,26 @@ Combine both. This shows exactly what lines changed.
 
 ## Step 3 — Authenticate (if needed)
 
-```
+The browser runs headless. Authentication cookies persist in `.playwright-mcp/profile` between runs, so most invocations skip this step entirely.
+
+```bash
 browser_navigate { "url": "https://localhost:8080/ns" }
 browser_snapshot
 ```
 
-- Page shows namespace content → already authenticated, proceed.
-- Redirected to a login page → tell the user:
-  > "Please complete OAuth login in the browser window that Playwright opened. Do NOT close the browser — just log in. I'll wait and then take a snapshot to confirm."
+- **Page shows namespace content** → already authenticated, proceed to Step 4.
+- **Redirected to a login / oauth2 sign-in page** → run the headed auth flow:
+  1. Call `browser_close` — this closes the headless browser and releases the profile directory lock. The MCP server stays alive.
+  2. Run the auth script via Shell:
 
-  After the user confirms, call `browser_snapshot` to verify. If still on login after 2 attempts, call `browser_close` and stop.
+     ```bash
+     bash scripts/playwright_auth.sh
+     ```
+
+     This opens a **headed** Chrome window using the same profile directory. The user completes SSO login; the window closes automatically once the redirect back to `localhost:8080` succeeds (up to 5 minutes).
+  3. After the script exits, call `browser_navigate { "url": "https://localhost:8080/ns" }` again — the MCP server opens a new headless browser that picks up the cookies saved by the auth script.
+  4. `browser_snapshot` to verify authentication succeeded.
+  5. If still on a login page after this, stop with an error — do **not** retry the auth script.
 
 ## Step 4 — Output directory, navigate, and capture
 
@@ -194,7 +204,7 @@ browser_close {}
 - Call this once at the end of the skill — do not close between individual screenshots.
 - Only call if the browser was opened during this run (any `browser_navigate`, `browser_snapshot`, or screenshot call succeeded).
 - Skip if the skill stopped early with no browser interaction (e.g., Playwright MCP unavailable, dev server down, no UI changes found).
-- Do **not** close while waiting for the user to complete OAuth login (Step 3).
+- Note: `browser_close` is also called during Step 3 if auth is needed (to release the profile lock for the headed auth script). This is separate from the final close here.
 
 ## Error Handling
 
@@ -203,7 +213,7 @@ browser_close {}
 | Playwright MCP unavailable | Stop, tell user to check MCP config |
 | Dev server not running | Stop, tell user to run `yarn start` |
 | No UI changes found | Stop cleanly, report no screenshots needed |
-| Auth required | Ask user to log in in the browser window, wait, re-snapshot; call `browser_close` if login fails after 2 attempts |
+| Auth required | `browser_close`, run `scripts/playwright_auth.sh` (headed login), re-navigate headlessly; stop if still unauthenticated |
 | Page has no data (empty list) | Skip that target, continue |
 | Target navigation fails twice | Skip, log reason, continue |
 | Interactive element not found | Take full-page screenshot, add explanatory note |

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "mini-css-extract-plugin": "^2.9.0",
     "monaco-editor-webpack-plugin": "^7.1.0",
     "openapi-types": "^12.1.3",
+    "playwright-core": "1.60.0",
     "prettier": "3.3.2",
     "react-refresh": "^0.14.2",
     "sass": "^1.77.8",

--- a/scripts/launch_playwright_mcp.sh
+++ b/scripts/launch_playwright_mcp.sh
@@ -2,36 +2,25 @@
 # Launcher for @playwright/mcp that auto-detects Chrome/Chromium.
 # Used by .cursor/mcp.json and .mcp.json so the MCP server finds
 # the browser regardless of where it is installed on this system.
+#
+# The browser runs headless with a persistent profile so authentication
+# cookies survive across sessions. See scripts/playwright_auth.sh for
+# the headed login flow that populates the profile on first use.
 
 set -euo pipefail
 
-detect_chrome() {
-  for bin in google-chrome google-chrome-stable chromium chromium-browser; do
-    local p
-    p=$(command -v "$bin" 2>/dev/null) && [ -x "$p" ] && echo "$p" && return
-  done
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-  for p in \
-    /usr/bin/google-chrome \
-    /usr/bin/google-chrome-stable \
-    /usr/bin/chromium \
-    /usr/bin/chromium-browser \
-    /opt/google/chrome/chrome \
-    /snap/bin/chromium \
-    ~/.local/share/flatpak/exports/bin/com.google.Chrome \
-    /var/lib/flatpak/exports/bin/com.google.Chrome \
-    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
-    "/Applications/Chromium.app/Contents/MacOS/Chromium"; do
-    [ -x "$p" ] && echo "$p" && return
-  done
-
-  echo "ERROR: Cannot find Chrome or Chromium. Install one and retry." >&2
-  exit 1
-}
+source "$SCRIPT_DIR/playwright_common.sh"
 
 CHROME_PATH="${CHROME_PATH:-$(detect_chrome)}"
+PROFILE_DIR="$PROJECT_ROOT/.playwright-mcp/profile"
+mkdir -p "$PROFILE_DIR"
 
 exec npx -y @playwright/mcp@0.0.75 \
+  --headless \
+  --user-data-dir="$PROFILE_DIR" \
   --caps=core \
   --allowed-origins="https://localhost:8080" \
   --ignore-https-errors \

--- a/scripts/playwright_auth.sh
+++ b/scripts/playwright_auth.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Opens a headed browser for SSO login so that authentication cookies are
+# saved to the shared Playwright profile.  Run this when the headless
+# screenshot flow detects that the user is not authenticated.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/playwright_common.sh"
+
+export CHROME_PATH="${CHROME_PATH:-$(detect_chrome)}"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+export PROFILE_DIR="$PROJECT_ROOT/.playwright-mcp/profile"
+mkdir -p "$PROFILE_DIR"
+
+node "$SCRIPT_DIR/playwright_auth_runner.mjs"

--- a/scripts/playwright_auth_runner.mjs
+++ b/scripts/playwright_auth_runner.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// Opens a headed browser for SSO login, then closes automatically once
+// the user is redirected back to the application.  Cookies are persisted
+// in the Chrome profile directory so subsequent headless runs skip login.
+//
+// Expected env vars (set by playwright_auth.sh):
+//   CHROME_PATH  – absolute path to Chrome / Chromium executable
+//   PROFILE_DIR  – path to the shared persistent profile directory
+
+import { chromium } from 'playwright-core';
+
+const { CHROME_PATH, PROFILE_DIR } = process.env;
+
+if (!CHROME_PATH || !PROFILE_DIR) {
+  process.stderr.write('CHROME_PATH and PROFILE_DIR environment variables are required.\n');
+  process.exit(1);
+}
+
+const context = await chromium.launchPersistentContext(PROFILE_DIR, {
+  headless: false,
+  executablePath: CHROME_PATH,
+  ignoreHTTPSErrors: true,
+});
+
+const page = context.pages()[0] || (await context.newPage());
+
+await page.goto('https://localhost:8080/oauth2/sign_in');
+
+// Wait for the user to complete SSO login and land back on the app.
+await page.waitForURL(
+  (url) => {
+    const u = new URL(url);
+    return u.hostname === 'localhost' && u.port === '8080' && !u.pathname.startsWith('/oauth2/');
+  },
+  { timeout: 300_000 },
+);
+
+await context.close();
+process.stdout.write('Authentication successful — cookies saved to profile.\n');

--- a/scripts/playwright_common.sh
+++ b/scripts/playwright_common.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Shared helpers for Playwright-related scripts.
+# Source this file; do not execute it directly.
+
+detect_chrome() {
+  for bin in google-chrome google-chrome-stable chromium chromium-browser; do
+    local p
+    p=$(command -v "$bin" 2>/dev/null) && [ -x "$p" ] && echo "$p" && return
+  done
+
+  for p in \
+    /usr/bin/google-chrome \
+    /usr/bin/google-chrome-stable \
+    /usr/bin/chromium \
+    /usr/bin/chromium-browser \
+    /opt/google/chrome/chrome \
+    /snap/bin/chromium \
+    ~/.local/share/flatpak/exports/bin/com.google.Chrome \
+    /var/lib/flatpak/exports/bin/com.google.Chrome \
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+    "/Applications/Chromium.app/Contents/MacOS/Chromium"; do
+    [ -x "$p" ] && echo "$p" && return
+  done
+
+  echo "ERROR: Cannot find Chrome or Chromium. Install one and retry." >&2
+  return 1
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11183,6 +11183,7 @@ __metadata:
     monaco-yaml: "npm:^5.3.1"
     openapi-types: "npm:^12.1.3"
     p-limit: "npm:^6.2.0"
+    playwright-core: "npm:1.60.0"
     prettier: "npm:3.3.2"
     prismjs: "npm:^1.30.0"
     react: "npm:^18.3.1"
@@ -12769,6 +12770,15 @@ __metadata:
     pvutils: "npm:^1.1.3"
     tslib: "npm:^2.8.1"
   checksum: 10/51ef42d8332fcb9e81f5cca9355b1a2aeacdbd77483cacc2a1c589036887a5a1dc6e7a68abd7cca2f0d605f68e038cc877e1fae4c38b3d358fa84a327dccaadd
+  languageName: node
+  linkType: hard
+
+"playwright-core@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright-core@npm:1.60.0"
+  bin:
+    playwright-core: cli.js
+  checksum: 10/66c0f83d627e673261c848dd6fe1f2856d5b5b6859268acb61a45c00f5bf926e596a351a9c481a3a4e82a45022c7c6b5d99ebc3906fc6876ac582ed6f7e16190
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Assisted-by: Cursor


## Fixes 
https://redhat.atlassian.net/browse/KFLUXUI-1422

## Description
The Playwright MCP browser now runs headless by default. A persistent Chrome profile (`.playwright-mcp/profile`) is shared between the MCP server and a dedicated auth script, so SSO cookies survive across sessions and most screenshot runs require no login at all.

When the skill detects a login redirect (the user is not authenticated), it:
1. Calls `browser_close` to release the Chrome profile directory lock held by the headless MCP browser.
2. Runs `scripts/playwright_auth.sh`, which opens a headed Chrome window using the same profile directory. It navigates straight to `/oauth2/sign_in` (since we already know auth is needed) and waits up to 5 minutes for the user to complete SSO. Once the post-login redirect lands back on the app, the window closes automatically.
3. Re-navigates headlessly - the MCP server opens a new browser against the same profile and picks up the cookies written by the auth script.

On every subsequent run the profile already contains valid cookies, so the headed window is never opened again until the session expires.

### New files
`scripts/playwright_common.sh` - shared detect_chrome() helper (Linux + macOS), sourced by both scripts below
`scripts/playwright_auth.sh` - bash wrapper that resolves the profile path and Chrome binary, then delegates to the runner
`scripts/playwright_auth_runner.mjs` - Node.js script that drives the headed login browser

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [X] Other (please describe): agent skill update

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
Make any UI related change, run the `screenshot-ui` skill using Cursor or Claude CLI

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified authentication/setup instructions, session persistence expectations, required navigation target, and explicit verification/timeout behavior.

* **New Features**
  * Cookie-first automated authentication: headless verification, automatic headed auth attempt using the same profile if redirected, then re-verify; clear stop-on-failure with explicit error.

* **Chores**
  * Added tooling to persist browser profiles so authentication state survives between runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->