### PR TITLE
fix(KFLUXUI-1415): restore overview banner border radius and border styling

### DIFF
--- a/src/components/Overview/IntroBanner.scss
+++ b/src/components/Overview/IntroBanner.scss
@@ -1,5 +1,9 @@
 .intro-banner {
   background: linear-gradient(90deg, var(--banner-gradient, white) 0%, var(--banner-gradient, white) 40%, var(--banner-gradient-end, #D1D1D1) 100%);
+  border-width: var(--pf-t--global--border--width--box--default);
+  border-color: var(--pf-t--global--border--color--subtle);
+  border-style: solid;
+  border-radius: var(--pf-t--global--border--radius--medium);
 
   &__content {
     background-color: transparent;

--- a/src/components/Overview/IntroBanner.tsx
+++ b/src/components/Overview/IntroBanner.tsx
@@ -30,6 +30,7 @@ const IntroBanner: React.FC = () => {
           className="intro-banner__content"
           isLarge
           isFullHeight
+          isPlain
           data-test="intro-banner-content"
         >
           <CardTitle>


### PR DESCRIPTION
## Fixes
Fixes: https://issues.redhat.com/browse/KFLUXUI-1415

## Description
The overview intro banner lost its border radius and border styling after the PF v6 migration. PF v6 cards render borders by default, which clashed with the banner's custom gradient background. This fix adds `isPlain` to the Card to remove the default card border, then applies border and border-radius explicitly using PF v6 global design tokens.

## Type of change

- [x] Bugfix

## Screen shots / Gifs for design review

**Before:**
<!-- upload before screenshot -->

**After:**
<!-- upload after screenshot -->

## How to test or reproduce?
- Navigate to the Overview page
- Verify the intro banner has rounded corners and a subtle border
- Verify the gradient background renders correctly

## Browser conformance:
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge