### PR TITLE
fix(KFLUXUI-1411, KFLUXUI-1412): fix PageLayout stretching to fill viewport

### DIFF
--- a/src/components/PageLayout/PageLayout.tsx
+++ b/src/components/PageLayout/PageLayout.tsx
@@ -30,7 +30,7 @@ const PageLayout: React.FC<React.PropsWithChildren<PageLayoutProps>> = ({
 }) => {
   return (
     <>
-      <PageGroup>
+      <PageGroup isFilled={false}>
         {breadcrumbs && (
           <PageBreadcrumb hasBodyWrapper={false}>
             {<BreadCrumbs breadcrumbs={breadcrumbs} />}


### PR DESCRIPTION
## Fixes
Fixes: https://issues.redhat.com/browse/KFLUXUI-1411
Fixes: https://issues.redhat.com/browse/KFLUXUI-1412

## Description

PF v6 defaults `PageGroup` `isFilled` to `true`, which causes the page header area (breadcrumbs, title, description) to stretch and push content below the fold. Setting `isFilled={false}` restores the expected compact layout.

## Type of change

- [x] Bugfix

## Screen recordings for design review

**Before (page header stretches, content pushed down):**
<!-- paste screen recording -->

https://github.com/user-attachments/assets/cda21946-d2f9-4471-aea5-f2bb382915f9

**After (compact header, content visible):**
<!-- paste screen recording -->

https://github.com/user-attachments/assets/c67d228a-739a-437b-99f6-7c07be51a2e6

## How to test or reproduce?

**KFLUXUI-1411 — Create Application page:**
- Navigate to the Create Application page (import flow)
- Verify the form content is aligned at the top of the page, not pushed to the bottom

**KFLUXUI-1412 — Namespaces page filter shift:**
- Go to the Namespaces page
- Type in the text filter input
- Verify the table content stays in place and does not jump/shift downward

## Browser conformance:
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge