### PR TITLE
fix(KFLUXUI-1410): migrate Modal from deprecated to composable PF v6 API

### DIFF
--- a/src/components/ComponentRelation/cr-modals.tsx
+++ b/src/components/ComponentRelation/cr-modals.tsx
@@ -13,8 +13,12 @@ import {
   HelperText,
   HelperTextItem,
   Icon,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
 } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 import { CheckCircleIcon } from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
 import { PlusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 import { FieldArray, useFormikContext } from 'formik';
@@ -43,19 +47,96 @@ export const DefineComponentRelationModal: React.FC<DefineComponentRelationModal
     useFormikContext<ComponentRelationFormikValue>();
   const isDuplicateRelationExist = errors?.relations?.includes(DUPLICATE_RELATONSHIP);
 
+  const { isOpen, appendTo, ...rest } = modalProps || {};
+
   return (
     <Modal
-      {...modalProps}
+      {...rest}
+      isOpen={isOpen}
       onClose={onCancel}
-      title="Component relationships"
-      description={
-        <>
-          Nudging references another component by digest.{' '}
-          <ExternalLink href={LEARN_MORE_ABOUT_NUDGING}>Learn more about nudging.</ExternalLink>
-        </>
-      }
+      appendTo={appendTo}
       variant={ModalVariant.medium}
-      footer={
+    >
+      <ModalHeader
+        title="Component relationships"
+        description={
+          <>
+            Nudging references another component by digest.{' '}
+            <ExternalLink href={LEARN_MORE_ABOUT_NUDGING}>Learn more about nudging.</ExternalLink>
+          </>
+        }
+      />
+      <ModalBody>
+        <Form onSubmit={handleSubmit}>
+          <FieldArray
+            name="relations"
+            render={(arrayHelpers) => {
+              return (
+                <Flex direction={{ default: 'column' }}>
+                  {values.relations.map((_, index) => {
+                    return (
+                      <>
+                        <ComponentRelation
+                          key={index}
+                          componentNames={componentNames}
+                          sortedGroupedComponents={sortedGroupedComponents}
+                          index={index}
+                          removeProps={{
+                            disableRemove:
+                              values.relations.length === 1 &&
+                              values.relations[0].source === '' &&
+                              values.relations[0].target.length === 0,
+                            onRemove: () =>
+                              values.relations.length <= 1
+                                ? arrayHelpers.replace(0, {
+                                    source: '',
+                                    nudgeType: ComponentRelationNudgeType.NUDGES,
+                                    target: [],
+                                  })
+                                : arrayHelpers.remove(index),
+                          }}
+                        />
+                        {index !== values.relations.length - 1 ? <Divider /> : null}
+                      </>
+                    );
+                  })}
+                  <FlexItem>
+                    {isDuplicateRelationExist && (
+                      <FormHelperText>
+                        <HelperText>
+                          <HelperTextItem variant="error">
+                            This relationship is already set up. To edit, go to the respective field
+                            in this modal
+                          </HelperTextItem>
+                        </HelperText>
+                      </FormHelperText>
+                    )}
+                  </FlexItem>
+                  <FlexItem>
+                    <Button
+                      className="pf-m-link--align-left"
+                      onClick={() =>
+                        arrayHelpers.push({
+                          source: '',
+                          nudgeType: ComponentRelationNudgeType.NUDGES,
+                          target: [],
+                        })
+                      }
+                      type="button"
+                      data-test="add-key-value-button"
+                      variant="link"
+                      icon={<PlusCircleIcon />}
+                    >
+                      Add another component relationship
+                    </Button>
+                  </FlexItem>
+                </Flex>
+              );
+            }}
+          />
+        </Form>
+      </ModalBody>
+      <ModalFooter>
         <FormFooter
           submitLabel={'Save relationships'}
           handleCancel={onCancel}
@@ -64,76 +145,7 @@ export const DefineComponentRelationModal: React.FC<DefineComponentRelationModal
           disableSubmit={!dirty || !isEmpty(errors) || isSubmitting}
           errorMessage={status?.submitError}
         />
-      }
-    >
-      <Form onSubmit={handleSubmit}>
-        <FieldArray
-          name="relations"
-          render={(arrayHelpers) => {
-            return (
-              <Flex direction={{ default: 'column' }}>
-                {values.relations.map((_, index) => {
-                  return (
-                    <>
-                      <ComponentRelation
-                        key={index}
-                        componentNames={componentNames}
-                        sortedGroupedComponents={sortedGroupedComponents}
-                        index={index}
-                        removeProps={{
-                          disableRemove:
-                            values.relations.length === 1 &&
-                            values.relations[0].source === '' &&
-                            values.relations[0].target.length === 0,
-                          onRemove: () =>
-                            values.relations.length <= 1
-                              ? arrayHelpers.replace(0, {
-                                  source: '',
-                                  nudgeType: ComponentRelationNudgeType.NUDGES,
-                                  target: [],
-                                })
-                              : arrayHelpers.remove(index),
-                        }}
-                      />
-                      {index !== values.relations.length - 1 ? <Divider /> : null}
-                    </>
-                  );
-                })}
-                <FlexItem>
-                  {isDuplicateRelationExist && (
-                    <FormHelperText>
-                      <HelperText>
-                        <HelperTextItem variant="error">
-                          This relationship is already set up. To edit, go to the respective field
-                          in this modal
-                        </HelperTextItem>
-                      </HelperText>
-                    </FormHelperText>
-                  )}
-                </FlexItem>
-                <FlexItem>
-                  <Button
-                    className="pf-m-link--align-left"
-                    onClick={() =>
-                      arrayHelpers.push({
-                        source: '',
-                        nudgeType: ComponentRelationNudgeType.NUDGES,
-                        target: [],
-                      })
-                    }
-                    type="button"
-                    data-test="add-key-value-button"
-                    variant="link"
-                    icon={<PlusCircleIcon />}
-                  >
-                    Add another component relationship
-                  </Button>
-                </FlexItem>
-              </Flex>
-            );
-          }}
-        />
-      </Form>
+      </ModalFooter>
     </Modal>
   );
 };
@@ -148,19 +160,29 @@ type ConfirmSubmissionComponentRelationModalProps = Pick<RawComponentProps, 'mod
 
 export const ConfirmSubmissionComponentRelationModal: React.FC<
   ConfirmSubmissionComponentRelationModalProps
-> = ({ modalProps: { onClose, ...rest } }) => {
+> = ({ modalProps }) => {
+  const { isOpen, onClose, appendTo, ...rest } = modalProps || {};
+
   return (
-    <Modal {...rest} variant={ModalVariant.medium} showClose={false}>
-      <EmptyState headingLevel="h2" icon={SuccessIcon} titleText="Relationships updated!">
-        <EmptyStateBody>Checkout each component&apos;s details page to view</EmptyStateBody>
-        <EmptyStateFooter>
-          <EmptyStateActions>
-            <Button variant="primary" onClick={onClose}>
-              Done
-            </Button>
-          </EmptyStateActions>
-        </EmptyStateFooter>
-      </EmptyState>
+    <Modal
+      {...rest}
+      isOpen={isOpen}
+      onClose={onClose}
+      appendTo={appendTo}
+      variant={ModalVariant.medium}
+    >
+      <ModalBody>
+        <EmptyState headingLevel="h2" icon={SuccessIcon} titleText="Relationships updated!">
+          <EmptyStateBody>Checkout each component&apos;s details page to view</EmptyStateBody>
+          <EmptyStateFooter>
+            <EmptyStateActions>
+              <Button variant="primary" onClick={onClose}>
+                Done
+              </Button>
+            </EmptyStateActions>
+          </EmptyStateFooter>
+        </EmptyState>
+      </ModalBody>
     </Modal>
   );
 };
@@ -171,23 +193,21 @@ type ConfirmCancelationComponentRelationModalProps = Pick<RawComponentProps, 'mo
 
 export const ConfirmCancelationComponentRelationModal: React.FC<
   ConfirmCancelationComponentRelationModalProps
-> = ({ modalProps: { onClose, ...rest }, onGoBack }) => {
+> = ({ modalProps, onGoBack }) => {
+  const { isOpen, onClose, appendTo, ...rest } = modalProps || {};
+
   return (
-    <Modal
-      {...rest}
-      showClose={false}
-      title="Your changes will be lost!"
-      variant={ModalVariant.small}
-      actions={[
+    <Modal {...rest} isOpen={isOpen} appendTo={appendTo} variant={ModalVariant.small}>
+      <ModalHeader title="Your changes will be lost!" />
+      <ModalBody>Are you sure you want to close the window?</ModalBody>
+      <ModalFooter>
         <Button key="confirm" variant="primary" onClick={onGoBack}>
           Go back
-        </Button>,
+        </Button>
         <Button key="cancel" variant="link" onClick={onClose}>
           Close anyway
-        </Button>,
-      ]}
-    >
-      Are you sure you want to close the window?
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/src/components/Components/ComponentDetails/tabs/EditImageRepositoryVisibilityModal.tsx
+++ b/src/components/Components/ComponentDetails/tabs/EditImageRepositoryVisibilityModal.tsx
@@ -12,8 +12,8 @@ import {
   Switch,
   ContentVariants,
   Content,
+  ModalVariant,
 } from '@patternfly/react-core';
-import { ModalVariant } from '@patternfly/react-core/deprecated';
 import { Formik } from 'formik';
 import { ComponentProps, createModalLauncher } from '~/components/modal/createModalLauncher';
 import { ImageRepositoryKind, ImageRepositoryVisibility } from '~/types';

--- a/src/components/Components/LinkSecret/LinkSecret.tsx
+++ b/src/components/Components/LinkSecret/LinkSecret.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Stack, StackItem } from '@patternfly/react-core';
-import { ModalVariant } from '@patternfly/react-core/deprecated';
+import { Stack, StackItem, ModalVariant } from '@patternfly/react-core';
 import { Formik } from 'formik';
 import { ComponentProps, createModalLauncher } from '../../modal/createModalLauncher';
 import { SecretSelector } from './SecretSelector';

--- a/src/components/Components/UnlinkSecret/UnlinkSecret.tsx
+++ b/src/components/Components/UnlinkSecret/UnlinkSecret.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { useParams } from 'react-router-dom';
-import { Button, Flex, FlexItem, Content, Alert } from '@patternfly/react-core';
-import { ModalVariant } from '@patternfly/react-core/deprecated';
+import { Button, Flex, FlexItem, Content, Alert, ModalVariant } from '@patternfly/react-core';
 import { RouterParams } from '@routes/utils';
 import { COMMON_SECRETS_LABEL } from '~/consts/pipeline';
 import { useComponent } from '~/hooks/useComponents';

--- a/src/components/CustomizedPipeline/CustomizeAllPipelines.tsx
+++ b/src/components/CustomizedPipeline/CustomizeAllPipelines.tsx
@@ -5,8 +5,10 @@ import {
   EmptyStateBody,
   EmptyStateVariant,
   EmptyStateFooter,
+  Modal,
+  ModalBody,
+  ModalHeader,
 } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
 import { getErrorState } from '~/shared/utils/error-utils';
 import { useComponents } from '../../hooks/useComponents';
 import { ComponentModel } from '../../models';
@@ -37,9 +39,16 @@ const CustomizeAllPipelines: React.FC<React.PropsWithChildren<Props>> = ({
     [loaded, components, filter],
   );
 
+  const { isOpen, onClose: handleClose, appendTo, ...rest } = modalProps || {};
+
   if (loaded) {
     if (error) {
-      return <Modal {...modalProps}>{getErrorState(error, loaded, 'components')}</Modal>;
+      return (
+        <Modal {...rest} isOpen={isOpen} onClose={handleClose} appendTo={appendTo} variant="large">
+          <ModalHeader />
+          <ModalBody>{getErrorState(error, loaded, 'components')}</ModalBody>
+        </Modal>
+      );
     }
 
     if (filteredComponents.length > 0) {
@@ -53,35 +62,37 @@ const CustomizeAllPipelines: React.FC<React.PropsWithChildren<Props>> = ({
     }
 
     return (
-      <Modal {...modalProps}>
-        <EmptyState headingLevel="h4" titleText="No components" variant={EmptyStateVariant.lg}>
-          <EmptyStateBody>To get started, add a component to your application.</EmptyStateBody>
-          <EmptyStateFooter>
-            <ButtonWithAccessTooltip
-              variant="primary"
-              component={(props) => (
-                <Link
-                  {...props}
-                  to={`${IMPORT_PATH.createPath({ workspaceName: namespace })}?application=${applicationName}`}
-                  onClick={(event) => {
-                    props.onClick?.(event);
-                    onClose?.();
-                  }}
-                />
-              )}
-              isDisabled={!canCreateComponent}
-              tooltip="You don't have access to add a component"
-              analytics={{
-                link_name: 'add-component',
-                link_location: 'manage-build-pipelines',
-                app_name: applicationName,
-                namespace,
-              }}
-            >
-              Add component
-            </ButtonWithAccessTooltip>
-          </EmptyStateFooter>
-        </EmptyState>
+      <Modal {...rest} isOpen={isOpen} onClose={handleClose} appendTo={appendTo} variant="large">
+        <ModalBody>
+          <EmptyState headingLevel="h4" titleText="No components" variant={EmptyStateVariant.lg}>
+            <EmptyStateBody>To get started, add a component to your application.</EmptyStateBody>
+            <EmptyStateFooter>
+              <ButtonWithAccessTooltip
+                variant="primary"
+                component={(props) => (
+                  <Link
+                    {...props}
+                    to={`${IMPORT_PATH.createPath({ workspaceName: namespace })}?application=${applicationName}`}
+                    onClick={(event) => {
+                      props.onClick?.(event);
+                      onClose?.();
+                    }}
+                  />
+                )}
+                isDisabled={!canCreateComponent}
+                tooltip="You don't have access to add a component"
+                analytics={{
+                  link_name: 'add-component',
+                  link_location: 'manage-build-pipelines',
+                  app_name: applicationName,
+                  namespace,
+                }}
+              >
+                Add component
+              </ButtonWithAccessTooltip>
+            </EmptyStateFooter>
+          </EmptyState>
+        </ModalBody>
       </Modal>
     );
   }

--- a/src/components/CustomizedPipeline/CustomizePipelines.tsx
+++ b/src/components/CustomizedPipeline/CustomizePipelines.tsx
@@ -7,14 +7,12 @@ import {
   pluralize,
   Content,
   ContentVariants,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
   Truncate,
 } from '@patternfly/react-core';
-import {
-  Modal,
-  ModalBoxBody,
-  ModalBoxFooter,
-  ModalBoxHeader,
-} from '@patternfly/react-core/deprecated';
 import { Tbody, Thead, Th, Tr, Td, Table } from '@patternfly/react-table';
 import SendIconUrl from '../../assets/send.svg';
 import SuccessIconUrl from '../../assets/success.svg';
@@ -296,10 +294,12 @@ const CustomizePipeline: React.FC<React.PropsWithChildren<Props>> = ({
     onClose();
   }, [onClose, applicationName, namespace, track]);
 
+  const { isOpen, appendTo, ...rest } = modalProps || {};
+
   return (
-    <Modal {...modalProps} onClose={trackedOnClose}>
-      <ModalBoxHeader />
-      <ModalBoxBody>
+    <Modal {...rest} isOpen={isOpen} onClose={trackedOnClose} appendTo={appendTo} variant="large">
+      <ModalHeader title="Manage build pipelines" />
+      <ModalBody>
         <>
           <Content
             className="pf-v6-u-pt-lg"
@@ -383,8 +383,8 @@ const CustomizePipeline: React.FC<React.PropsWithChildren<Props>> = ({
             </p>
           ) : undefined}
         </>
-      </ModalBoxBody>
-      <ModalBoxFooter>
+      </ModalBody>
+      <ModalFooter>
         <AnalyticsButton
           variant={ButtonVariant.secondary}
           onClick={trackedOnClose}
@@ -392,7 +392,7 @@ const CustomizePipeline: React.FC<React.PropsWithChildren<Props>> = ({
         >
           Close
         </AnalyticsButton>
-      </ModalBoxFooter>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/src/components/CustomizedPipeline/CustomizePipelinesModal.tsx
+++ b/src/components/CustomizedPipeline/CustomizePipelinesModal.tsx
@@ -1,4 +1,4 @@
-import { ModalVariant } from '@patternfly/react-core/deprecated';
+import { ModalVariant } from '@patternfly/react-core';
 import { ComponentKind } from '../../types';
 import { createRawModalLauncher } from '../modal/createModalLauncher';
 import CustomizeAllPipelines from './CustomizeAllPipelines';

--- a/src/components/CustomizedPipeline/__tests__/CustomizeAllPipelines.spec.tsx
+++ b/src/components/CustomizedPipeline/__tests__/CustomizeAllPipelines.spec.tsx
@@ -42,7 +42,11 @@ describe('CustomizeAllPipelines', () => {
   it('should render error state', () => {
     useK8sWatchResourceMock.mockReturnValue([[], true, { code: 400 }]);
     const result = render(
-      <CustomizeAllPipelines applicationName="" namespace="" modalProps={{ isOpen: true }} />,
+      <CustomizeAllPipelines
+        applicationName=""
+        namespace=""
+        modalProps={{ isOpen: true, onClose: jest.fn() }}
+      />,
     );
     expect(result.getByText('Unable to load components')).toBeInTheDocument();
   });

--- a/src/components/FeedbackSection/FeedbackModal.tsx
+++ b/src/components/FeedbackSection/FeedbackModal.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { Flex, FlexItem, Panel } from '@patternfly/react-core';
-import { ModalVariant } from '@patternfly/react-core/deprecated';
+import { Flex, FlexItem, ModalVariant, Panel } from '@patternfly/react-core';
 import { TrackEvents } from '~/analytics/gen/analytics-types';
 import { useTrackAnalyticsEvent } from '~/analytics/hooks';
 import { ComponentProps, createModalLauncher } from '~/components/modal/createModalLauncher';

--- a/src/components/Header/AboutModal.tsx
+++ b/src/components/Header/AboutModal.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react';
-import { Stack, StackItem, Content, ContentVariants, List, ListItem } from '@patternfly/react-core';
-import { ModalVariant } from '@patternfly/react-core/deprecated';
+import {
+  Stack,
+  StackItem,
+  Content,
+  ContentVariants,
+  List,
+  ListItem,
+  ModalVariant,
+} from '@patternfly/react-core';
 import { createModalLauncher } from '~/components/modal/createModalLauncher';
 import {
   EXTERNAL_DOCUMENTATION_BASE_URL,

--- a/src/components/IntegrationTests/EditContextsModal.tsx
+++ b/src/components/IntegrationTests/EditContextsModal.tsx
@@ -5,10 +5,10 @@ import {
   Button,
   ButtonType,
   ButtonVariant,
+  ModalVariant,
   Stack,
   StackItem,
 } from '@patternfly/react-core';
-import { ModalVariant } from '@patternfly/react-core/deprecated';
 import { Formik, FormikValues } from 'formik';
 import { k8sPatchResource } from '../../k8s/k8s-fetch';
 import { IntegrationTestScenarioModel } from '../../models';

--- a/src/components/IntegrationTests/EditParamsModal.tsx
+++ b/src/components/IntegrationTests/EditParamsModal.tsx
@@ -6,10 +6,10 @@ import {
   ButtonType,
   ButtonVariant,
   Form,
+  ModalVariant,
   Stack,
   StackItem,
 } from '@patternfly/react-core';
-import { ModalVariant } from '@patternfly/react-core/deprecated';
 import { Formik, FormikValues } from 'formik';
 import { K8sQueryPatchResource } from '../../k8s';
 import { IntegrationTestScenarioModel } from '../../models';

--- a/src/components/Issues/IssuesListView/IssuesListRow.tsx
+++ b/src/components/Issues/IssuesListView/IssuesListRow.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Button, Flex, FlexItem, capitalize } from '@patternfly/react-core';
-import { ModalVariant } from '@patternfly/react-core/deprecated';
+import { Button, Flex, FlexItem, ModalVariant, capitalize } from '@patternfly/react-core';
 import { createModalLauncher } from '~/components/modal/createModalLauncher';
 import { useModalLauncher } from '~/components/modal/ModalProvider';
 import { Issue, IssueState } from '~/kite/issue-type';

--- a/src/components/LogViewer/BuildLogViewer.tsx
+++ b/src/components/LogViewer/BuildLogViewer.tsx
@@ -5,8 +5,8 @@ import {
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
+  ModalVariant,
 } from '@patternfly/react-core';
-import { ModalVariant } from '@patternfly/react-core/deprecated';
 import dayjs from 'dayjs';
 import { PIPELINERUN_DETAILS_PATH } from '@routes/paths';
 import { FeatureFlagIndicator } from '~/feature-flags/FeatureFlagIndicator';

--- a/src/components/NamespaceList/ManageVisibilityModalLauncher.tsx
+++ b/src/components/NamespaceList/ManageVisibilityModalLauncher.tsx
@@ -1,4 +1,4 @@
-import { ModalVariant } from '@patternfly/react-core/deprecated';
+import { ModalVariant } from '@patternfly/react-core';
 import { createModalLauncher } from '~/components/modal/createModalLauncher';
 import ManageVisibilityModal from '~/components/NamespaceList/ManageVisibilityModal';
 import { NamespaceKind } from '~/types';

--- a/src/components/PipelineRun/PipelineRunDetailsView/tabs/PipelineRunSBOMsModal.tsx
+++ b/src/components/PipelineRun/PipelineRunDetailsView/tabs/PipelineRunSBOMsModal.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
-import { Stack, StackItem, Content } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
+import {
+  Stack,
+  StackItem,
+  Content,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalVariant,
+} from '@patternfly/react-core';
 import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import { createRawModalLauncher, RawComponentProps } from '~/components/modal/createModalLauncher';
 import ExternalLink from '~/shared/components/links/ExternalLink';
@@ -13,38 +20,49 @@ type PipelineRunSBOMsProps = {
 type PipelineRunSBOMsModalProps = RawComponentProps & PipelineRunSBOMsProps;
 
 const PipelineRunSBOMsModal: React.FC<PipelineRunSBOMsModalProps> = ({ modalProps, sboms }) => {
+  const { isOpen, onClose, appendTo, ...rest } = modalProps || {};
+
   return (
-    <Modal {...modalProps} title="SBOMs" variant={ModalVariant.small}>
-      <Stack hasGutter>
-        <StackItem>
-          <Table variant="compact" borders>
-            <Thead>
-              <Tr>
-                <Th>Note</Th>
-                <Th>Link</Th>
-              </Tr>
-            </Thead>
-            <Tbody>
-              {sboms.map((sbom, i) => (
-                <Tr key={`${sbom.url}-${i}`}>
-                  <Td>
-                    {sbom.isIndex ? (
-                      <Content component="p" style={{ fontWeight: 'bold' }}>
-                        Index
-                      </Content>
-                    ) : (
-                      sbom.platform || '-'
-                    )}
-                  </Td>
-                  <Td>
-                    <ExternalLink href={sbom.url}>View SBOM</ExternalLink>
-                  </Td>
+    <Modal
+      {...rest}
+      isOpen={isOpen}
+      onClose={onClose}
+      appendTo={appendTo}
+      variant={ModalVariant.small}
+    >
+      <ModalHeader title="SBOMs" />
+      <ModalBody>
+        <Stack hasGutter>
+          <StackItem>
+            <Table variant="compact" borders>
+              <Thead>
+                <Tr>
+                  <Th>Note</Th>
+                  <Th>Link</Th>
                 </Tr>
-              ))}
-            </Tbody>
-          </Table>
-        </StackItem>
-      </Stack>
+              </Thead>
+              <Tbody>
+                {sboms.map((sbom, i) => (
+                  <Tr key={`${sbom.url}-${i}`}>
+                    <Td>
+                      {sbom.isIndex ? (
+                        <Content component="p" style={{ fontWeight: 'bold' }}>
+                          Index
+                        </Content>
+                      ) : (
+                        sbom.platform || '-'
+                      )}
+                    </Td>
+                    <Td>
+                      <ExternalLink href={sbom.url}>View SBOM</ExternalLink>
+                    </Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+          </StackItem>
+        </Stack>
+      </ModalBody>
     </Modal>
   );
 };

--- a/src/components/PipelineRun/PipelineRunDetailsView/tabs/PipelineRunSBOMsModal.tsx
+++ b/src/components/PipelineRun/PipelineRunDetailsView/tabs/PipelineRunSBOMsModal.tsx
@@ -1,15 +1,7 @@
 import React from 'react';
-import {
-  Stack,
-  StackItem,
-  Content,
-  Modal,
-  ModalBody,
-  ModalHeader,
-  ModalVariant,
-} from '@patternfly/react-core';
+import { Stack, StackItem, Content, ModalVariant } from '@patternfly/react-core';
 import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
-import { createRawModalLauncher, RawComponentProps } from '~/components/modal/createModalLauncher';
+import { createModalLauncher, RawComponentProps } from '~/components/modal/createModalLauncher';
 import ExternalLink from '~/shared/components/links/ExternalLink';
 import { TaskRunSBOM } from '../utils/pipelinerun-utils';
 
@@ -19,55 +11,44 @@ type PipelineRunSBOMsProps = {
 
 type PipelineRunSBOMsModalProps = RawComponentProps & PipelineRunSBOMsProps;
 
-const PipelineRunSBOMsModal: React.FC<PipelineRunSBOMsModalProps> = ({ modalProps, sboms }) => {
-  const { isOpen, onClose, appendTo, ...rest } = modalProps || {};
-
+const PipelineRunSBOMsModal: React.FC<PipelineRunSBOMsModalProps> = ({ sboms }) => {
   return (
-    <Modal
-      {...rest}
-      isOpen={isOpen}
-      onClose={onClose}
-      appendTo={appendTo}
-      variant={ModalVariant.small}
-    >
-      <ModalHeader title="SBOMs" />
-      <ModalBody>
-        <Stack hasGutter>
-          <StackItem>
-            <Table variant="compact" borders>
-              <Thead>
-                <Tr>
-                  <Th>Note</Th>
-                  <Th>Link</Th>
-                </Tr>
-              </Thead>
-              <Tbody>
-                {sboms.map((sbom, i) => (
-                  <Tr key={`${sbom.url}-${i}`}>
-                    <Td>
-                      {sbom.isIndex ? (
-                        <Content component="p" style={{ fontWeight: 'bold' }}>
-                          Index
-                        </Content>
-                      ) : (
-                        sbom.platform || '-'
-                      )}
-                    </Td>
-                    <Td>
-                      <ExternalLink href={sbom.url}>View SBOM</ExternalLink>
-                    </Td>
-                  </Tr>
-                ))}
-              </Tbody>
-            </Table>
-          </StackItem>
-        </Stack>
-      </ModalBody>
-    </Modal>
+    <Stack hasGutter>
+      <StackItem>
+        <Table variant="compact" borders>
+          <Thead>
+            <Tr>
+              <Th>Note</Th>
+              <Th>Link</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {sboms.map((sbom, i) => (
+              <Tr key={`${sbom.url}-${i}`}>
+                <Td>
+                  {sbom.isIndex ? (
+                    <Content component="p" style={{ fontWeight: 'bold' }}>
+                      Index
+                    </Content>
+                  ) : (
+                    sbom.platform || '-'
+                  )}
+                </Td>
+                <Td>
+                  <ExternalLink href={sbom.url}>View SBOM</ExternalLink>
+                </Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      </StackItem>
+    </Stack>
   );
 };
 
 export const createPipelineRunSBOMsModal = (props: PipelineRunSBOMsProps) =>
-  createRawModalLauncher<PipelineRunSBOMsProps, Record<string, unknown>>(PipelineRunSBOMsModal, {
-    'data-test': 'pipelinerun-sboms-modal',
+  createModalLauncher(PipelineRunSBOMsModal, {
+    'data-test': `pipelinerun-sboms-modal`,
+    variant: ModalVariant.small,
+    title: 'SBOMs',
   })(props);

--- a/src/components/PipelineRun/PipelineRunListView/__tests__/PipelineRunListView.spec.tsx
+++ b/src/components/PipelineRun/PipelineRunListView/__tests__/PipelineRunListView.spec.tsx
@@ -599,12 +599,12 @@ describe('Pipeline run List', () => {
     renderWithQueryClient(<TestedComponent name={appName} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Manage columns' }));
-    expect(screen.getByRole('dialog', { name: 'Manage pipeline run columns' })).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: /Manage pipeline run columns/ })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Close' }));
 
     expect(
-      screen.queryByRole('dialog', { name: 'Manage pipeline run columns' }),
+      screen.queryByRole('dialog', { name: /Manage pipeline run columns/ }),
     ).not.toBeInTheDocument();
   });
 

--- a/src/components/ReleaseService/ReleasePlan/TriggerRelease/AddIssueSection/AddIssueModal.tsx
+++ b/src/components/ReleaseService/ReleasePlan/TriggerRelease/AddIssueSection/AddIssueModal.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Button } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
+import { Button, Modal, ModalBody, ModalHeader, ModalVariant } from '@patternfly/react-core';
 import { Formik } from 'formik';
 import * as yup from 'yup';
 import { URL_ERROR_MSG, URL_REGEX } from '../../../../../utils/validation-utils';
@@ -56,30 +55,32 @@ export const AddIssueModal: React.FC<React.PropsWithChildren<AddIssueModalProps>
       </Button>
       <Modal
         variant={ModalVariant.medium}
-        title={isBug ? 'Add Jira issue' : 'Add a CVE'}
         isOpen={isModalOpen}
         onClose={handleModalToggle}
         data-test="add-issue-modal"
       >
-        <Formik
-          onSubmit={setValues}
-          initialValues={
-            isBug
-              ? { id: '', source: '', uploadDate: dateFormat(new Date()) }
-              : {
-                  key: '',
-                  component: '',
-                  packages: [],
-                }
-          }
-          validationSchema={isBug ? IssueFormSchema : CVEFormSchema}
-        >
-          {isBug ? (
-            <BugFormContent modalToggle={handleModalToggle} />
-          ) : (
-            <CVEFormContent modalToggle={handleModalToggle} />
-          )}
-        </Formik>
+        <ModalHeader title={isBug ? 'Add Jira issue' : 'Add a CVE'} />
+        <ModalBody>
+          <Formik
+            onSubmit={setValues}
+            initialValues={
+              isBug
+                ? { id: '', source: '', uploadDate: dateFormat(new Date()) }
+                : {
+                    key: '',
+                    component: '',
+                    packages: [],
+                  }
+            }
+            validationSchema={isBug ? IssueFormSchema : CVEFormSchema}
+          >
+            {isBug ? (
+              <BugFormContent modalToggle={handleModalToggle} />
+            ) : (
+              <CVEFormContent modalToggle={handleModalToggle} />
+            )}
+          </Formik>
+        </ModalBody>
       </Modal>
     </>
   );

--- a/src/components/Secrets/SecretModal.tsx
+++ b/src/components/Secrets/SecretModal.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
-import { Button } from '@patternfly/react-core';
-import { Modal, ModalBoxBody, ModalVariant } from '@patternfly/react-core/deprecated';
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+} from '@patternfly/react-core';
 import { Formik } from 'formik';
 import { isEmpty, merge } from 'lodash-es';
 import {
@@ -92,22 +98,33 @@ const SecretModal: React.FC<React.PropsWithChildren<SecretModalProps>> = ({
     return merged;
   }, [existingSecrets, currentComponent, initialSecret]);
 
+  const { isOpen, onClose: handleClose, appendTo, ...rest } = modalProps || {};
+
   return (
     <Formik
-      onSubmit={(v) => createPartnerTaskSecret(v, onSubmit, modalProps.onClose)}
+      onSubmit={(v) => createPartnerTaskSecret(v, onSubmit, handleClose)}
       initialValues={initialValues}
       validationSchema={SecretFromSchema}
     >
       {(props) => {
         return (
           <Modal
-            {...modalProps}
-            title={isEdit ? 'Edit build secret' : 'Create new build secret'}
-            description="Keep your data secure with a build-time secret."
+            {...rest}
+            isOpen={isOpen}
+            onClose={handleClose}
+            appendTo={appendTo}
             variant={ModalVariant.medium}
             data-test="build-secret-modal"
             className="build-secret-modal"
-            actions={[
+          >
+            <ModalHeader
+              title={isEdit ? 'Edit build secret' : 'Create new build secret'}
+              description="Keep your data secure with a build-time secret."
+            />
+            <ModalBody>
+              <SecretForm existingSecrets={existingSecrets} currentComponent={currentComponent} />
+            </ModalBody>
+            <ModalFooter>
               <Button
                 key="confirm"
                 variant="primary"
@@ -118,15 +135,11 @@ const SecretModal: React.FC<React.PropsWithChildren<SecretModalProps>> = ({
                 isDisabled={!props.dirty || !isEmpty(props.errors) || props.isSubmitting}
               >
                 {isEdit ? 'Save' : 'Create'}
-              </Button>,
-              <Button key="cancel" variant="link" onClick={modalProps.onClose}>
+              </Button>
+              <Button key="cancel" variant="link" onClick={handleClose}>
                 Cancel
-              </Button>,
-            ]}
-          >
-            <ModalBoxBody>
-              <SecretForm existingSecrets={existingSecrets} currentComponent={currentComponent} />
-            </ModalBoxBody>
+              </Button>
+            </ModalFooter>
           </Modal>
         );
       }}

--- a/src/components/Secrets/SecretModalLauncher.tsx
+++ b/src/components/Secrets/SecretModalLauncher.tsx
@@ -1,4 +1,4 @@
-import { ModalVariant } from '@patternfly/react-core/deprecated';
+import { ModalVariant } from '@patternfly/react-core';
 import { SecretFormValues, BuildTimeSecret, CurrentComponentRef, ImportSecret } from '../../types';
 import { createRawModalLauncher } from '../modal/createModalLauncher';
 import SecretModal from './SecretModal';

--- a/src/components/Secrets/SecretsListView/SecretsListRowWithComponents.tsx
+++ b/src/components/Secrets/SecretsListView/SecretsListRowWithComponents.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, Popover, Spinner } from '@patternfly/react-core';
+import { Button, ModalVariant, Popover, Spinner } from '@patternfly/react-core';
 import ErrorModal from '~/components/modal/ErrorModal';
 import { BackgroundStatusIconWithText } from '~/components/StatusIcon/BackgroundTaskStatusIcon';
 import { LINKING_ERROR_ANNOTATION, LINKING_STATUS_ANNOTATION } from '~/consts/secrets';
@@ -12,6 +12,8 @@ import { isLinkableSecret } from '~/utils/service-account/service-account-utils'
 import { BackgroundJobStatus, useTaskStore } from '~/utils/task-store';
 import { RowFunctionArgs, TableData } from '../../../shared';
 import ActionMenu from '../../../shared/components/action-menu/ActionMenu';
+import { createModalLauncher } from '../../modal/createModalLauncher';
+import { useModalLauncher } from '../../modal/ModalProvider';
 import { useSecretActions } from '../secret-actions';
 import { SecretLabels } from './SecretLabels';
 import { secretsTableColumnClasses } from './SecretsListHeaderWithComponents';
@@ -28,6 +30,7 @@ const SecretsListRowWithComponents: React.FC<React.PropsWithChildren<SecretsList
   customData,
   index,
 }) => {
+  const showModal = useModalLauncher();
   const actions = useSecretActions(obj);
   const namespace = useNamespace();
   const { expandedIds, handleToggle } = customData;
@@ -47,12 +50,6 @@ const SecretsListRowWithComponents: React.FC<React.PropsWithChildren<SecretsList
     obj,
     true,
   );
-
-  const [isErrorModalOpen, setIsErrorModalOpen] = React.useState(false);
-
-  const handleErrorModalToggle = () => {
-    setIsErrorModalOpen(!isErrorModalOpen);
-  };
 
   return (
     <>
@@ -97,17 +94,21 @@ const SecretsListRowWithComponents: React.FC<React.PropsWithChildren<SecretsList
       >
         <BackgroundStatusIconWithText status={taskStatus as BackgroundJobStatus} />
         {taskStatus === BackgroundJobStatus.Failed && taskError && (
-          <>
-            <Button onClick={handleErrorModalToggle} variant="link" className="error-button">
-              View Error
-            </Button>
-            <ErrorModal
-              title="Secret link task failed:"
-              errorMessage={taskError}
-              isOpen={isErrorModalOpen}
-              onClose={handleErrorModalToggle}
-            />
-          </>
+          <Button
+            onClick={() =>
+              showModal(
+                createModalLauncher(ErrorModal, {
+                  'data-test': 'secrets-error-modal',
+                  variant: ModalVariant.small,
+                  title: 'Secret link task failed:',
+                })({ errorMessage: taskError }),
+              )
+            }
+            variant="link"
+            className="error-button"
+          >
+            View Error
+          </Button>
         )}
       </TableData>
       <TableData className={`${secretsTableColumnClasses.kebab} vertical-cell-align`}>

--- a/src/components/UserAccess/RevokeAccessModal.tsx
+++ b/src/components/UserAccess/RevokeAccessModal.tsx
@@ -8,8 +8,12 @@ import {
   Button,
   ButtonType,
   ButtonVariant,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
 } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 import { K8sQueryDeleteResource } from '../../k8s';
 import { RoleBindingModel } from '../../models';
 import { RoleBinding } from '../../types';
@@ -31,8 +35,6 @@ export const RevokeAccessModal: React.FC<React.PropsWithChildren<Props>> = ({
   const handleSubmit = React.useCallback(
     async (e) => {
       e.preventDefault();
-      // We need to set submitting as true, this ensure the 'Revoke' button cannot be
-      // reclicked during the resource is deleting.
       setSubmitting(true);
       setError(null);
       try {
@@ -51,42 +53,62 @@ export const RevokeAccessModal: React.FC<React.PropsWithChildren<Props>> = ({
     [onClose, rb],
   );
 
+  const {
+    isOpen,
+    onClose: handleClose,
+    appendTo,
+    title,
+    titleIconVariant,
+    ...rest
+  } = modalProps || {};
+
   return (
-    <Modal {...modalProps} variant={ModalVariant.small}>
-      <Stack hasGutter>
-        <StackItem>
-          <Content>
-            <Content component="p" data-test="description">
-              The user <strong>{username}</strong> will lose access to this namespace and all of its
-              applications, environments, and any other dependent items.
+    <Modal
+      {...rest}
+      isOpen={isOpen}
+      onClose={handleClose}
+      appendTo={appendTo}
+      variant={ModalVariant.small}
+    >
+      <ModalHeader title={title} titleIconVariant={titleIconVariant} />
+      <ModalBody>
+        <Stack hasGutter>
+          <StackItem>
+            <Content>
+              <Content component="p" data-test="description">
+                The user <strong>{username}</strong> will lose access to this namespace and all of
+                its applications, environments, and any other dependent items.
+              </Content>
+              <Content component="p">You can always grant the user access later.</Content>
             </Content>
-            <Content component="p">You can always grant the user access later.</Content>
-          </Content>
-        </StackItem>
-        <StackItem>
-          {error && (
-            <Alert isInline variant={AlertVariant.danger} title="An error occurred">
-              {error}
-            </Alert>
-          )}
-          <Button
-            type={ButtonType.submit}
-            variant={ButtonVariant.danger}
-            isLoading={submitting}
-            onClick={handleSubmit}
-            isDisabled={submitting}
-            data-test="revoke-access"
-          >
-            Revoke
-          </Button>
-          <Button
-            variant={ButtonVariant.link}
-            onClick={() => onClose(null, { submitClicked: false })}
-          >
-            Cancel
-          </Button>
-        </StackItem>
-      </Stack>
+          </StackItem>
+          <StackItem>
+            {error && (
+              <Alert isInline variant={AlertVariant.danger} title="An error occurred">
+                {error}
+              </Alert>
+            )}
+          </StackItem>
+        </Stack>
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          type={ButtonType.submit}
+          variant={ButtonVariant.danger}
+          isLoading={submitting}
+          onClick={handleSubmit}
+          isDisabled={submitting}
+          data-test="revoke-access"
+        >
+          Revoke
+        </Button>
+        <Button
+          variant={ButtonVariant.link}
+          onClick={() => onClose(null, { submitClicked: false })}
+        >
+          Cancel
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/src/components/UserAccess/RevokeAccessModal.tsx
+++ b/src/components/UserAccess/RevokeAccessModal.tsx
@@ -8,11 +8,8 @@ import {
   Button,
   ButtonType,
   ButtonVariant,
-  Modal,
-  ModalBody,
-  ModalFooter,
-  ModalHeader,
-  ModalVariant,
+  Flex,
+  FlexItem,
 } from '@patternfly/react-core';
 import { K8sQueryDeleteResource } from '../../k8s';
 import { RoleBindingModel } from '../../models';
@@ -28,7 +25,6 @@ export const RevokeAccessModal: React.FC<React.PropsWithChildren<Props>> = ({
   rb,
   username,
   onClose,
-  modalProps,
 }) => {
   const [error, setError] = React.useState<string>();
   const [submitting, setSubmitting] = React.useState(false);
@@ -53,62 +49,52 @@ export const RevokeAccessModal: React.FC<React.PropsWithChildren<Props>> = ({
     [onClose, rb],
   );
 
-  const {
-    isOpen,
-    onClose: handleClose,
-    appendTo,
-    title,
-    titleIconVariant,
-    ...rest
-  } = modalProps || {};
-
   return (
-    <Modal
-      {...rest}
-      isOpen={isOpen}
-      onClose={handleClose}
-      appendTo={appendTo}
-      variant={ModalVariant.small}
-    >
-      <ModalHeader title={title} titleIconVariant={titleIconVariant} />
-      <ModalBody>
-        <Stack hasGutter>
-          <StackItem>
-            <Content>
-              <Content component="p" data-test="description">
-                The user <strong>{username}</strong> will lose access to this namespace and all of
-                its applications, environments, and any other dependent items.
-              </Content>
-              <Content component="p">You can always grant the user access later.</Content>
+    <>
+      <Stack hasGutter>
+        <StackItem>
+          <Content>
+            <Content component="p" data-test="description">
+              The user <strong>{username}</strong> will lose access to this namespace and all of its
+              applications, environments, and any other dependent items.
             </Content>
-          </StackItem>
-          <StackItem>
-            {error && (
-              <Alert isInline variant={AlertVariant.danger} title="An error occurred">
-                {error}
-              </Alert>
-            )}
-          </StackItem>
-        </Stack>
-      </ModalBody>
-      <ModalFooter>
-        <Button
-          type={ButtonType.submit}
-          variant={ButtonVariant.danger}
-          isLoading={submitting}
-          onClick={handleSubmit}
-          isDisabled={submitting}
-          data-test="revoke-access"
-        >
-          Revoke
-        </Button>
-        <Button
-          variant={ButtonVariant.link}
-          onClick={() => onClose(null, { submitClicked: false })}
-        >
-          Cancel
-        </Button>
-      </ModalFooter>
-    </Modal>
+            <Content component="p">You can always grant the user access later.</Content>
+          </Content>
+        </StackItem>
+        <StackItem>
+          {error && (
+            <Alert isInline variant={AlertVariant.danger} title="An error occurred">
+              {error}
+            </Alert>
+          )}
+        </StackItem>
+
+        <StackItem>
+          <Flex>
+            <FlexItem>
+              <Button
+                type={ButtonType.submit}
+                variant={ButtonVariant.danger}
+                isLoading={submitting}
+                onClick={handleSubmit}
+                isDisabled={submitting}
+                data-test="revoke-access"
+              >
+                Revoke
+              </Button>
+            </FlexItem>
+
+            <FlexItem>
+              <Button
+                variant={ButtonVariant.link}
+                onClick={() => onClose(null, { submitClicked: false })}
+              >
+                Cancel
+              </Button>
+            </FlexItem>
+          </Flex>
+        </StackItem>
+      </Stack>
+    </>
   );
 };

--- a/src/components/UserAccess/RevokeAccessModal.tsx
+++ b/src/components/UserAccess/RevokeAccessModal.tsx
@@ -50,10 +50,16 @@ export const RevokeAccessModal: React.FC<React.PropsWithChildren<Props>> = ({
     [onClose, rb],
   );
 
-  const { isOpen, variant, title } = modalProps || {};
+  const { isOpen, variant, title, ...rest } = modalProps || {};
 
   return (
-    <Modal variant={variant} isOpen={isOpen} onClose={onClose} data-test="revoke-access-modal">
+    <Modal
+      {...rest}
+      variant={variant}
+      isOpen={isOpen}
+      onClose={onClose}
+      data-test="revoke-access-modal"
+    >
       <ModalHeader title={title} />
       <ModalBody>
         <Content>

--- a/src/components/UserAccess/RevokeAccessModal.tsx
+++ b/src/components/UserAccess/RevokeAccessModal.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import {
-  Stack,
-  StackItem,
   Content,
   Alert,
   AlertVariant,
   Button,
   ButtonType,
   ButtonVariant,
-  Flex,
-  FlexItem,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
 } from '@patternfly/react-core';
 import { K8sQueryDeleteResource } from '../../k8s';
 import { RoleBindingModel } from '../../models';
@@ -25,6 +25,7 @@ export const RevokeAccessModal: React.FC<React.PropsWithChildren<Props>> = ({
   rb,
   username,
   onClose,
+  modalProps,
 }) => {
   const [error, setError] = React.useState<string>();
   const [submitting, setSubmitting] = React.useState(false);
@@ -49,52 +50,43 @@ export const RevokeAccessModal: React.FC<React.PropsWithChildren<Props>> = ({
     [onClose, rb],
   );
 
+  const { isOpen, variant, title } = modalProps || {};
+
   return (
-    <>
-      <Stack hasGutter>
-        <StackItem>
-          <Content>
-            <Content component="p" data-test="description">
-              The user <strong>{username}</strong> will lose access to this namespace and all of its
-              applications, environments, and any other dependent items.
-            </Content>
-            <Content component="p">You can always grant the user access later.</Content>
+    <Modal variant={variant} isOpen={isOpen} onClose={onClose} data-test="revoke-access-modal">
+      <ModalHeader title={title} />
+      <ModalBody>
+        <Content>
+          <Content component="p" data-test="description">
+            The user <strong>{username}</strong> will lose access to this namespace and all of its
+            applications, environments, and any other dependent items.
           </Content>
-        </StackItem>
-        <StackItem>
-          {error && (
-            <Alert isInline variant={AlertVariant.danger} title="An error occurred">
-              {error}
-            </Alert>
-          )}
-        </StackItem>
-
-        <StackItem>
-          <Flex>
-            <FlexItem>
-              <Button
-                type={ButtonType.submit}
-                variant={ButtonVariant.danger}
-                isLoading={submitting}
-                onClick={handleSubmit}
-                isDisabled={submitting}
-                data-test="revoke-access"
-              >
-                Revoke
-              </Button>
-            </FlexItem>
-
-            <FlexItem>
-              <Button
-                variant={ButtonVariant.link}
-                onClick={() => onClose(null, { submitClicked: false })}
-              >
-                Cancel
-              </Button>
-            </FlexItem>
-          </Flex>
-        </StackItem>
-      </Stack>
-    </>
+          <Content component="p">You can always grant the user access later.</Content>
+        </Content>
+        {error && (
+          <Alert isInline variant={AlertVariant.danger} title="An error occurred">
+            {error}
+          </Alert>
+        )}
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          type={ButtonType.submit}
+          variant={ButtonVariant.danger}
+          isLoading={submitting}
+          onClick={handleSubmit}
+          isDisabled={submitting}
+          data-test="revoke-access"
+        >
+          Revoke
+        </Button>
+        <Button
+          variant={ButtonVariant.link}
+          onClick={() => onClose?.(null, { submitClicked: false })}
+        >
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
   );
 };

--- a/src/components/UserAccess/user-access-actions.ts
+++ b/src/components/UserAccess/user-access-actions.ts
@@ -1,16 +1,18 @@
+import { ModalVariant } from '@patternfly/react-core';
 import { USER_ACCESS_EDIT_PAGE } from '@routes/paths';
 import { RoleBindingModel } from '../../models';
 import { Action } from '../../shared/components/action-menu/types';
 import { useNamespace } from '../../shared/providers/Namespace';
 import { RoleBinding } from '../../types';
 import { useAccessReviewForModel } from '../../utils/rbac';
-import { createRawModalLauncher } from '../modal/createModalLauncher';
+import { createModalLauncher } from '../modal/createModalLauncher';
 import { useModalLauncher } from '../modal/ModalProvider';
 import { RevokeAccessModal } from './RevokeAccessModal';
 
 const revokeAccessModalLauncher = (username: string, rb: RoleBinding) =>
-  createRawModalLauncher(RevokeAccessModal, {
+  createModalLauncher(RevokeAccessModal, {
     'data-test': 'revoke-access-modal',
+    variant: ModalVariant.small,
     title: 'Revoke access?',
   })({ username, rb });
 

--- a/src/components/UserAccess/user-access-actions.ts
+++ b/src/components/UserAccess/user-access-actions.ts
@@ -5,12 +5,12 @@ import { Action } from '../../shared/components/action-menu/types';
 import { useNamespace } from '../../shared/providers/Namespace';
 import { RoleBinding } from '../../types';
 import { useAccessReviewForModel } from '../../utils/rbac';
-import { createModalLauncher } from '../modal/createModalLauncher';
+import { createRawModalLauncher } from '../modal/createModalLauncher';
 import { useModalLauncher } from '../modal/ModalProvider';
 import { RevokeAccessModal } from './RevokeAccessModal';
 
 const revokeAccessModalLauncher = (username: string, rb: RoleBinding) =>
-  createModalLauncher(RevokeAccessModal, {
+  createRawModalLauncher(RevokeAccessModal, {
     'data-test': 'revoke-access-modal',
     variant: ModalVariant.small,
     title: 'Revoke access?',

--- a/src/components/modal/DeleteResourceModal.tsx
+++ b/src/components/modal/DeleteResourceModal.tsx
@@ -12,8 +12,8 @@ import {
   Content,
   ContentVariants,
   ValidatedOptions,
+  ModalVariant,
 } from '@patternfly/react-core';
-import { ModalVariant } from '@patternfly/react-core/deprecated';
 import { Formik } from 'formik';
 import { InputField } from 'formik-pf';
 import { useNamespace } from '~/shared/providers/Namespace';

--- a/src/components/modal/ErrorModal.tsx
+++ b/src/components/modal/ErrorModal.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
-import { Button, Content } from '@patternfly/react-core';
-import { Modal } from '@patternfly/react-core/deprecated';
+import {
+  Button,
+  Content,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+} from '@patternfly/react-core';
 
 interface ErrorModalProps {
   title: string;
@@ -11,23 +17,20 @@ interface ErrorModalProps {
 
 const ErrorModal: React.FC<ErrorModalProps> = ({ title, errorMessage, isOpen, onClose }) => {
   return (
-    <Modal
-      title={title}
-      isOpen={isOpen}
-      onClose={onClose}
-      aria-label="Error details modal"
-      className="pf-m-sm"
-      actions={[
+    <Modal isOpen={isOpen} onClose={onClose} aria-label="Error details modal" variant="small">
+      <ModalHeader title={title} />
+      <ModalBody>
+        <Content>
+          <Content component="pre" style={{ whiteSpace: 'pre-wrap' }}>
+            {errorMessage}
+          </Content>
+        </Content>
+      </ModalBody>
+      <ModalFooter>
         <Button key="close" variant="primary" onClick={onClose}>
           Close
-        </Button>,
-      ]}
-    >
-      <Content>
-        <Content component="pre" style={{ whiteSpace: 'pre-wrap' }}>
-          {errorMessage}
-        </Content>
-      </Content>
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 };

--- a/src/components/modal/ErrorModal.tsx
+++ b/src/components/modal/ErrorModal.tsx
@@ -1,37 +1,24 @@
 import React from 'react';
-import {
-  Button,
-  Content,
-  Modal,
-  ModalBody,
-  ModalFooter,
-  ModalHeader,
-} from '@patternfly/react-core';
+import { Button, Content } from '@patternfly/react-core';
+import { ComponentProps } from './createModalLauncher';
 
-interface ErrorModalProps {
-  title: string;
+type ErrorModalProps = ComponentProps & {
   errorMessage: string;
-  isOpen: boolean;
-  onClose: () => void;
-}
+};
 
-const ErrorModal: React.FC<ErrorModalProps> = ({ title, errorMessage, isOpen, onClose }) => {
+const ErrorModal: React.FC<ErrorModalProps> = ({ errorMessage, onClose }) => {
   return (
-    <Modal isOpen={isOpen} onClose={onClose} aria-label="Error details modal" variant="small">
-      <ModalHeader title={title} />
-      <ModalBody>
-        <Content>
-          <Content component="pre" style={{ whiteSpace: 'pre-wrap' }}>
-            {errorMessage}
-          </Content>
+    <>
+      <Content>
+        <Content component="pre" style={{ whiteSpace: 'pre-wrap' }}>
+          {errorMessage}
         </Content>
-      </ModalBody>
-      <ModalFooter>
-        <Button key="close" variant="primary" onClick={onClose}>
-          Close
-        </Button>
-      </ModalFooter>
-    </Modal>
+      </Content>
+
+      <Button key="close" variant="primary" onClick={onClose} className="pf-v6-u-mt-md">
+        Close
+      </Button>
+    </>
   );
 };
 

--- a/src/shared/components/modal/createModalLauncher.tsx
+++ b/src/shared/components/modal/createModalLauncher.tsx
@@ -1,7 +1,18 @@
 import * as React from 'react';
-import { Modal, ModalProps as PFModalProps } from '@patternfly/react-core';
+import {
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalProps as PFModalProps,
+} from '@patternfly/react-core';
 
-export type ModalProps = Omit<PFModalProps, 'children' | 'ref'>;
+export type ModalProps = Omit<PFModalProps, 'children' | 'ref'> & {
+  title?: React.ReactNode;
+  titleIconVariant?: 'success' | 'danger' | 'warning' | 'info' | 'custom' | React.ComponentType;
+  description?: React.ReactNode;
+  actions?: React.ReactNode[];
+};
 
 type ModalComponentProps = Omit<ModalProps, 'isOpen' | 'appendTo'> & {
   'data-test': string;
@@ -51,12 +62,22 @@ export const createModalLauncher = <D extends Record<string, unknown>, P extends
   Component: React.ComponentType<React.PropsWithChildren<P>>,
   inModalProps: ModalComponentProps,
 ) =>
-  createRawModalLauncher(
-    ({ modalProps, ...props }: P & { modalProps?: ModalProps }) => (
-      <Modal {...modalProps}>
-        {/* eslint-disable-next-line */}
-        <Component {...(props as any)} />
+  createRawModalLauncher(({ modalProps, ...props }: P & { modalProps?: ModalProps }) => {
+    const { title, titleIconVariant, description, actions, ...rest } = modalProps || {};
+    return (
+      <Modal {...rest}>
+        {title !== undefined && (
+          <ModalHeader
+            title={title}
+            titleIconVariant={titleIconVariant}
+            description={description}
+          />
+        )}
+        <ModalBody>
+          {/* eslint-disable-next-line */}
+          <Component {...(props as any)} />
+        </ModalBody>
+        {actions?.length > 0 && <ModalFooter>{actions}</ModalFooter>}
       </Modal>
-    ),
-    inModalProps,
-  );
+    );
+  }, inModalProps);

--- a/src/shared/components/table/ColumnManagement.tsx
+++ b/src/shared/components/table/ColumnManagement.tsx
@@ -8,8 +8,12 @@ import {
   ContentVariants,
   Flex,
   FlexItem,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
 } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 
 export interface ColumnDefinition<T extends string> {
   key: T;
@@ -45,7 +49,6 @@ function ColumnManagement<T extends string>({
   const previouslyOpen = React.useRef(false);
 
   React.useEffect(() => {
-    // Only sync when modal first opens, not when it's already open
     if (isOpen && !previouslyOpen.current) {
       setLocalVisibleColumns(new Set(visibleColumns));
     }
@@ -55,7 +58,6 @@ function ColumnManagement<T extends string>({
   const handleColumnToggle = (columnKey: T) => {
     const newColumns = new Set(localVisibleColumns);
     if (newColumns.has(columnKey)) {
-      // Don't allow hiding non-hidable columns
       if (!nonHidableColumns.includes(columnKey)) {
         newColumns.delete(columnKey);
       }
@@ -74,48 +76,44 @@ function ColumnManagement<T extends string>({
     setLocalVisibleColumns(new Set(defaultVisibleColumns));
   };
 
-  // Show all columns, but non-hidable ones will be disabled
-
   return (
-    <Modal
-      variant={ModalVariant.medium}
-      title={title}
-      isOpen={isOpen}
-      onClose={onClose}
-      actions={[
+    <Modal variant={ModalVariant.medium} isOpen={isOpen} onClose={onClose}>
+      <ModalHeader title={title} />
+      <ModalBody>
+        <Content>
+          <Content component={ContentVariants.p}>{description}</Content>
+        </Content>
+        <Form>
+          <FormGroup>
+            <Flex direction={{ default: 'column' }}>
+              <FlexItem className="pf-v6-u-my-md">
+                <Button variant="primary" onClick={handleReset}>
+                  Reset to default
+                </Button>
+              </FlexItem>
+              {columns.map((column) => (
+                <FlexItem key={column.key}>
+                  <Checkbox
+                    id={`column-${column.key}`}
+                    label={column.title}
+                    isChecked={localVisibleColumns.has(column.key)}
+                    onChange={() => handleColumnToggle(column.key)}
+                    isDisabled={nonHidableColumns.includes(column.key)}
+                  />
+                </FlexItem>
+              ))}
+            </Flex>
+          </FormGroup>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
         <Button key="save" variant="primary" onClick={handleSave}>
           Save
-        </Button>,
+        </Button>
         <Button key="cancel" variant="link" onClick={onClose}>
           Cancel
-        </Button>,
-      ]}
-    >
-      <Content>
-        <Content component={ContentVariants.p}>{description}</Content>
-      </Content>
-      <Form>
-        <FormGroup>
-          <Flex direction={{ default: 'column' }}>
-            <FlexItem className="pf-v6-u-my-md">
-              <Button variant="primary" onClick={handleReset}>
-                Reset to default
-              </Button>
-            </FlexItem>
-            {columns.map((column) => (
-              <FlexItem key={column.key}>
-                <Checkbox
-                  id={`column-${column.key}`}
-                  label={column.title}
-                  isChecked={localVisibleColumns.has(column.key)}
-                  onChange={() => handleColumnToggle(column.key)}
-                  isDisabled={nonHidableColumns.includes(column.key)}
-                />
-              </FlexItem>
-            ))}
-          </Flex>
-        </FormGroup>
-      </Form>
+        </Button>
+      </ModalFooter>
     </Modal>
   );
 }

--- a/src/shared/components/truncate-text/Truncate.tsx
+++ b/src/shared/components/truncate-text/Truncate.tsx
@@ -1,12 +1,7 @@
 import * as React from 'react';
-import {
-  Button,
-  Content,
-  Modal,
-  ModalBody,
-  ModalHeader,
-  ModalVariant,
-} from '@patternfly/react-core';
+import { Button, Content, ModalVariant } from '@patternfly/react-core';
+import { ComponentProps, createModalLauncher } from '../../../components/modal/createModalLauncher';
+import { useModalLauncher } from '../../../components/modal/ModalProvider';
 
 const DEFAULT_MAX_LENGTH = 80;
 
@@ -17,17 +12,29 @@ export type TruncateProps = {
   'data-test'?: string;
 };
 
+type TruncateModalProps = ComponentProps & {
+  content: string;
+};
+
+const TruncateModal: React.FC<React.PropsWithChildren<TruncateModalProps>> = ({ content }) => {
+  return (
+    <Content>
+      <Content component="p" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+        {content}
+      </Content>
+    </Content>
+  );
+};
+
 export const Truncate: React.FC<TruncateProps> = ({
   content,
   modalTitle,
   maxLength = DEFAULT_MAX_LENGTH,
   'data-test': dataTest,
 }) => {
-  const [isModalOpen, setIsModalOpen] = React.useState(false);
-  const shouldTruncate = content.length > maxLength;
+  const showModal = useModalLauncher();
 
-  const handleOpen = () => setIsModalOpen(true);
-  const handleClose = () => setIsModalOpen(false);
+  const shouldTruncate = content.length > maxLength;
 
   if (!shouldTruncate) {
     return <span data-test={dataTest}>{content}</span>;
@@ -41,27 +48,20 @@ export const Truncate: React.FC<TruncateProps> = ({
       <Button
         variant="link"
         isInline
-        onClick={handleOpen}
+        onClick={() =>
+          showModal(
+            createModalLauncher(TruncateModal, {
+              'data-test': dataTest ? `${dataTest}-modal` : 'truncate-modal',
+              variant: ModalVariant.medium,
+              title: modalTitle,
+            })({ content }),
+          )
+        }
         data-test={dataTest}
         style={{ textAlign: 'left' }}
       >
         more
       </Button>
-      <Modal
-        isOpen={isModalOpen}
-        onClose={handleClose}
-        variant={ModalVariant.medium}
-        data-test={dataTest ? `${dataTest}-modal` : 'truncate-modal'}
-      >
-        {modalTitle && <ModalHeader title={modalTitle} />}
-        <ModalBody>
-          <Content>
-            <Content component="p" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
-              {content}
-            </Content>
-          </Content>
-        </ModalBody>
-      </Modal>
     </>
   );
 };

--- a/src/shared/components/truncate-text/Truncate.tsx
+++ b/src/shared/components/truncate-text/Truncate.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
-import { Button, Content } from '@patternfly/react-core';
-import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
+import {
+  Button,
+  Content,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalVariant,
+} from '@patternfly/react-core';
 
 const DEFAULT_MAX_LENGTH = 80;
 
@@ -11,12 +17,6 @@ export type TruncateProps = {
   'data-test'?: string;
 };
 
-/**
- * Truncate component
- *
- * Displays text content, truncating it if it exceeds the specified maxLength.
- * When truncated, clicking on 'more' opens a modal displaying the full content.
- */
 export const Truncate: React.FC<TruncateProps> = ({
   content,
   modalTitle,
@@ -50,15 +50,17 @@ export const Truncate: React.FC<TruncateProps> = ({
       <Modal
         isOpen={isModalOpen}
         onClose={handleClose}
-        title={modalTitle}
         variant={ModalVariant.medium}
         data-test={dataTest ? `${dataTest}-modal` : 'truncate-modal'}
       >
-        <Content>
-          <Content component="p" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
-            {content}
+        {modalTitle && <ModalHeader title={modalTitle} />}
+        <ModalBody>
+          <Content>
+            <Content component="p" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+              {content}
+            </Content>
           </Content>
-        </Content>
+        </ModalBody>
       </Modal>
     </>
   );

--- a/src/shared/components/truncate-text/__tests__/Truncate.spec.tsx
+++ b/src/shared/components/truncate-text/__tests__/Truncate.spec.tsx
@@ -1,11 +1,21 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { Truncate } from '../Truncate';
 
+const showModalMock = jest.fn();
+
+jest.mock('../../../../components/modal/ModalProvider', () => ({
+  useModalLauncher: () => showModalMock,
+}));
+
 describe('Truncate', () => {
   const shortContent = 'Hello';
   const exactLengthContent = 'A'.repeat(80); // Exactly 80 characters
   const longContent =
     'This is a very long text that exceeds the default maximum length of 80 characters and should be truncated';
+
+  beforeEach(() => {
+    showModalMock.mockClear();
+  });
 
   it('should render full text when content is shorter than 80 characters', () => {
     render(<Truncate content={shortContent} />);
@@ -21,19 +31,16 @@ describe('Truncate', () => {
 
   it('should truncate text when content is longer than 80 characters', () => {
     render(<Truncate content={longContent} />);
-    // Should show first 80 characters followed by "...more" button
     expect(screen.getByText(`${longContent.slice(0, 80)}...`)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'more' })).toBeInTheDocument();
   });
 
-  it('should open modal with full text when "more" is clicked', () => {
+  it('should open modal when "more" is clicked', () => {
     render(<Truncate content={longContent} modalTitle="Full Text" />);
 
-    // Click the "...more" button
     fireEvent.click(screen.getByRole('button', { name: 'more' }));
 
-    // Modal should be open with full text
-    expect(screen.getByText(longContent)).toBeInTheDocument();
+    expect(showModalMock).toHaveBeenCalledTimes(1);
   });
 
   it('should use custom maxLength when provided', () => {
@@ -42,27 +49,12 @@ describe('Truncate', () => {
     expect(screen.getByRole('button', { name: 'more' })).toBeInTheDocument();
   });
 
-  it('should use custom modal title when provided', () => {
+  it('should launch modal with custom title when provided', () => {
     render(<Truncate content={longContent} modalTitle="View Details" />);
 
     fireEvent.click(screen.getByRole('button', { name: 'more' }));
 
-    expect(screen.getByText('View Details')).toBeInTheDocument();
-  });
-
-  it('should close modal when close button is clicked', () => {
-    render(<Truncate content={longContent} />);
-
-    // Open modal
-    fireEvent.click(screen.getByRole('button', { name: 'more' }));
-    expect(screen.getByText(longContent)).toBeInTheDocument();
-
-    // Close modal
-    const closeButton = screen.getByRole('button', { name: /close/i });
-    fireEvent.click(closeButton);
-
-    // Modal content should not be visible (only truncated text remains)
-    expect(screen.getByText(`${longContent.slice(0, 80)}...`)).toBeInTheDocument();
+    expect(showModalMock).toHaveBeenCalledTimes(1);
   });
 
   it('should handle empty string content', () => {


### PR DESCRIPTION
## Fixes
Fixes: https://issues.redhat.com/browse/KFLUXUI-1410

## Description
Migrates all Modal usage from the deprecated props-based API (`@patternfly/react-core/deprecated`) to the PF v6 composable API using `ModalHeader`, `ModalBody`, and `ModalFooter` as children. See [PF v6 Modal docs](https://www.patternfly.org/components/modal/).

**Changes by category:**

1. **Core abstraction** — `createModalLauncher` now renders the composable Modal structure (`ModalHeader` + `ModalBody` + `ModalFooter`), which automatically migrates ~14 consumer files.

2. **Raw modal consumers** — manually migrated `SecretModal`, `RevokeAccessModal`, `cr-modals`, `CustomizeAllPipelines`/`CustomizePipelines`, and `PipelineRunSBOMsModal`.

3. **Standalone modals** — manually migrated `ErrorModal`, `Truncate`, and `ColumnManagement`.

4. **Import cleanup** — moved `ModalVariant` from `@patternfly/react-core/deprecated` to `@patternfly/react-core` across ~14 files.

5. **Test fix** — added `ModalHeader` to `CustomizeAllPipelines` error state to satisfy PF v6's focus-trap requirement (needs at least one tabbable node).

## Type of change

- [x] Bugfix

## Screen shots / Gifs for design review
<!-- Screen recording to be attached -->

https://github.com/user-attachments/assets/91eae91b-3d42-4489-9a96-df4cced218bb


## How to test or reproduce?
- Open any modal in the app (delete resource, about, feedback, secrets, revoke access, component relations, customize pipelines, SBOMs, error details, truncated text, column management)
- Verify modals open with correct header, body content, and footer buttons
- Verify modals close properly via close button and cancel actions

## Browser conformance:
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge