### PR TITLE
chore(KFLUXUI-1443): adding labels to dependency update PRs

### DIFF
--- a/.github/workflows/pr-deps-label.yaml
+++ b/.github/workflows/pr-deps-label.yaml
@@ -1,0 +1,79 @@
+name: Label Dependency Update PRs
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+  workflow_dispatch:
+
+jobs:
+  label-deps-pr:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.action == 'opened' ||
+      github.event.action == 'reopened' ||
+      (github.event.action == 'edited' && github.event.changes.title)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Label chore(deps) pull requests
+        continue-on-error: true
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const label = 'update of dependencies';
+            const { owner, repo } = context.repo;
+
+            const syncLabel = async (prNumber, title) => {
+              try {
+                const isDepsPr = title.startsWith('chore(deps)');
+
+                const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                });
+                const hasLabel = labels.some((entry) => entry.name === label);
+
+                if (isDepsPr && !hasLabel) {
+                  await github.rest.issues.addLabels({
+                    owner,
+                    repo,
+                    issue_number: prNumber,
+                    labels: [label],
+                  });
+                  console.log(`Added label "${label}" to PR #${prNumber}`);
+                } else if (!isDepsPr && hasLabel) {
+                  await github.rest.issues.removeLabel({
+                    owner,
+                    repo,
+                    issue_number: prNumber,
+                    name: label,
+                  });
+                  console.log(`Removed label "${label}" from PR #${prNumber}`);
+                } else {
+                  console.log(`No label change needed for PR #${prNumber}`);
+                }
+              } catch (error) {
+                console.warn(`Failed to sync label for PR #${prNumber}: ${error.message}`);
+              }
+            };
+
+            if (context.eventName === 'workflow_dispatch') {
+              const { data: pullRequests } = await github.rest.pulls.list({
+                owner,
+                repo,
+                state: 'open',
+                per_page: 100,
+              });
+
+              for (const pullRequest of pullRequests) {
+                await syncLabel(pullRequest.number, pullRequest.title);
+              }
+              return;
+            }
+
+            const pullRequest = context.payload.pull_request;
+            await syncLabel(pullRequest.number, pullRequest.title);

--- a/.github/workflows/pr-deps-label.yaml
+++ b/.github/workflows/pr-deps-label.yaml
@@ -1,79 +1,60 @@
-name: Label Dependency Update PRs
+name: PR Dependency Update Label
 
 on:
   pull_request_target:
     types: [opened, edited, reopened]
-  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   label-deps-pr:
     if: >-
-      github.event_name == 'workflow_dispatch' ||
       github.event.action == 'opened' ||
       github.event.action == 'reopened' ||
       (github.event.action == 'edited' && github.event.changes.title)
     runs-on: ubuntu-latest
     continue-on-error: true
     permissions:
+      issues: write
       pull-requests: write
     steps:
-      - name: Label chore(deps) pull requests
-        continue-on-error: true
-        uses: actions/github-script@v9
+      - name: Label dependency update pull requests
+        uses: actions/github-script@v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const label = 'update of dependencies';
             const { owner, repo } = context.repo;
 
-            const syncLabel = async (prNumber, title) => {
-              try {
-                const isDepsPr = title.startsWith('chore(deps)');
-
-                const { data: labels } = await github.rest.issues.listLabelsOnIssue({
-                  owner,
-                  repo,
-                  issue_number: prNumber,
-                });
-                const hasLabel = labels.some((entry) => entry.name === label);
-
-                if (isDepsPr && !hasLabel) {
-                  await github.rest.issues.addLabels({
-                    owner,
-                    repo,
-                    issue_number: prNumber,
-                    labels: [label],
-                  });
-                  console.log(`Added label "${label}" to PR #${prNumber}`);
-                } else if (!isDepsPr && hasLabel) {
-                  await github.rest.issues.removeLabel({
-                    owner,
-                    repo,
-                    issue_number: prNumber,
-                    name: label,
-                  });
-                  console.log(`Removed label "${label}" from PR #${prNumber}`);
-                } else {
-                  console.log(`No label change needed for PR #${prNumber}`);
-                }
-              } catch (error) {
-                console.warn(`Failed to sync label for PR #${prNumber}: ${error.message}`);
+            const addLabelIfNeeded = async (prNumber, title) => {
+              const isDepsPr = title.startsWith('chore(deps)') || title.startsWith('fix(deps)');
+              if (!isDepsPr) {
+                console.log(`Skipping PR #${prNumber} — not a dependency update PR`);
+                return;
               }
-            };
 
-            if (context.eventName === 'workflow_dispatch') {
-              const { data: pullRequests } = await github.rest.pulls.list({
+              const labels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
                 owner,
                 repo,
-                state: 'open',
-                per_page: 100,
+                issue_number: prNumber,
               });
+              const hasLabel = labels.some((entry) => entry.name === label);
 
-              for (const pullRequest of pullRequests) {
-                await syncLabel(pullRequest.number, pullRequest.title);
+              if (hasLabel) {
+                console.log(`PR #${prNumber} already has label "${label}"`);
+                return;
               }
-              return;
-            }
+
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: prNumber,
+                labels: [label],
+              });
+              console.log(`Added label "${label}" to PR #${prNumber}`);
+            };
 
             const pullRequest = context.payload.pull_request;
-            await syncLabel(pullRequest.number, pullRequest.title);
+            await addLabelIfNeeded(pullRequest.number, pullRequest.title);


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->
https://issues.redhat.com/browse/KFLUXUI-1443

## Description
Adds label to PRs which update dependencies


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an automated GitHub Actions workflow that inspects pull request titles and applies an “update of dependencies” label to dependency-related PRs.

* **Chores**
  * Runs on pull request open and reopen, and on title edits when the title changes; adds the label only if it’s not already present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->