### PR TITLE
fix(KFLUXUI-1440): Displays status of commits in new Components page

### DIFF
--- a/src/components/Commits/CommitsListPage/CommitsListViewV2.tsx
+++ b/src/components/Commits/CommitsListPage/CommitsListViewV2.tsx
@@ -100,21 +100,6 @@ const CommitsListViewV2: React.FC<React.PropsWithChildren<CommitsListViewPropsV2
     );
   }, [pipelineRuns]);
 
-  const allVersions = React.useMemo(
-    () => component?.spec?.source?.versions ?? [],
-    [component?.spec?.source?.versions],
-  );
-  const allVersionBranches = React.useMemo(() => allVersions.map((v) => v.revision), [allVersions]);
-
-  // used in CommitListRow to calculate the correct latest PLR status
-  const allPipelineRunsFilteredByVersions = React.useMemo(
-    () =>
-      pipelineRuns?.filter((plr) =>
-        allVersionBranches.includes(plr.metadata?.labels?.[PipelineRunLabel.COMPONENT_VERSION]),
-      ) ?? [],
-    [allVersionBranches, pipelineRuns],
-  );
-
   const commits = React.useMemo(
     () => (plrLoaded && buildPipelineRuns && getCommitsFromPLRs(buildPipelineRuns)) || [],
     [plrLoaded, buildPipelineRuns],
@@ -122,7 +107,7 @@ const CommitsListViewV2: React.FC<React.PropsWithChildren<CommitsListViewPropsV2
 
   const commitPipelineRunMap = React.useMemo<Record<string, PipelineRunKind[]>>(
     () =>
-      allPipelineRunsFilteredByVersions.reduce(
+      (pipelineRuns ?? []).reduce(
         (acc, plr) => {
           const sha = getCommitSha(plr);
           if (sha) {
@@ -135,7 +120,7 @@ const CommitsListViewV2: React.FC<React.PropsWithChildren<CommitsListViewPropsV2
         },
         {} as Record<string, PipelineRunKind[]>,
       ),
-    [allPipelineRunsFilteredByVersions],
+    [pipelineRuns],
   );
 
   const commitStatusMap = React.useMemo<Record<string, runStatus>>(


### PR DESCRIPTION
Assisted-by: Cursor


## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->
https://redhat.atlassian.net/browse/KFLUXUI-1440

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Previously, `commitPipelineRunMap` and `commitStatusMap` were built from `allPipelineRunsFilteredByVersions`, which only included PLRs whose `COMPONENT_VERSION` label matched a declared version revision. Since component versions are not fully implemented yet, that filter could exclude valid pipeline runs and produce incorrect or `Unknown` commit statuses.

This change removes the version-based filtering (`allVersions`, `allVersionBranches`, `allPipelineRunsFilteredByVersions`) and uses all fetched pipelineRuns when building the commit → pipeline run map

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [X] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
**Before:**
<img width="2559" height="948" alt="Screenshot 2026-06-23 at 13 57 37" src="https://github.com/user-attachments/assets/4cb18d2b-74ad-4e6f-989d-4a638726489f" />

**After:**
<img width="2559" height="948" alt="Screenshot 2026-06-23 at 13 57 02" src="https://github.com/user-attachments/assets/7debcb7e-50d9-4ae8-8a88-ee981189c51b" />


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
- Open new `Components` page -> Select a component -> `Activity` -> `Latest commits`
- Check that the status column does not show `Unknown` for all rows
<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal data processing efficiency for pipeline runs display. Simplified how commits and pipeline run mappings are calculated to reduce computational overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->