### PR TITLE
fix(KFLUXUI-1407): fix context switcher full-width dropdown and invisible tabs

### DIFF
--- a/src/AppRoot/AppRoot.tsx
+++ b/src/AppRoot/AppRoot.tsx
@@ -52,7 +52,7 @@ export const AppRoot: React.FC = () => {
         <ActivePageAlert />
         <SidePanelHost>
           {!showSwitcher ? (
-            <PageSection hasBodyWrapper={false} style={{ paddingBlock: 0 }} hasShadowBottom>
+            <PageSection style={{ paddingBlock: 0 }} hasShadowBottom>
               <NamespaceSwitcher />
             </PageSection>
           ) : null}

--- a/src/AppRoot/AppRoot.tsx
+++ b/src/AppRoot/AppRoot.tsx
@@ -52,7 +52,7 @@ export const AppRoot: React.FC = () => {
         <ActivePageAlert />
         <SidePanelHost>
           {!showSwitcher ? (
-            <PageSection style={{ paddingBlock: 0 }} hasShadowBottom>
+            <PageSection className="pf-v6-u-py-sm" hasShadowBottom>
               <NamespaceSwitcher />
             </PageSection>
           ) : null}

--- a/src/shared/components/ContextSwitcher/ContextSwitcher.scss
+++ b/src/shared/components/ContextSwitcher/ContextSwitcher.scss
@@ -1,10 +1,6 @@
 .context-switcher {
   z-index: var(--pf-t--global--z-index--md);
 
-  &__dropdown {
-    padding-left: 0;
-    padding-right: 0.6rem;
-  }
   &__menu {
     --pf-v6-c-menu--Width: 360px;
 

--- a/src/shared/components/ContextSwitcher/ContextSwitcher.spec.tsx
+++ b/src/shared/components/ContextSwitcher/ContextSwitcher.spec.tsx
@@ -86,6 +86,7 @@ describe('ContextSwitcher', () => {
       expect.objectContaining({ lastTab: { resource: 0 } }),
     );
 
+    act(() => screen.getByText('All').click());
     act(() => screen.getByText('Test 1').click());
     expect(setStorageMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/shared/components/ContextSwitcher/ContextSwitcher.tsx
+++ b/src/shared/components/ContextSwitcher/ContextSwitcher.tsx
@@ -220,6 +220,7 @@ export const ContextSwitcher: React.FC<React.PropsWithChildren<ContextSwitcherPr
               />
             </MenuSearchInput>
           </MenuSearch>
+          {/* Tabs must be outside MenuContent to avoid being clipped by PF v6's overflow:hidden */}
           <Tabs activeKey={activeTab} onSelect={onTabChange} isFilled>
             <Tab eventKey={ContextTab.Recent} title={<TabTitleText>Recent</TabTitleText>} />
             <Tab eventKey={ContextTab.All} title={<TabTitleText>All</TabTitleText>} />

--- a/src/shared/components/ContextSwitcher/ContextSwitcher.tsx
+++ b/src/shared/components/ContextSwitcher/ContextSwitcher.tsx
@@ -169,7 +169,6 @@ export const ContextSwitcher: React.FC<React.PropsWithChildren<ContextSwitcherPr
     <MenuToggle
       ref={defaultToggleRef}
       id="toggle-context-switcher"
-      className="context-switcher__dropdown"
       aria-label="toggle context switcher menu"
       onClick={() => setIsOpen((val) => !val)}
       variant="plain"

--- a/src/shared/components/ContextSwitcher/ContextSwitcher.tsx
+++ b/src/shared/components/ContextSwitcher/ContextSwitcher.tsx
@@ -220,23 +220,20 @@ export const ContextSwitcher: React.FC<React.PropsWithChildren<ContextSwitcherPr
               />
             </MenuSearchInput>
           </MenuSearch>
+          <Tabs activeKey={activeTab} onSelect={onTabChange} isFilled>
+            <Tab eventKey={ContextTab.Recent} title={<TabTitleText>Recent</TabTitleText>} />
+            <Tab eventKey={ContextTab.All} title={<TabTitleText>All</TabTitleText>} />
+          </Tabs>
           <MenuContent menuHeight={`${menuHeights[activeMenu]}px`}>
-            <Tabs activeKey={activeTab} onSelect={onTabChange} isFilled>
-              <Tab eventKey={ContextTab.Recent} title={<TabTitleText>Recent</TabTitleText>}>
-                <MenuList>
-                  {filteredRecentItems.map((item) => (
+            <MenuList>
+              {activeTab === ContextTab.Recent
+                ? filteredRecentItems.map((item) => (
+                    <ContextMenuListItem key={item.key} item={item} />
+                  ))
+                : filteredAllItems.map((item) => (
                     <ContextMenuListItem key={item.key} item={item} />
                   ))}
-                </MenuList>
-              </Tab>
-              <Tab eventKey={ContextTab.All} title={<TabTitleText>All</TabTitleText>}>
-                <MenuList>
-                  {filteredAllItems.map((item) => (
-                    <ContextMenuListItem key={item.key} item={item} />
-                  ))}
-                </MenuList>
-              </Tab>
-            </Tabs>
+            </MenuList>
           </MenuContent>
           {footer && <MenuFooter>{footer}</MenuFooter>}
         </Menu>

--- a/src/shared/providers/Namespace/NamespaceSwitcher.tsx
+++ b/src/shared/providers/Namespace/NamespaceSwitcher.tsx
@@ -45,7 +45,7 @@ export const NamespaceSwitcher: React.FC<
       selectedItem={{ key: selectedItem?.metadata.name, name: selectedItem?.metadata.name }}
       onSelect={onSelect}
       toggle={(props) => (
-        <MenuToggle style={{ paddingInlineStart: 0 }} variant="plainText" {...props}>
+        <MenuToggle variant="plainText" {...props}>
           Namespace: {namespace}
         </MenuToggle>
       )}

--- a/src/shared/providers/Namespace/NamespaceSwitcher.tsx
+++ b/src/shared/providers/Namespace/NamespaceSwitcher.tsx
@@ -44,7 +44,6 @@ export const NamespaceSwitcher: React.FC<
       menuItems={menuItems}
       selectedItem={{ key: selectedItem?.metadata.name, name: selectedItem?.metadata.name }}
       onSelect={onSelect}
-      footer={<></>}
       toggle={(props) => (
         <MenuToggle style={{ paddingInlineStart: 0 }} variant="plainText" {...props}>
           Namespace: {namespace}


### PR DESCRIPTION
## Fixes

Fixes: https://redhat.atlassian.net/browse/KFLUXUI-1407
Fixes: https://redhat.atlassian.net/browse/KFLUXUI-1408

## Description

Two PF v6 regressions in the context switcher (namespace and application switchers):

1. **Dropdown rendered full-width** instead of a compact floating menu — caused by `hasBodyWrapper={false}` on the `PageSection` wrapping the `NamespaceSwitcher`, which removed the inner container that gives the `MenuContainer` a proper positioning context.

2. **Tabs (Recent/All) became invisible** when the menu had many items — caused by `Tabs` being nested inside `MenuContent`, which has `overflow: hidden` and `max-height` in PF v6. Moved `Tabs` outside `MenuContent` and switched from tab panels to conditional rendering of the active tab's items.

Updated the unit test to match the new conditional rendering behavior.

## Type of change

- [x] Bugfix

## Screen recordings for design review

**Before (both switchers — full-width dropdown, invisible tabs):**
<!-- paste screen recording -->

https://github.com/user-attachments/assets/15ecad52-ba6e-40db-9c32-d0f905192833

**After (both switchers — compact dropdown, visible tabs):**
<!-- paste screen recording -->

https://github.com/user-attachments/assets/0b368f59-001c-4918-ad85-cdfa08282bbc

## How to test or reproduce?

- Open the namespace switcher dropdown — verify it renders as a compact floating menu, not full-width
- Verify Recent/All tabs are visible and switchable
- Open the application switcher (on an app details page) — verify the same behavior
- Run `yarn test -- src/shared/components/ContextSwitcher/ContextSwitcher.spec.tsx`

## Browser conformance:
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured context switcher's tabbed menu layout to consolidate content filtering logic.
  * Updated namespace switcher wrapper styling configuration.

* **Tests**
  * Enhanced context switcher test flow to include additional tab navigation steps before item selection verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->