### PR TITLE
fix(KFLUXUI-1416): fix Components tab layout issues for PF v6

### DIFF
--- a/src/components/Components/ComponentDetails/ComponentDetailsView.tsx
+++ b/src/components/Components/ComponentDetails/ComponentDetailsView.tsx
@@ -78,7 +78,6 @@ const ComponentDetailsView: React.FC = () => {
             title="For maximum security, upgrade the build pipeline plans for your component."
             imgSrc={pipelineImg}
             imgAlt="build pipeline plans"
-            isLight
           >
             <div>
               Using the Advanced or Custom build pipeline, you can enable all additional tasks for

--- a/src/components/Components/ComponentsListView/ComponentListView.tsx
+++ b/src/components/Components/ComponentsListView/ComponentListView.tsx
@@ -177,7 +177,7 @@ const ComponentListView: React.FC<React.PropsWithChildren<ComponentListViewProps
         title="Upgrade build pipeline plans for your components."
         imgSrc={pipelineImg}
         imgAlt="build pipeline plans"
-        isLight
+        hasHorizontalPadding={false}
       >
         <Flex
           justifyContent={{ default: 'justifyContentSpaceBetween' }}

--- a/src/components/Components/ComponentsListView/ComponentListView.tsx
+++ b/src/components/Components/ComponentsListView/ComponentListView.tsx
@@ -271,7 +271,7 @@ const ComponentListView: React.FC<React.PropsWithChildren<ComponentListViewProps
       {gettingStartedCard}
       {componentsLoaded && pipelineRunsLoaded && pendingCount > 0 && !mergeAlertHidden ? (
         <Alert
-          className="pf-v6-u-mt-md"
+          className="pf-v6-u-my-md"
           variant={AlertVariant.warning}
           isInline
           title={`${pluralize(

--- a/src/components/GettingStartedCard/GettingStartedCard.tsx
+++ b/src/components/GettingStartedCard/GettingStartedCard.tsx
@@ -20,7 +20,7 @@ type GettingStartedCardProps = {
   title: string;
   imgSrc?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   imgAlt?: string;
-  isLight?: boolean;
+  hasHorizontalPadding?: boolean;
 };
 
 const LOCAL_STORAGE_KEY = 'getting-started-card';
@@ -31,8 +31,8 @@ export const GettingStartedCard: React.FC<React.PropsWithChildren<GettingStarted
   title,
   imgSrc,
   imgAlt,
-  isLight,
   children,
+  hasHorizontalPadding = true,
 }) => {
   const [storageKeys, setStorageKeys] = useLocalStorage<{ [key: string]: boolean }>(
     LOCAL_STORAGE_KEY,
@@ -44,7 +44,10 @@ export const GettingStartedCard: React.FC<React.PropsWithChildren<GettingStarted
 
   return (
     !isDismissed && (
-      <PageSection hasBodyWrapper={false} variant={isLight ? 'secondary' : 'default'}>
+      <PageSection
+        hasBodyWrapper={false}
+        className={`pf-v6-u-py-xl ${hasHorizontalPadding ? '' : 'pf-v6-u-px-0'}`}
+      >
         <Card>
           <Split>
             {imgSrc && (


### PR DESCRIPTION
## Fixes

- https://issues.redhat.com/browse/KFLUXUI-1416

## Description

Fixes layout issues in the Components tab caused by the PF v6 migration:

- **Gray background removed**: The PF v6 `secondary` PageSection variant adds a visible background and borders that weren't present in v5. Replaced with utility classes for spacing.
- **Card alignment**: Added `hasHorizontalPadding` prop to GettingStartedCard so the ComponentListView card aligns with the "Components" heading and description text.
- **Alert/filter spacing**: Removing the `secondary` variant's extra borders restores proper spacing between the warning alert and the filter toolbar.

Also removed the unused `isLight` prop from GettingStartedCard and its usage in ComponentDetailsView.

## Type of change

- [x] Bugfix

## Screenshots for design review

### Before

https://github.com/user-attachments/assets/6fea19cc-5ef8-49f9-9257-d544f54d0a32

### After

https://github.com/user-attachments/assets/b7e6ff72-b05f-4294-91fd-8f068523e34d


## How to test or reproduce?

- Navigate to an application's Components tab
- Verify the "Upgrade build pipeline plans" card has no gray background
- Verify the card is aligned with the "Components" heading
- Verify there is spacing between the warning alert and the filter toolbar

## Browser conformance
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge