### PR TITLE
fix(KFLUXUI-1404): restore side panel padding lost in PF v6 migration

### DIFF
--- a/src/components/Commits/CommitDetails/sidepanels/BuildSidePanel.tsx
+++ b/src/components/Commits/CommitDetails/sidepanels/BuildSidePanel.tsx
@@ -73,116 +73,114 @@ const BuildSidePanel: React.FC<React.PropsWithChildren<PipelineSidePanelBodyProp
 
   return (
     <>
-      <div className="commit-side-panel__head">
-        <DrawerHead data-test="build-side-panel-head">
-          <span className="commit-side-panel__head-title">
-            <Link
-              to={PIPELINE_RUNS_DETAILS_PATH.createPath({
-                workspaceName: namespace,
-                applicationName: workflowData.application,
-                pipelineRunName: pipelineRun.metadata.name,
-              })}
-            >
-              {pipelineRun.metadata.name}
-            </Link>
-            <StatusIconWithTextLabel status={workflowNode.getData().status} />
-          </span>
-          <span className="pf-v6-u-mt-xs commit-side-panel__subtext">
-            <PipelineIcon role="img" aria-label="Pipeline run" /> Pipeline run{' '}
-            <FeatureFlagIndicator flags={['taskruns-kubearchive']} />
-          </span>
-          <DrawerActions>
-            <DrawerCloseButton onClick={onClose} />
-          </DrawerActions>
-        </DrawerHead>
-        <DrawerPanelBody data-test="build-side-panel-body">
-          <DescriptionList
-            data-test="pipeline-run-details"
-            columnModifier={{
-              default: '2Col',
-            }}
+      <DrawerHead data-test="build-side-panel-head">
+        <span className="commit-side-panel__head-title">
+          <Link
+            to={PIPELINE_RUNS_DETAILS_PATH.createPath({
+              workspaceName: namespace,
+              applicationName: workflowData.application,
+              pipelineRunName: pipelineRun.metadata.name,
+            })}
           >
-            <DescriptionListGroup>
-              <DescriptionListTerm>Created at</DescriptionListTerm>
-              <DescriptionListDescription>
-                <Timestamp timestamp={pipelineRun.metadata?.creationTimestamp ?? '-'} />
-              </DescriptionListDescription>
-            </DescriptionListGroup>
-            <DescriptionListGroup>
-              <DescriptionListTerm>Duration</DescriptionListTerm>
-              <DescriptionListDescription>{duration ?? '-'}</DescriptionListDescription>
-            </DescriptionListGroup>
-            <DescriptionListGroup>
-              <DescriptionListTerm>Type</DescriptionListTerm>
-              <DescriptionListDescription>Build</DescriptionListDescription>
-            </DescriptionListGroup>
-            <DescriptionListGroup>
-              <DescriptionListTerm>Pipeline</DescriptionListTerm>
-              <DescriptionListDescription>
-                {pipelineRun.metadata?.labels[PipelineRunLabel.PIPELINE_NAME] ?? '-'}
-              </DescriptionListDescription>
-            </DescriptionListGroup>
-          </DescriptionList>
-          <DescriptionList
-            className="pf-v6-u-mt-lg"
-            data-test="pipeline-run-details"
-            columnModifier={{
-              default: '1Col',
-            }}
-          >
-            <DescriptionListGroup>
-              <DescriptionListTerm>Component</DescriptionListTerm>
-              <DescriptionListDescription>
-                {pipelineRun.metadata?.labels?.[PipelineRunLabel.COMPONENT] ? (
-                  pipelineRun.metadata?.labels?.[PipelineRunLabel.APPLICATION] ? (
-                    <Link
-                      to={COMPONENT_DETAILS_PATH.createPath({
-                        workspaceName: namespace,
-                        applicationName: pipelineRun.metadata.labels[PipelineRunLabel.APPLICATION],
-                        componentName: pipelineRun.metadata.labels[PipelineRunLabel.COMPONENT],
-                      })}
-                    >
-                      {pipelineRun.metadata.labels[PipelineRunLabel.COMPONENT]}
-                    </Link>
-                  ) : (
-                    pipelineRun.metadata.labels[PipelineRunLabel.COMPONENT]
-                  )
+            {pipelineRun.metadata.name}
+          </Link>
+          <StatusIconWithTextLabel status={workflowNode.getData().status} />
+        </span>
+        <span className="pf-v6-u-mt-xs commit-side-panel__subtext">
+          <PipelineIcon role="img" aria-label="Pipeline run" /> Pipeline run{' '}
+          <FeatureFlagIndicator flags={['taskruns-kubearchive']} />
+        </span>
+        <DrawerActions>
+          <DrawerCloseButton onClick={onClose} />
+        </DrawerActions>
+      </DrawerHead>
+      <DrawerPanelBody data-test="build-side-panel-body">
+        <DescriptionList
+          data-test="pipeline-run-details"
+          columnModifier={{
+            default: '2Col',
+          }}
+        >
+          <DescriptionListGroup>
+            <DescriptionListTerm>Created at</DescriptionListTerm>
+            <DescriptionListDescription>
+              <Timestamp timestamp={pipelineRun.metadata?.creationTimestamp ?? '-'} />
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Duration</DescriptionListTerm>
+            <DescriptionListDescription>{duration ?? '-'}</DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Type</DescriptionListTerm>
+            <DescriptionListDescription>Build</DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Pipeline</DescriptionListTerm>
+            <DescriptionListDescription>
+              {pipelineRun.metadata?.labels[PipelineRunLabel.PIPELINE_NAME] ?? '-'}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+        </DescriptionList>
+        <DescriptionList
+          className="pf-v6-u-mt-lg"
+          data-test="pipeline-run-details"
+          columnModifier={{
+            default: '1Col',
+          }}
+        >
+          <DescriptionListGroup>
+            <DescriptionListTerm>Component</DescriptionListTerm>
+            <DescriptionListDescription>
+              {pipelineRun.metadata?.labels?.[PipelineRunLabel.COMPONENT] ? (
+                pipelineRun.metadata?.labels?.[PipelineRunLabel.APPLICATION] ? (
+                  <Link
+                    to={COMPONENT_DETAILS_PATH.createPath({
+                      workspaceName: namespace,
+                      applicationName: pipelineRun.metadata.labels[PipelineRunLabel.APPLICATION],
+                      componentName: pipelineRun.metadata.labels[PipelineRunLabel.COMPONENT],
+                    })}
+                  >
+                    {pipelineRun.metadata.labels[PipelineRunLabel.COMPONENT]}
+                  </Link>
                 ) : (
-                  '-'
-                )}
-              </DescriptionListDescription>
-            </DescriptionListGroup>
-            {taskRunsLoaded && !taskRunsError && (
-              <ScanDescriptionListGroup taskRuns={taskRuns} hideIfNotFound />
-            )}
-            <DescriptionListGroup>
-              <DescriptionListDescription>
-                <Link
-                  to={PIPELINE_RUNS_LOG_PATH.createPath({
-                    workspaceName: namespace,
-                    applicationName: workflowData.application,
-                    pipelineRunName: pipelineRun.metadata.name,
-                  })}
-                >
-                  View logs
-                </Link>
-              </DescriptionListDescription>
-            </DescriptionListGroup>
-          </DescriptionList>
-          {results ? (
-            <div className="pf-v6-u-mt-lg">
-              <RunResultsList results={results} status={pipelineStatus} compressed />
-            </div>
-          ) : null}
-
-          {specParams?.length && (
-            <>
-              <Divider style={{ padding: 'var(--pf-t--global--spacer--lg)' }} />
-              <RunParamsList params={specParams} compressed />
-            </>
+                  pipelineRun.metadata.labels[PipelineRunLabel.COMPONENT]
+                )
+              ) : (
+                '-'
+              )}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          {taskRunsLoaded && !taskRunsError && (
+            <ScanDescriptionListGroup taskRuns={taskRuns} hideIfNotFound />
           )}
-        </DrawerPanelBody>
-      </div>
+          <DescriptionListGroup>
+            <DescriptionListDescription>
+              <Link
+                to={PIPELINE_RUNS_LOG_PATH.createPath({
+                  workspaceName: namespace,
+                  applicationName: workflowData.application,
+                  pipelineRunName: pipelineRun.metadata.name,
+                })}
+              >
+                View logs
+              </Link>
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+        </DescriptionList>
+        {results ? (
+          <div className="pf-v6-u-mt-lg">
+            <RunResultsList results={results} status={pipelineStatus} compressed />
+          </div>
+        ) : null}
+
+        {specParams?.length && (
+          <>
+            <Divider style={{ padding: 'var(--pf-t--global--spacer--lg)' }} />
+            <RunParamsList params={specParams} compressed />
+          </>
+        )}
+      </DrawerPanelBody>
     </>
   );
 };

--- a/src/components/Commits/CommitDetails/sidepanels/IntegrationTestSidePanel.tsx
+++ b/src/components/Commits/CommitDetails/sidepanels/IntegrationTestSidePanel.tsx
@@ -66,62 +66,102 @@ const IntegrationTestSidePanel: React.FC<
 
   return (
     <>
-      <div className="commit-side-panel__head">
-        <DrawerHead data-test="int-test-side-panel-head">
-          <span className="commit-side-panel__head-title">
-            {integrationTestPipeline ? (
-              <Link
-                to={INTEGRATION_TEST_DETAILS_PATH.createPath({
-                  applicationName: workflowData.application,
-                  workspaceName: namespace,
-                  integrationTestName: workflowNode.getLabel(),
-                })}
-              >
-                {workflowNode.getLabel()}
-              </Link>
-            ) : (
+      <DrawerHead data-test="int-test-side-panel-head">
+        <span className="commit-side-panel__head-title">
+          {integrationTestPipeline ? (
+            <Link
+              to={INTEGRATION_TEST_DETAILS_PATH.createPath({
+                applicationName: workflowData.application,
+                workspaceName: namespace,
+                integrationTestName: workflowNode.getLabel(),
+              })}
+            >
+              {workflowNode.getLabel()}
+            </Link>
+          ) : (
+            workflowNode.getLabel()
+          )}
+          <StatusIconWithTextLabel status={workflowNode.getData().status} />
+        </span>
+        <span className="pf-v6-u-mt-xs commit-side-panel__subtext">
+          <PipelineIcon role="img" aria-label="Pipeline run" /> Integration test{' '}
+          <FeatureFlagIndicator flags={['taskruns-kubearchive']} />
+        </span>
+        <DrawerActions>
+          <DrawerCloseButton onClick={onClose} />
+        </DrawerActions>
+      </DrawerHead>
+      <DrawerPanelBody data-test="int-test-side-panel-body">
+        <DescriptionList
+          data-test="pipeline-run-details"
+          columnModifier={{
+            default: '2Col',
+          }}
+        >
+          <DescriptionListGroup>
+            <DescriptionListTerm>Started</DescriptionListTerm>
+            <DescriptionListDescription>
+              <Timestamp timestamp={integrationTestPipeline?.metadata?.creationTimestamp ?? '-'} />
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Duration</DescriptionListTerm>
+            <DescriptionListDescription>{duration ?? '-'}</DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Type</DescriptionListTerm>
+            <DescriptionListDescription>Test</DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Pipeline</DescriptionListTerm>
+            <DescriptionListDescription>
+              {integrationTestPipeline?.metadata?.namespace ?? '-'}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+        </DescriptionList>
+        <DescriptionList
+          className="pf-v6-u-mt-lg"
+          data-test="pipeline-run-details"
+          columnModifier={{
+            default: '1Col',
+          }}
+        >
+          <DescriptionListGroup>
+            <DescriptionListTerm>Component</DescriptionListTerm>
+            <DescriptionListDescription>
+              {integrationTestPipeline?.metadata?.labels?.[PipelineRunLabel.COMPONENT] ? (
+                integrationTestPipeline?.metadata?.labels?.[PipelineRunLabel.APPLICATION] ? (
+                  <Link
+                    to={COMPONENT_DETAILS_PATH.createPath({
+                      applicationName:
+                        integrationTestPipeline.metadata.labels[PipelineRunLabel.APPLICATION],
+                      componentName:
+                        integrationTestPipeline.metadata.labels[PipelineRunLabel.COMPONENT],
+                      workspaceName: namespace,
+                    })}
+                  >
+                    {integrationTestPipeline.metadata.labels[PipelineRunLabel.COMPONENT]}
+                  </Link>
+                ) : (
+                  integrationTestPipeline?.metadata.labels[PipelineRunLabel.COMPONENT]
+                )
+              ) : (
+                '-'
+              )}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <CommitIntegrationTestsList
+            componentName={integrationTestPipeline?.metadata?.labels?.[PipelineRunLabel.COMPONENT]}
+            integrationTestScenario={
+              integrationTestPipeline?.metadata?.labels?.[PipelineRunLabel.TEST_SERVICE_SCENARIO] ??
               workflowNode.getLabel()
-            )}
-            <StatusIconWithTextLabel status={workflowNode.getData().status} />
-          </span>
-          <span className="pf-v6-u-mt-xs commit-side-panel__subtext">
-            <PipelineIcon role="img" aria-label="Pipeline run" /> Integration test{' '}
-            <FeatureFlagIndicator flags={['taskruns-kubearchive']} />
-          </span>
-          <DrawerActions>
-            <DrawerCloseButton onClick={onClose} />
-          </DrawerActions>
-        </DrawerHead>
-        <DrawerPanelBody data-test="int-test-side-panel-body">
-          <DescriptionList
-            data-test="pipeline-run-details"
-            columnModifier={{
-              default: '2Col',
-            }}
-          >
-            <DescriptionListGroup>
-              <DescriptionListTerm>Started</DescriptionListTerm>
-              <DescriptionListDescription>
-                <Timestamp
-                  timestamp={integrationTestPipeline?.metadata?.creationTimestamp ?? '-'}
-                />
-              </DescriptionListDescription>
-            </DescriptionListGroup>
-            <DescriptionListGroup>
-              <DescriptionListTerm>Duration</DescriptionListTerm>
-              <DescriptionListDescription>{duration ?? '-'}</DescriptionListDescription>
-            </DescriptionListGroup>
-            <DescriptionListGroup>
-              <DescriptionListTerm>Type</DescriptionListTerm>
-              <DescriptionListDescription>Test</DescriptionListDescription>
-            </DescriptionListGroup>
-            <DescriptionListGroup>
-              <DescriptionListTerm>Pipeline</DescriptionListTerm>
-              <DescriptionListDescription>
-                {integrationTestPipeline?.metadata?.namespace ?? '-'}
-              </DescriptionListDescription>
-            </DescriptionListGroup>
-          </DescriptionList>
+            }
+          />
+          {integrationTestPipeline && taskRunsLoaded && !taskRunsError ? (
+            <ScanDescriptionListGroup taskRuns={taskRuns} hideIfNotFound showLogsLink />
+          ) : null}
+        </DescriptionList>
+        {Object.keys(pipelineRunFailed).length > 0 && (
           <DescriptionList
             className="pf-v6-u-mt-lg"
             data-test="pipeline-run-details"
@@ -130,89 +170,42 @@ const IntegrationTestSidePanel: React.FC<
             }}
           >
             <DescriptionListGroup>
-              <DescriptionListTerm>Component</DescriptionListTerm>
+              <DescriptionListTerm>Message</DescriptionListTerm>
               <DescriptionListDescription>
-                {integrationTestPipeline?.metadata?.labels?.[PipelineRunLabel.COMPONENT] ? (
-                  integrationTestPipeline?.metadata?.labels?.[PipelineRunLabel.APPLICATION] ? (
-                    <Link
-                      to={COMPONENT_DETAILS_PATH.createPath({
-                        applicationName:
-                          integrationTestPipeline.metadata.labels[PipelineRunLabel.APPLICATION],
-                        componentName:
-                          integrationTestPipeline.metadata.labels[PipelineRunLabel.COMPONENT],
-                        workspaceName: namespace,
-                      })}
-                    >
-                      {integrationTestPipeline.metadata.labels[PipelineRunLabel.COMPONENT]}
-                    </Link>
-                  ) : (
-                    integrationTestPipeline?.metadata.labels[PipelineRunLabel.COMPONENT]
-                  )
-                ) : (
-                  '-'
-                )}
+                {pipelineRunFailed.title ?? '-'}
               </DescriptionListDescription>
             </DescriptionListGroup>
-            <CommitIntegrationTestsList
-              componentName={
-                integrationTestPipeline?.metadata?.labels?.[PipelineRunLabel.COMPONENT]
-              }
-              integrationTestScenario={
-                integrationTestPipeline?.metadata?.labels?.[
-                  PipelineRunLabel.TEST_SERVICE_SCENARIO
-                ] ?? workflowNode.getLabel()
-              }
-            />
-            {integrationTestPipeline && taskRunsLoaded && !taskRunsError ? (
-              <ScanDescriptionListGroup taskRuns={taskRuns} hideIfNotFound showLogsLink />
-            ) : null}
+            <DescriptionListGroup>
+              <DescriptionListTerm>Log snippet</DescriptionListTerm>
+              <DescriptionListDescription>
+                <CodeBlock>
+                  <CodeBlockCode id="code-content">
+                    {pipelineRunFailed.staticMessage ?? '-'}
+                  </CodeBlockCode>
+                </CodeBlock>
+                {integrationTestPipeline ? (
+                  <Button
+                    variant="link"
+                    isInline
+                    component={(props) => (
+                      <Link
+                        {...props}
+                        to={PIPELINE_RUNS_LOG_PATH.createPath({
+                          applicationName: workflowData.application,
+                          pipelineRunName: integrationTestPipeline.metadata?.name,
+                          workspaceName: namespace,
+                        })}
+                      />
+                    )}
+                  >
+                    See logs
+                  </Button>
+                ) : null}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
           </DescriptionList>
-          {Object.keys(pipelineRunFailed).length > 0 && (
-            <DescriptionList
-              className="pf-v6-u-mt-lg"
-              data-test="pipeline-run-details"
-              columnModifier={{
-                default: '1Col',
-              }}
-            >
-              <DescriptionListGroup>
-                <DescriptionListTerm>Message</DescriptionListTerm>
-                <DescriptionListDescription>
-                  {pipelineRunFailed.title ?? '-'}
-                </DescriptionListDescription>
-              </DescriptionListGroup>
-              <DescriptionListGroup>
-                <DescriptionListTerm>Log snippet</DescriptionListTerm>
-                <DescriptionListDescription>
-                  <CodeBlock>
-                    <CodeBlockCode id="code-content">
-                      {pipelineRunFailed.staticMessage ?? '-'}
-                    </CodeBlockCode>
-                  </CodeBlock>
-                  {integrationTestPipeline ? (
-                    <Button
-                      variant="link"
-                      isInline
-                      component={(props) => (
-                        <Link
-                          {...props}
-                          to={PIPELINE_RUNS_LOG_PATH.createPath({
-                            applicationName: workflowData.application,
-                            pipelineRunName: integrationTestPipeline.metadata?.name,
-                            workspaceName: namespace,
-                          })}
-                        />
-                      )}
-                    >
-                      See logs
-                    </Button>
-                  ) : null}
-                </DescriptionListDescription>
-              </DescriptionListGroup>
-            </DescriptionList>
-          )}
-        </DrawerPanelBody>
-      </div>
+        )}
+      </DrawerPanelBody>
     </>
   );
 };

--- a/src/components/Commits/CommitDetails/sidepanels/ReleaseSidePanel.tsx
+++ b/src/components/Commits/CommitDetails/sidepanels/ReleaseSidePanel.tsx
@@ -33,45 +33,43 @@ const ReleaseSidePanel: React.FC<React.PropsWithChildren<ReleaseSidePanelBodyPro
 
   return (
     <>
-      <div className="commit-side-panel__head">
-        <DrawerHead data-test="release-side-panel-head">
-          <span className="commit-side-panel__head-title">
-            {release ? workflowNode.getLabel() : 'Release'}
-            {release ? <StatusIconWithTextLabel status={workflowNode.getData().status} /> : null}
-          </span>
-          <span className="pf-v6-u-mt-xs commit-side-panel__subtext">
-            <PipelineIcon role="img" aria-label="Pipeline run" /> Release
-          </span>
-          <DrawerActions>
-            <DrawerCloseButton onClick={onClose} />
-          </DrawerActions>
-        </DrawerHead>
-        <DrawerPanelBody data-test="release-side-panel-body">
-          <DescriptionList
-            data-test="pipeline-run-details"
-            columnModifier={{
-              default: '1Col',
-            }}
-          >
-            <DescriptionListGroup>
-              {!release ? <DescriptionListTerm>No releases set</DescriptionListTerm> : null}
-              <DescriptionListDescription>{RELEASE_DESC}</DescriptionListDescription>
-            </DescriptionListGroup>
-            <DescriptionListGroup>
-              <DescriptionListDescription>
-                <Link
-                  to={PIPELINE_RUNS_LIST_PATH.createPath({
-                    workspaceName: namespace,
-                    applicationName: workflowData.application,
-                  })}
-                >
-                  View pipeline runs
-                </Link>
-              </DescriptionListDescription>
-            </DescriptionListGroup>
-          </DescriptionList>
-        </DrawerPanelBody>
-      </div>
+      <DrawerHead data-test="release-side-panel-head">
+        <span className="commit-side-panel__head-title">
+          {release ? workflowNode.getLabel() : 'Release'}
+          {release ? <StatusIconWithTextLabel status={workflowNode.getData().status} /> : null}
+        </span>
+        <span className="pf-v6-u-mt-xs commit-side-panel__subtext">
+          <PipelineIcon role="img" aria-label="Pipeline run" /> Release
+        </span>
+        <DrawerActions>
+          <DrawerCloseButton onClick={onClose} />
+        </DrawerActions>
+      </DrawerHead>
+      <DrawerPanelBody data-test="release-side-panel-body">
+        <DescriptionList
+          data-test="pipeline-run-details"
+          columnModifier={{
+            default: '1Col',
+          }}
+        >
+          <DescriptionListGroup>
+            {!release ? <DescriptionListTerm>No releases set</DescriptionListTerm> : null}
+            <DescriptionListDescription>{RELEASE_DESC}</DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup>
+            <DescriptionListDescription>
+              <Link
+                to={PIPELINE_RUNS_LIST_PATH.createPath({
+                  workspaceName: namespace,
+                  applicationName: workflowData.application,
+                })}
+              >
+                View pipeline runs
+              </Link>
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+        </DescriptionList>
+      </DrawerPanelBody>
     </>
   );
 };

--- a/src/components/PipelineRun/PipelineRunDetailsView/sidepanels/TaskRunDetails.tsx
+++ b/src/components/PipelineRun/PipelineRunDetailsView/sidepanels/TaskRunDetails.tsx
@@ -64,7 +64,7 @@ const TaskRunDetails: React.FC<React.PropsWithChildren<Props>> = ({ taskRun, sta
 
       {specParams?.length && (
         <>
-          <Divider style={{ padding: 'var(--pf-t--global--spacer--lg)' }} />
+          <Divider className="pf-v6-u-mt-lg pf-v6-u-mb-lg" />
           <RunParamsList params={specParams} compressed />
         </>
       )}

--- a/src/components/PipelineRun/PipelineRunDetailsView/sidepanels/TaskRunPanel.scss
+++ b/src/components/PipelineRun/PipelineRunDetailsView/sidepanels/TaskRunPanel.scss
@@ -27,6 +27,7 @@
       min-height: 0;
       display: flex;
       flex-direction: column;
+      padding: var(--pf-t--global--spacer--md);
     }
   }
 }


### PR DESCRIPTION
## Fixes
Fixes: https://issues.redhat.com/browse/KFLUXUI-1404

## Description

PF v6 applies `DrawerHead` and `DrawerPanelBody` padding via direct-child CSS selectors (`drawer__panel-main > drawer__body`). Wrapper `<div>` elements in the side panel components broke this selector chain, causing padding to disappear.

**Commit side panels** (Build, IntegrationTest, Release): Removed the `<div className="commit-side-panel__head">` wrapper so `DrawerHead` and `DrawerPanelBody` are direct children of the drawer panel, restoring PF's native padding.

**TaskRunPanel**: Kept the wrapper divs (needed for flex layout of the logs tab) and applied padding explicitly via the `--pf-t--global--spacer--md` token to match PF's default.

Also replaced inline `style` on a `Divider` in `TaskRunDetails` with PF utility classes.

## Type of change

- [x] Bugfix

## Screen recordings for design review

**Before (missing padding in side panels):**
<!-- paste screen recording -->

https://github.com/user-attachments/assets/778da4a8-2460-4e4f-9d5e-a43f517f9fd1

**After (padding restored):**
<!-- paste screen recording -->

https://github.com/user-attachments/assets/e7f1228c-2576-4447-86e3-f0ca2262d63a


## How to test or reproduce?

- Navigate to the Commit details page and click on a pipeline run node in the commit graph to open the **Build** side panel — verify proper padding around the header and body content
- Click on an integration test node to open the **IntegrationTest** side panel — verify padding
- Click on a release node to open the **Release** side panel — verify padding
- Navigate to a Pipeline Run details page and click on a task node to open the **TaskRun** side panel — verify the Details tab has proper padding and the Logs tab renders correctly

## Browser conformance:
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge