### PR TITLE
fix(KFLUXUI-1405): restore empty state images lost in PF v6 migration

### DIFF
--- a/src/shared/components/empty-state/AppEmptyState.tsx
+++ b/src/shared/components/empty-state/AppEmptyState.tsx
@@ -18,21 +18,24 @@ const AppEmptyState: React.FC<React.PropsWithChildren<AppEmptyStateProps>> = ({
   isXl,
   ...props
 }) => {
-  const EmptyStateImage =
-    typeof emptyStateImg === 'string'
-      ? () => (
-          <img
-            src={emptyStateImg}
-            className={css('app-empty-state__icon', isXl && 'm-is-xl')}
-            alt=""
-          />
-        )
-      : () => {
-          const SvgComponent = emptyStateImg as unknown as React.ComponentType<
-            React.SVGProps<SVGSVGElement>
-          >;
-          return <SvgComponent className={css('app-empty-state__icon', isXl && 'm-is-xl')} />;
-        };
+  const EmptyStateImage = React.useMemo(
+    () =>
+      typeof emptyStateImg === 'string'
+        ? () => (
+            <img
+              src={emptyStateImg}
+              className={css('app-empty-state__icon', isXl && 'm-is-xl')}
+              alt=""
+            />
+          )
+        : () => {
+            const SvgComponent = emptyStateImg as unknown as React.ComponentType<
+              React.SVGProps<SVGSVGElement>
+            >;
+            return <SvgComponent className={css('app-empty-state__icon', isXl && 'm-is-xl')} />;
+          },
+    [emptyStateImg, isXl],
+  );
   return (
     <EmptyState
       headingLevel="h3"

--- a/src/shared/components/empty-state/AppEmptyState.tsx
+++ b/src/shared/components/empty-state/AppEmptyState.tsx
@@ -14,16 +14,36 @@ const AppEmptyState: React.FC<React.PropsWithChildren<AppEmptyStateProps>> = ({
   className,
   title,
   children,
+  emptyStateImg,
+  isXl,
   ...props
-}) => (
-  <EmptyState
-    headingLevel="h3"
-    titleText={<>{title}</>}
-    className={css('app-empty-state m-is-top-level', className)}
-    {...props}
-  >
-    <EmptyStateFooter>{children}</EmptyStateFooter>
-  </EmptyState>
-);
+}) => {
+  const EmptyStateImage =
+    typeof emptyStateImg === 'string'
+      ? () => (
+          <img
+            src={emptyStateImg}
+            className={css('app-empty-state__icon', isXl && 'm-is-xl')}
+            alt=""
+          />
+        )
+      : () => {
+          const SvgComponent = emptyStateImg as unknown as React.ComponentType<
+            React.SVGProps<SVGSVGElement>
+          >;
+          return <SvgComponent className={css('app-empty-state__icon', isXl && 'm-is-xl')} />;
+        };
+  return (
+    <EmptyState
+      headingLevel="h3"
+      titleText={<>{title}</>}
+      icon={EmptyStateImage}
+      className={css('app-empty-state m-is-top-level', className)}
+      {...props}
+    >
+      <EmptyStateFooter>{children}</EmptyStateFooter>
+    </EmptyState>
+  );
+};
 
 export default AppEmptyState;

--- a/src/shared/components/empty-state/AppEmptyState.tsx
+++ b/src/shared/components/empty-state/AppEmptyState.tsx
@@ -39,7 +39,7 @@ const AppEmptyState: React.FC<React.PropsWithChildren<AppEmptyStateProps>> = ({
   return (
     <EmptyState
       headingLevel="h3"
-      titleText={<>{title}</>}
+      titleText={title}
       icon={EmptyStateImage}
       className={css('app-empty-state m-is-top-level', className)}
       {...props}

--- a/src/shared/components/empty-state/__tests__/AppEmptyState.spec.tsx
+++ b/src/shared/components/empty-state/__tests__/AppEmptyState.spec.tsx
@@ -46,6 +46,15 @@ describe('AppEmptyState', () => {
     expect(screen.getByTestId('mock-svg')).toHaveClass('m-is-xl');
   });
 
+  it('should not apply xl class when isXl is not provided', () => {
+    render(
+      <AppEmptyState emptyStateImg={MockSvg} title="Default test">
+        <p>body</p>
+      </AppEmptyState>,
+    );
+    expect(screen.getByTestId('mock-svg')).not.toHaveClass('m-is-xl');
+  });
+
   it('should render children in the footer', () => {
     render(
       <AppEmptyState emptyStateImg={MockSvg} title="Footer test">

--- a/src/shared/components/empty-state/__tests__/AppEmptyState.spec.tsx
+++ b/src/shared/components/empty-state/__tests__/AppEmptyState.spec.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import AppEmptyState from '../AppEmptyState';
+
+const MockSvgComponent = (props: SVGSVGElement) => (
+  <svg data-test="mock-svg" {...(props as unknown as React.SVGProps<SVGSVGElement>)} />
+);
+const MockSvg = MockSvgComponent as unknown as React.ComponentType<SVGSVGElement>;
+
+describe('AppEmptyState', () => {
+  it('should render the title', () => {
+    render(
+      <AppEmptyState emptyStateImg={MockSvg} title="Test title">
+        <p>body</p>
+      </AppEmptyState>,
+    );
+    expect(screen.getByText('Test title')).toBeInTheDocument();
+  });
+
+  it('should render the icon when emptyStateImg is an SVG component', () => {
+    render(
+      <AppEmptyState emptyStateImg={MockSvg} title="SVG test">
+        <p>body</p>
+      </AppEmptyState>,
+    );
+    expect(screen.getByTestId('mock-svg')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-svg')).toHaveClass('app-empty-state__icon');
+  });
+
+  it('should render the icon when emptyStateImg is a string URL', () => {
+    render(
+      <AppEmptyState emptyStateImg="/test-image.png" title="URL test">
+        <p>body</p>
+      </AppEmptyState>,
+    );
+    const img = document.querySelector('img[src="/test-image.png"]');
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveClass('app-empty-state__icon');
+  });
+
+  it('should apply xl class when isXl is true', () => {
+    render(
+      <AppEmptyState emptyStateImg={MockSvg} title="XL test" isXl>
+        <p>body</p>
+      </AppEmptyState>,
+    );
+    expect(screen.getByTestId('mock-svg')).toHaveClass('m-is-xl');
+  });
+
+  it('should render children in the footer', () => {
+    render(
+      <AppEmptyState emptyStateImg={MockSvg} title="Footer test">
+        <p>footer content</p>
+      </AppEmptyState>,
+    );
+    expect(screen.getByText('footer content')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Fixes
Fixes: https://issues.redhat.com/browse/KFLUXUI-1405

## Description

The PF v6 codemod removed the `emptyStateImg` prop usage from `AppEmptyState`, causing all empty state pages to lose their images. This re-wires the prop through the PF v6 `EmptyState` `icon` API, handling both string URLs and SVG components.

Added unit tests for `AppEmptyState` to prevent this regression in the future.

## Type of change

- [x] Bugfix

## Screen shots / Gifs for design review

**Before (image missing):**

<img width="1920" height="1011" alt="patternfly-v6-app-empty-state-ISSUE" src="https://github.com/user-attachments/assets/b9e74639-4bff-4f94-9832-4935a722a7d2" />

**After (image restored):**

<img width="1918" height="1015" alt="patternfly-v6-app-empty-state-FIX" src="https://github.com/user-attachments/assets/c2158ec7-d3f3-4809-b49a-3904e8d5faaa" />


## How to test or reproduce?

- Navigate to any page that shows an empty state with an image (e.g. Releases tab with no releases, Applications list with no apps, Commits tab with no commits)
- Verify the image renders above the title text
- Run `yarn test -- src/shared/components/empty-state/__tests__/AppEmptyState.spec.tsx`

## Browser conformance:
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge