### PR TITLE
fix(KFLUXUI-1419): use primary variant for toolbar action buttons

### DIFF
--- a/src/components/Components/ComponentsListView/ComponentListView.tsx
+++ b/src/components/Components/ComponentsListView/ComponentListView.tsx
@@ -222,7 +222,7 @@ const ComponentListView: React.FC<React.PropsWithChildren<ComponentListViewProps
         options={statusFilterObj}
       />
       <ButtonWithAccessTooltip
-        variant="secondary"
+        variant="primary"
         component={(p) => (
           <Link
             {...p}

--- a/src/components/Components/LinkSecret/LinkSecretView.tsx
+++ b/src/components/Components/LinkSecret/LinkSecretView.tsx
@@ -6,7 +6,7 @@ export const LinkSecretView = () => {
   const showModal = useModalLauncher();
   return (
     <>
-      <Button variant="secondary" onClick={() => showModal(createLinkSecretModalLauncher()())}>
+      <Button variant="primary" onClick={() => showModal(createLinkSecretModalLauncher()())}>
         Link Secrets
       </Button>
     </>

--- a/src/components/Filter/components/ColumnManagementButton.tsx
+++ b/src/components/Filter/components/ColumnManagementButton.tsx
@@ -15,7 +15,7 @@ const ColumnManagementButton: React.FC<ColumnManagementButtonProps> = ({
   }
 
   return (
-    <Button variant="secondary" aria-label="Manage columns" onClick={onClick}>
+    <Button variant="primary" aria-label="Manage columns" onClick={onClick}>
       Manage columns
     </Button>
   );

--- a/src/components/IntegrationTests/IntegrationTestsListView/IntegrationTestsListView.tsx
+++ b/src/components/IntegrationTests/IntegrationTestsListView/IntegrationTestsListView.tsx
@@ -103,7 +103,7 @@ const IntegrationTestsListView: React.FC<React.PropsWithChildren> = () => {
       dataTest="integration-list-toolbar"
     >
       <ButtonWithAccessTooltip
-        variant={ButtonVariant.secondary}
+        variant={ButtonVariant.primary}
         onClick={handleAddTest}
         isDisabled={!canCreateIntegrationTest}
         tooltip="You don't have access to add an integration test"


### PR DESCRIPTION
## Fixes

- https://issues.redhat.com/browse/KFLUXUI-1419

## Description

Changed Add component, Add integration test, Manage columns, and Link Secrets buttons from secondary to primary variant per [PatternFly toolbar guidance](https://www.patternfly.org/components/table/html-demos/basic/).

The other issues previously tracked here (KFLUXUI-1414, KFLUXUI-1417) were resolved by #1068.

## Type of change

- [x] Bugfix

## Screenshots for design review

### Add component button → primary (ComponentListView)
| Before | After |
|--------|-------|
| <img width="827" height="139" alt="component-list-view-add-component-button-secondary-BEFORE" src="https://github.com/user-attachments/assets/757b29dd-245b-4b7d-8eb2-4447154ddefa" /> | <img width="827" height="105" alt="component-list-view-add-component-button-primary-AFTER" src="https://github.com/user-attachments/assets/a88980da-3ab8-4b6b-9598-da534a99fb41" /> |

### Add integration test button → primary (IntegrationTestsListView)
| Before | After |
|--------|-------|
| <img width="497" height="127" alt="integration-tests-list-view-add-integration-test-button-secondary-BEFORE" src="https://github.com/user-attachments/assets/b90c5102-710e-488d-a97c-e9d0f9ba0a1b" /> | <img width="499" height="131" alt="integration-tests-list-view-add-integration-test-button-primary-AFTER" src="https://github.com/user-attachments/assets/ebe450fc-5f3d-4d2c-8a52-630f81dcdb94" /> |

### Link Secrets button → primary (LinkedSecretsListView)
| Before | After |
|--------|-------|
| <img width="380" height="118" alt="linked-secrets-list-view-link-secrets-button-secondary-BEFORE" src="https://github.com/user-attachments/assets/b53de88d-b0cc-411e-ac78-105f2f637f70" /> | <img width="368" height="116" alt="linked-secrets-list-view-link-secrets-button-primary-AFTER" src="https://github.com/user-attachments/assets/5673ef06-dffc-467f-be35-66e255a5cac8" /> |

### Manage columns button → primary
| Before | After |
|--------|-------|
| <img width="715" height="205" alt="manage-columns-button-secondary-BEFORE" src="https://github.com/user-attachments/assets/3bff2057-b11a-4026-a34e-7730f2e8c193" /> | <img width="713" height="194" alt="manage-columns-button-primary-AFTER" src="https://github.com/user-attachments/assets/493d8bb5-22bc-43b8-97cc-45cb9c19a21a" /> |

## How to test or reproduce?

- Verify Add component, Add integration test, Link Secrets, and Manage columns buttons use primary styling

## Browser conformance
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge