### PR TITLE
Fix .codecov.yml: standardize coverage config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,23 +2,20 @@ codecov:
   require_ci_to_pass: true
 
 coverage:
-  precision: 2
-  round: down
-  range: "60...80"
   status:
     project:
       default:
         target: auto
         threshold: 1%
+        informational: true
     patch:
       default:
         target: 85%
-        threshold: 5%
+        informational: true
 
 ignore:
   - "**/*__data__*/*.ts"
 
 comment:
   layout: "reach,diff,flags,files,footer"
-  behavior: default
-  require_changes: false
+  require_changes: true


### PR DESCRIPTION
## Summary

Updates codecov configuration to Konflux standard:
- Preserves existing CI gate setting (`require_ci_to_pass: true`)
- Preserves existing 85% patch target (above the 80% org minimum)
- Adds `informational: true` to project and patch status (won't block CI)
- Preserved ignore patterns

### Why informational: true?

Part of org-wide codecov standardization ([KFLUXDP-1020](https://redhat.atlassian.net/browse/KFLUXDP-1020)). Coverage checks are set to `informational: true` so they **never block CI or prevent merging** — they only provide visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KFLUXDP-1020]: https://redhat.atlassian.net/browse/KFLUXDP-1020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage configuration to refine reporting thresholds and enhance pull request review settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->