### PR TITLE
fix(KFLUXUI-1409): fix ExternalLink icon not inheriting link color

### DIFF
--- a/src/shared/components/links/ExternalLink.scss
+++ b/src/shared/components/links/ExternalLink.scss
@@ -1,3 +1,7 @@
 .highlightable-link {
   user-select: text; /* Enables text selection */
 }
+
+.external-link__icon {
+  margin-inline-start: var(--pf-t--global--spacer--xs);
+}

--- a/src/shared/components/links/ExternalLink.tsx
+++ b/src/shared/components/links/ExternalLink.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ButtonProps, ButtonVariant, Icon } from '@patternfly/react-core';
+import { ButtonProps, ButtonVariant } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 import { css } from '@patternfly/react-styles';
 import AnalyticsButton from '../../../components/AnalyticsButton/AnalyticsButton';
@@ -19,7 +19,6 @@ type ExternalLinkProps = {
   isInline?: boolean;
   onClick?: ButtonProps['onClick'];
   analytics?: AnalyticsButtonProperties;
-  size?: 'sm' | 'md' | 'lg' | 'xl';
   isHighlightable?: boolean;
 };
 
@@ -36,7 +35,6 @@ const ExternalLink: React.FC<React.PropsWithChildren<ExternalLinkProps>> = ({
   isInline = true,
   icon,
   onClick,
-  size = 'sm',
   isHighlightable,
 }) => (
   <AnalyticsButton
@@ -58,14 +56,7 @@ const ExternalLink: React.FC<React.PropsWithChildren<ExternalLinkProps>> = ({
     }}
   >
     {children || text}
-    {!hideIcon ? (
-      <>
-        {' '}
-        <Icon iconSize={size}>
-          <ExternalLinkAltIcon />
-        </Icon>
-      </>
-    ) : null}
+    {!hideIcon ? <ExternalLinkAltIcon className="external-link__icon" /> : null}
   </AnalyticsButton>
 );
 


### PR DESCRIPTION
## Fixes
Fixes: https://issues.redhat.com/browse/KFLUXUI-1409

## Description

The ExternalLink icon was rendering in PF's default icon color instead of matching the link text color. This was caused by the PF `Icon` wrapper component, which applies its own color token (`--pf-v6-c-icon__content--Color`) that overrides `currentColor` inheritance.

Removed the `Icon` wrapper and render `ExternalLinkAltIcon` directly — the SVG uses `fill="currentColor"` so it now inherits the button's link color. Also removed the unused `size` prop and moved icon spacing to a CSS class.

## Type of change

- [x] Bugfix

## Screenshots for design review

**Before (icon color mismatched from link text):**
<!-- paste screenshot -->

<img width="166" height="87" alt="external-link-icon-color-ISSUE" src="https://github.com/user-attachments/assets/a49b5c3a-7eca-4c4a-9e7c-af3ec7672234" />


**After (icon matches link color):**
<!-- paste screenshot -->

<img width="205" height="125" alt="external-link-icon-color-FIX" src="https://github.com/user-attachments/assets/86c7c65f-4ca7-47a6-8559-674541c5b34b" />

## How to test or reproduce?

- Find any external link in the app (e.g. commit SHA links, SBOM links, "Learn more" links)
- Verify the external link icon color matches the link text color

## Browser conformance:
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge