### PR TITLE
feat(KFLUXSE-166): collapse arch-duplicate Conforma violations

### DIFF
--- a/src/components/Conforma/ConformaResultsTab/ConformaGroupedTable.tsx
+++ b/src/components/Conforma/ConformaResultsTab/ConformaGroupedTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Text, TextContent, Truncate as PfTruncate } from '@patternfly/react-core';
+import { Text, TextContent, Tooltip, Truncate as PfTruncate } from '@patternfly/react-core';
 import {
   ExpandableRowContent,
   Table,
@@ -14,6 +14,7 @@ import type { ComponentProps } from '~/shared/components/table/Table';
 import { Truncate } from '~/shared/components/truncate-text/Truncate';
 import type { ConformaResultRow } from '~/types/conforma';
 import type { GroupByMode, GroupedConformaRow } from './conforma-grouping-utils';
+import { getCommonImageName } from './conforma-grouping-utils';
 import { getConformaGroupedHeader } from './ConformaResultsListHeader';
 import ConformaResultsListRow from './ConformaResultsListRow';
 import './ConformaResultsTab.scss';
@@ -26,7 +27,12 @@ type ConformaGroupedTableProps = {
 };
 
 const DetailSubTable: React.FC<{ rows: ConformaResultRow[] }> = ({ rows }) => (
-  <Table aria-label="Conforma detail rows" variant="compact" borders={false}>
+  <Table
+    aria-label="Conforma detail rows"
+    variant="compact"
+    borders={false}
+    className="conforma-results-tab__detail-table"
+  >
     <Thead>
       <Tr>
         <Th width={20}>Rule</Th>
@@ -37,39 +43,65 @@ const DetailSubTable: React.FC<{ rows: ConformaResultRow[] }> = ({ rows }) => (
       </Tr>
     </Thead>
     <Tbody>
-      {rows.map((row, idx) => (
-        <Tr key={`${row.component}-${row.title}-${idx}`}>
-          <Td dataLabel="Rule">
-            <TextContent>
-              <Text component="p">
-                <strong>{row.title ?? '-'}</strong>
-              </Text>
-              {row.description && <Text component="small">{row.description}</Text>}
-            </TextContent>
-          </Td>
-          <Td dataLabel="Component">{row.component}</Td>
-          <Td dataLabel="Image">
-            {row.image ? <PfTruncate content={row.image} /> : '-'}
-          </Td>
-          <Td dataLabel="Status">{getRuleStatus(row.status)}</Td>
-          <Td dataLabel="Message">
-            <TextContent>
-              <Text component="p">
-                {row.msg != null ? (
-                  <Truncate
-                    content={row.msg}
-                    expandInline
-                    data-test="conforma-violation-msg"
-                  />
-                ) : (
-                  '-'
-                )}
-              </Text>
-              {row.solution && <Text component="small">Solution: {row.solution}</Text>}
-            </TextContent>
-          </Td>
-        </Tr>
-      ))}
+      {rows.map((row, idx) => {
+        const commonName = row.images.length > 1 ? getCommonImageName(row.images) : undefined;
+        return (
+          <Tr key={`${row.component}-${row.title}-${idx}`}>
+            <Td dataLabel="Rule">
+              <TextContent>
+                <Text component="p">
+                  <strong>{row.title ?? '-'}</strong>
+                </Text>
+                {row.description && <Text component="small">{row.description}</Text>}
+              </TextContent>
+            </Td>
+            <Td dataLabel="Component">{row.component}</Td>
+            <Td dataLabel="Image">
+              {row.images.length > 1 ? (
+                <Tooltip
+                  content={
+                    <ul>
+                      {row.images.map((img) => (
+                        <li key={img}>{img}</li>
+                      ))}
+                    </ul>
+                  }
+                >
+                  <TextContent>
+                    {commonName ? (
+                      <>
+                        <Text component="p">
+                          <PfTruncate content={commonName} />
+                        </Text>
+                        <Text component="small">{row.images.length} arch variants</Text>
+                      </>
+                    ) : (
+                      <Text component="p">Affects {row.images.length} images</Text>
+                    )}
+                  </TextContent>
+                </Tooltip>
+              ) : row.images.length === 1 ? (
+                <PfTruncate content={row.images[0]} />
+              ) : (
+                '-'
+              )}
+            </Td>
+            <Td dataLabel="Status">{getRuleStatus(row.status)}</Td>
+            <Td dataLabel="Message">
+              <TextContent>
+                <Text component="p">
+                  {row.msg != null ? (
+                    <Truncate content={row.msg} expandInline data-test="conforma-violation-msg" />
+                  ) : (
+                    '-'
+                  )}
+                </Text>
+                {row.solution && <Text component="small">Solution: {row.solution}</Text>}
+              </TextContent>
+            </Td>
+          </Tr>
+        );
+      })}
     </Tbody>
   </Table>
 );

--- a/src/components/Conforma/ConformaResultsTab/ConformaResultsTab.scss
+++ b/src/components/Conforma/ConformaResultsTab/ConformaResultsTab.scss
@@ -2,4 +2,8 @@
   &__summary-wrapper {
     margin-top: var(--pf-v5-global--spacer--md);
   }
+
+  &__detail-table tbody > tr > td {
+    vertical-align: top;
+  }
 }

--- a/src/components/Conforma/ConformaResultsTab/ConformaResultsTab.tsx
+++ b/src/components/Conforma/ConformaResultsTab/ConformaResultsTab.tsx
@@ -13,7 +13,13 @@ import { FilterContext, FilterContextProvider } from '~/components/Filter/generi
 import { useDeepCompareMemoize } from '~/shared';
 import { getErrorState } from '~/shared/utils/error-utils';
 import type { GroupByMode } from './conforma-grouping-utils';
-import { filterResults, groupByComponent, groupByRule } from './conforma-grouping-utils';
+import {
+  collapseArchDuplicates,
+  countResultsByStatus,
+  filterResults,
+  groupByComponent,
+  groupByRule,
+} from './conforma-grouping-utils';
 import { ConformaGroupedTable } from './ConformaGroupedTable';
 import { ConformaResultsToolbar } from './ConformaResultsToolbar';
 import { ConformaSummaryBar } from './ConformaSummaryBar';
@@ -32,9 +38,6 @@ const ConformaResultsTabContent: React.FC = () => {
     componentStatuses,
     totalComponents,
     totalFailed,
-    totalViolations,
-    totalWarnings,
-    totalSuccesses,
     loaded,
     error,
   } = useApplicationConformaResults(applicationName);
@@ -48,6 +51,7 @@ const ConformaResultsTabContent: React.FC = () => {
 
   const [groupBy, setGroupBy] = React.useState<GroupByMode>('rule');
   const [expandedGroups, setExpandedGroups] = React.useState<Set<string>>(new Set());
+  const [showDuplicates, setShowDuplicates] = React.useState(false);
 
   const handleGroupByChange = React.useCallback(
     (mode: GroupByMode) => {
@@ -57,9 +61,24 @@ const ConformaResultsTabContent: React.FC = () => {
     [],
   );
 
+  const displayResults = React.useMemo(
+    () => (showDuplicates ? allResults : collapseArchDuplicates(allResults)),
+    [allResults, showDuplicates],
+  );
+
+  // Display counts drive the primary numbers shown (they match what the
+  // table renders). Raw counts (always uncollapsed) are surfaced alongside
+  // them so the summary bar never silently hides real violations/warnings/
+  // successes that were merged away for display purposes.
+  const displayCounts = React.useMemo(
+    () => countResultsByStatus(displayResults),
+    [displayResults],
+  );
+  const rawCounts = React.useMemo(() => countResultsByStatus(allResults), [allResults]);
+
   const filteredResults = React.useMemo(
-    () => filterResults(allResults, nameFilter, statusFilter),
-    [allResults, nameFilter, statusFilter],
+    () => filterResults(displayResults, nameFilter, statusFilter),
+    [displayResults, nameFilter, statusFilter],
   );
 
   const allComponentNames = React.useMemo(
@@ -131,9 +150,12 @@ const ConformaResultsTabContent: React.FC = () => {
           <ConformaSummaryBar
             totalComponents={totalComponents}
             totalFailed={totalFailed}
-            totalViolations={totalViolations}
-            totalWarnings={totalWarnings}
-            totalSuccesses={totalSuccesses}
+            totalViolations={displayCounts.totalViolations}
+            totalWarnings={displayCounts.totalWarnings}
+            totalSuccesses={displayCounts.totalSuccesses}
+            totalViolationsRaw={rawCounts.totalViolations}
+            totalWarningsRaw={rawCounts.totalWarnings}
+            totalSuccessesRaw={rawCounts.totalSuccesses}
           />
         </div>
       </PageSection>
@@ -145,6 +167,8 @@ const ConformaResultsTabContent: React.FC = () => {
           onGroupByChange={handleGroupByChange}
           allExpanded={allExpanded}
           onToggleExpandAll={handleToggleExpandAll}
+          showDuplicates={showDuplicates}
+          onShowDuplicatesChange={setShowDuplicates}
         />
 
         {isEmpty ? (

--- a/src/components/Conforma/ConformaResultsTab/ConformaResultsToolbar.tsx
+++ b/src/components/Conforma/ConformaResultsTab/ConformaResultsToolbar.tsx
@@ -2,16 +2,19 @@ import * as React from 'react';
 import {
   Button,
   ButtonVariant,
+  Flex,
+  FlexItem,
   MenuToggle,
   Select,
   SelectList,
   SelectOption,
+  Switch,
 } from '@patternfly/react-core';
 import { FilterContext } from '~/components/Filter/generic/FilterContext';
 import { MultiSelect } from '~/components/Filter/generic/MultiSelect';
 import { BaseTextFilterToolbar } from '~/components/Filter/toolbars/BaseTextFIlterToolbar';
 import { createFilterObj } from '~/components/Filter/utils/filter-utils';
-import { useDeepCompareMemoize } from '~/shared';
+import { HelpTooltipIcon, useDeepCompareMemoize } from '~/shared';
 import { CONFORMA_RESULT_STATUS, type ConformaResultRow } from '~/types/conforma';
 import type { GroupByMode } from './conforma-grouping-utils';
 
@@ -21,6 +24,8 @@ type ConformaResultsToolbarProps = {
   onGroupByChange: (value: GroupByMode) => void;
   allExpanded: boolean;
   onToggleExpandAll: () => void;
+  showDuplicates: boolean;
+  onShowDuplicatesChange: (checked: boolean) => void;
 };
 
 const statuses = [
@@ -34,12 +39,17 @@ const groupByLabels: Record<GroupByMode, string> = {
   component: 'Component',
 };
 
+const SHOW_DUPLICATES_HELP_TEXT =
+  'When enabled, policy violations that share the same rule, message, and component but differ only by image digest (e.g. multi-arch builds) are shown as separate rows instead of being merged.';
+
 export const ConformaResultsToolbar: React.FC<ConformaResultsToolbarProps> = ({
   allResults,
   groupBy,
   onGroupByChange,
   allExpanded,
   onToggleExpandAll,
+  showDuplicates,
+  onShowDuplicatesChange,
 }) => {
   const { filters: unparsedFilters, setFilters, onClearFilters } = React.useContext(FilterContext);
   const filters = useDeepCompareMemoize({
@@ -101,6 +111,20 @@ export const ConformaResultsToolbar: React.FC<ConformaResultsToolbarProps> = ({
       >
         {allExpanded ? 'Collapse all' : 'Expand all'}
       </Button>
+      <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
+        <FlexItem>
+          <Switch
+            id="conforma-show-duplicates"
+            label="Show multi-arch duplicates"
+            isChecked={showDuplicates}
+            onChange={(_event, checked) => onShowDuplicatesChange(checked)}
+            data-test="conforma-show-duplicates"
+          />
+        </FlexItem>
+        <FlexItem>
+          <HelpTooltipIcon content={SHOW_DUPLICATES_HELP_TEXT} />
+        </FlexItem>
+      </Flex>
     </BaseTextFilterToolbar>
   );
 };

--- a/src/components/Conforma/ConformaResultsTab/ConformaSummaryBar.tsx
+++ b/src/components/Conforma/ConformaResultsTab/ConformaSummaryBar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Divider, Flex, FlexItem, Tooltip } from '@patternfly/react-core';
+import { Divider, Flex, FlexItem, Text, TextVariants, Tooltip } from '@patternfly/react-core';
 import { CheckCircleIcon } from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
 import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
@@ -14,21 +14,39 @@ type ConformaSummaryBarProps = {
   totalViolations: number;
   totalWarnings: number;
   totalSuccesses: number;
+  /**
+   * Raw (non-collapsed) counts. When provided and greater than the
+   * corresponding collapsed count, a "(N incl. multi-arch)" qualifier is
+   * shown so the summary bar never silently under-reports the true number
+   * of violations/warnings/successes when arch-duplicates are collapsed.
+   */
+  totalViolationsRaw?: number;
+  totalWarningsRaw?: number;
+  totalSuccessesRaw?: number;
 };
 
 type SummaryItemDef = {
   icon: React.ReactNode;
   count: number;
+  rawCount?: number;
   label: string;
   tooltip: string;
 };
 
-const SummaryItem: React.FC<SummaryItemDef> = ({ icon, count, label, tooltip }) => (
+const SummaryItem: React.FC<SummaryItemDef> = ({ icon, count, rawCount, label, tooltip }) => (
   <Tooltip content={tooltip}>
     <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
       <FlexItem>{icon}</FlexItem>
       <FlexItem>
         <strong>{count}</strong> {label}
+        {rawCount !== undefined && rawCount !== count && (
+          <Text
+            component={TextVariants.small}
+            className="pf-v5-u-ml-xs pf-v5-u-color-400"
+          >
+            ({rawCount} incl. multi-arch)
+          </Text>
+        )}
       </FlexItem>
     </Flex>
   </Tooltip>
@@ -40,6 +58,9 @@ export const ConformaSummaryBar: React.FC<ConformaSummaryBarProps> = ({
   totalViolations,
   totalWarnings,
   totalSuccesses,
+  totalViolationsRaw,
+  totalWarningsRaw,
+  totalSuccessesRaw,
 }) => {
   const items: SummaryItemDef[] = [
     {
@@ -57,18 +78,21 @@ export const ConformaSummaryBar: React.FC<ConformaSummaryBarProps> = ({
     {
       icon: <ExclamationCircleIcon color={dangerColor.value} />,
       count: totalViolations,
+      rawCount: totalViolationsRaw,
       label: 'Violations',
       tooltip: 'Total individual policy rule violations across all components',
     },
     {
       icon: <ExclamationTriangleIcon color={warningColor.value} />,
       count: totalWarnings,
+      rawCount: totalWarningsRaw,
       label: 'Warnings',
       tooltip: 'Total individual policy rule warnings across all components',
     },
     {
       icon: <CheckCircleIcon color={successColor.value} />,
       count: totalSuccesses,
+      rawCount: totalSuccessesRaw,
       label: 'Successes',
       tooltip: 'Total individual policy rules that passed across all components',
     },

--- a/src/components/Conforma/ConformaResultsTab/__tests__/ConformaGroupedTable.spec.tsx
+++ b/src/components/Conforma/ConformaResultsTab/__tests__/ConformaGroupedTable.spec.tsx
@@ -13,6 +13,7 @@ const createRow = (overrides: Partial<ConformaResultRow> = {}): ConformaResultRo
   status: CONFORMA_RESULT_STATUS.violations,
   component: 'test-component',
   msg: 'Test message',
+  images: [],
   ...overrides,
 });
 
@@ -132,6 +133,135 @@ describe('ConformaGroupedTable', () => {
     expect(screen.getAllByText('Message').length).toBeGreaterThanOrEqual(1);
   });
 
+  it('shows common image name and arch variant count when row has multiple images', () => {
+    const groupsWithMultipleImages: GroupedConformaRow[] = [
+      {
+        groupKey: 'Multi-arch rule',
+        violations: 1,
+        warnings: 0,
+        successes: 0,
+        rows: [
+          createRow({
+            images: ['quay.io/test/img@sha256:aaa', 'quay.io/test/img@sha256:bbb', 'quay.io/test/img@sha256:ccc'],
+          }),
+        ],
+      },
+    ];
+    const expandedGroups = new Set(['Multi-arch rule']);
+    routerRenderer(
+      <ConformaGroupedTable
+        {...defaultProps}
+        groups={groupsWithMultipleImages}
+        expandedGroups={expandedGroups}
+      />,
+    );
+
+    expect(screen.getByText('quay.io/test/img')).toBeInTheDocument();
+    expect(screen.getByText('3 arch variants')).toBeInTheDocument();
+  });
+
+  it('falls back to "Affects N images" when images have different repo names', () => {
+    const groupsWithDifferentImages: GroupedConformaRow[] = [
+      {
+        groupKey: 'Mixed images rule',
+        violations: 1,
+        warnings: 0,
+        successes: 0,
+        rows: [
+          createRow({
+            images: ['quay.io/test/img-a@sha256:aaa', 'quay.io/test/img-b@sha256:bbb'],
+          }),
+        ],
+      },
+    ];
+    const expandedGroups = new Set(['Mixed images rule']);
+    routerRenderer(
+      <ConformaGroupedTable
+        {...defaultProps}
+        groups={groupsWithDifferentImages}
+        expandedGroups={expandedGroups}
+      />,
+    );
+
+    expect(screen.getByText('Affects 2 images')).toBeInTheDocument();
+  });
+
+  it('shows truncated image when row has a single image', () => {
+    const groupsWithSingleImage: GroupedConformaRow[] = [
+      {
+        groupKey: 'Single-image rule',
+        violations: 1,
+        warnings: 0,
+        successes: 0,
+        rows: [createRow({ images: ['quay.io/test/img@sha256:only'] })],
+      },
+    ];
+    const expandedGroups = new Set(['Single-image rule']);
+    routerRenderer(
+      <ConformaGroupedTable
+        {...defaultProps}
+        groups={groupsWithSingleImage}
+        expandedGroups={expandedGroups}
+      />,
+    );
+
+    expect(screen.queryByText(/affects.*images/i)).not.toBeInTheDocument();
+  });
+
+  it('renders multi-image tooltip content', () => {
+    const groupsWithMultipleImages: GroupedConformaRow[] = [
+      {
+        groupKey: 'Multi-arch rule',
+        violations: 1,
+        warnings: 0,
+        successes: 0,
+        rows: [
+          createRow({
+            images: ['quay.io/test/img@sha256:aaa', 'quay.io/test/img@sha256:bbb'],
+          }),
+        ],
+      },
+    ];
+    const expandedGroups = new Set(['Multi-arch rule']);
+    routerRenderer(
+      <ConformaGroupedTable
+        {...defaultProps}
+        groups={groupsWithMultipleImages}
+        expandedGroups={expandedGroups}
+      />,
+    );
+
+    expect(screen.getByText('quay.io/test/img')).toBeInTheDocument();
+    expect(screen.getByText('2 arch variants')).toBeInTheDocument();
+  });
+
+  it('renders single collapsed image via images[0] without a tooltip', () => {
+    const groupsWithSingleCollapsedImage: GroupedConformaRow[] = [
+      {
+        groupKey: 'Single-collapsed rule',
+        violations: 1,
+        warnings: 0,
+        successes: 0,
+        rows: [
+          createRow({
+            images: ['quay.io/test/img@sha256:only'],
+          }),
+        ],
+      },
+    ];
+    const expandedGroups = new Set(['Single-collapsed rule']);
+    routerRenderer(
+      <ConformaGroupedTable
+        {...defaultProps}
+        groups={groupsWithSingleCollapsedImage}
+        expandedGroups={expandedGroups}
+      />,
+    );
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Affects 1 images/)).not.toBeInTheDocument();
+  });
+
   it('shows dash when row has no image', () => {
     const groupsWithImage: GroupedConformaRow[] = [
       {
@@ -140,8 +270,8 @@ describe('ConformaGroupedTable', () => {
         warnings: 0,
         successes: 0,
         rows: [
-          createRow({ image: 'quay.io/test/img@sha256:abc' }),
-          createRow({ image: undefined }),
+          createRow({ images: ['quay.io/test/img@sha256:abc'] }),
+          createRow({ images: [] }),
         ],
       },
     ];

--- a/src/components/Conforma/ConformaResultsTab/__tests__/ConformaResultsTab.spec.tsx
+++ b/src/components/Conforma/ConformaResultsTab/__tests__/ConformaResultsTab.spec.tsx
@@ -25,6 +25,7 @@ const createMockRow = (overrides: Partial<ConformaResultRow> = {}): ConformaResu
   status: CONFORMA_RESULT_STATUS.violations,
   component: 'test-component',
   msg: 'Test message',
+  images: [],
   ...overrides,
 });
 
@@ -33,9 +34,46 @@ const emptyResults: ApplicationConformaResults = {
   allResults: [],
   totalComponents: 0,
   totalFailed: 0,
-  totalViolations: 0,
-  totalWarnings: 0,
-  totalSuccesses: 0,
+  loaded: true,
+  settling: false,
+  error: undefined,
+};
+
+const archDupeResults: ApplicationConformaResults = {
+  componentStatuses: [
+    {
+      componentName: 'api-gateway',
+      status: 'fail',
+      violationCount: 3,
+      warningCount: 0,
+      successCount: 0,
+    },
+  ],
+  allResults: [
+    createMockRow({
+      title: 'CVE rule',
+      component: 'api-gateway',
+      msg: 'CVE-2024-001 found',
+      status: CONFORMA_RESULT_STATUS.violations,
+      images: ['quay.io/test/img@sha256:aaa'],
+    }),
+    createMockRow({
+      title: 'CVE rule',
+      component: 'api-gateway',
+      msg: 'CVE-2024-001 found',
+      status: CONFORMA_RESULT_STATUS.violations,
+      images: ['quay.io/test/img@sha256:bbb'],
+    }),
+    createMockRow({
+      title: 'CVE rule',
+      component: 'api-gateway',
+      msg: 'CVE-2024-001 found',
+      status: CONFORMA_RESULT_STATUS.violations,
+      images: ['quay.io/test/img@sha256:ccc'],
+    }),
+  ],
+  totalComponents: 1,
+  totalFailed: 1,
   loaded: true,
   settling: false,
   error: undefined,
@@ -82,9 +120,6 @@ const populatedResults: ApplicationConformaResults = {
   ],
   totalComponents: 2,
   totalFailed: 1,
-  totalViolations: 2,
-  totalWarnings: 1,
-  totalSuccesses: 1,
   loaded: true,
   settling: false,
   error: undefined,
@@ -193,6 +228,68 @@ describe('ConformaResultsTab', () => {
     fireEvent.click(toggleButtons[0]);
     // After collapse, detail sub-table content is hidden (S3 assertion)
     expect(screen.queryAllByText('Test message').length).toBe(0);
+  });
+
+  it('renders "Show multi-arch duplicates" switch unchecked by default (duplicates collapsed)', () => {
+    mockUseApplicationConformaResults.mockReturnValue(archDupeResults);
+
+    routerRenderer(<ConformaResultsTab />);
+
+    expect(screen.getByRole('checkbox', { name: /show multi-arch duplicates/i })).not.toBeChecked();
+  });
+
+  it('collapses arch-duplicate rows by default and shows image name with variant count', () => {
+    mockUseApplicationConformaResults.mockReturnValue(archDupeResults);
+
+    routerRenderer(<ConformaResultsTab />);
+
+    // Expand the single collapsed group
+    const toggleButtons = screen.getAllByRole('button', { name: /details/i });
+    fireEvent.click(toggleButtons[0]);
+
+    expect(screen.getByText('quay.io/test/img')).toBeInTheDocument();
+    expect(screen.getByText('3 arch variants')).toBeInTheDocument();
+  });
+
+  it('shows the raw violation count alongside the collapsed count when duplicates are collapsed', () => {
+    mockUseApplicationConformaResults.mockReturnValue(archDupeResults);
+
+    routerRenderer(<ConformaResultsTab />);
+
+    // 3 arch-duplicate violations collapse into 1 row; the true count (3)
+    // must still be surfaced, not silently dropped.
+    expect(screen.getByText('(3 incl. multi-arch)')).toBeInTheDocument();
+  });
+
+  it('hides the raw-count qualifier once "Show multi-arch duplicates" is enabled', () => {
+    mockUseApplicationConformaResults.mockReturnValue(archDupeResults);
+
+    routerRenderer(<ConformaResultsTab />);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /show multi-arch duplicates/i }));
+
+    // Once duplicates are shown individually, the displayed count already
+    // matches the raw count, so the qualifier is no longer needed.
+    expect(screen.queryByText(/incl\. multi-arch/i)).not.toBeInTheDocument();
+  });
+
+  it('shows all raw rows after enabling the show duplicates switch', () => {
+    mockUseApplicationConformaResults.mockReturnValue(archDupeResults);
+
+    routerRenderer(<ConformaResultsTab />);
+
+    // Turn on the show duplicates switch
+    fireEvent.click(screen.getByRole('checkbox', { name: /show multi-arch duplicates/i }));
+
+    // Expand the group — now all 3 raw rows are visible
+    const toggleButtons = screen.getAllByRole('button', { name: /details/i });
+    fireEvent.click(toggleButtons[0]);
+
+    expect(screen.queryByText(/affects.*images/i)).not.toBeInTheDocument();
+    // All 3 image digests appear individually
+    expect(screen.getByText(/sha256:aaa/)).toBeInTheDocument();
+    expect(screen.getByText(/sha256:bbb/)).toBeInTheDocument();
+    expect(screen.getByText(/sha256:ccc/)).toBeInTheDocument();
   });
 
   it('shows "no results match" when filters exclude all results', () => {

--- a/src/components/Conforma/ConformaResultsTab/__tests__/ConformaResultsToolbar.spec.tsx
+++ b/src/components/Conforma/ConformaResultsTab/__tests__/ConformaResultsToolbar.spec.tsx
@@ -11,6 +11,7 @@ const mockRow = (overrides: Partial<ConformaResultRow> = {}): ConformaResultRow 
   description: 'A test rule description',
   status: CONFORMA_RESULT_STATUS.violations,
   component: 'test-component',
+  images: [],
   ...overrides,
 });
 
@@ -25,12 +26,16 @@ describe('ConformaResultsToolbar', () => {
   const onGroupByChange = jest.fn();
   const onToggleExpandAll = jest.fn();
 
+  const onShowDuplicatesChange = jest.fn();
+
   const defaultProps = {
     allResults,
     groupBy: 'rule' as GroupByMode,
     onGroupByChange,
     allExpanded: false,
     onToggleExpandAll,
+    showDuplicates: false,
+    onShowDuplicatesChange,
   };
 
   const renderToolbar = (props: Partial<typeof defaultProps> = {}) => {
@@ -43,6 +48,36 @@ describe('ConformaResultsToolbar', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('renders show duplicates switch as unchecked by default (duplicates are collapsed)', () => {
+    renderToolbar({ showDuplicates: false });
+
+    const switchEl = screen.getByRole('checkbox', { name: /show multi-arch duplicates/i });
+    expect(switchEl).not.toBeChecked();
+  });
+
+  it('renders show duplicates switch as checked when showDuplicates is true', () => {
+    renderToolbar({ showDuplicates: true });
+
+    const switchEl = screen.getByRole('checkbox', { name: /show multi-arch duplicates/i });
+    expect(switchEl).toBeChecked();
+  });
+
+  it('calls onShowDuplicatesChange with true when an unchecked switch is clicked', () => {
+    renderToolbar({ showDuplicates: false, onShowDuplicatesChange });
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /show multi-arch duplicates/i }));
+
+    expect(onShowDuplicatesChange).toHaveBeenCalledWith(true);
+  });
+
+  it('calls onShowDuplicatesChange with false when a checked switch is clicked', () => {
+    renderToolbar({ showDuplicates: true, onShowDuplicatesChange });
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /show multi-arch duplicates/i }));
+
+    expect(onShowDuplicatesChange).toHaveBeenCalledWith(false);
   });
 
   it('renders the toolbar with the correct data-test attribute', () => {

--- a/src/components/Conforma/ConformaResultsTab/__tests__/ConformaSummaryBar.spec.tsx
+++ b/src/components/Conforma/ConformaResultsTab/__tests__/ConformaSummaryBar.spec.tsx
@@ -57,4 +57,39 @@ describe('ConformaSummaryBar', () => {
     expect(screen.getByText('4')).toBeInTheDocument();
     expect(screen.getByText('20')).toBeInTheDocument();
   });
+
+  it('does not show a raw-count qualifier when raw counts are not provided', () => {
+    routerRenderer(<ConformaSummaryBar {...defaultProps} />);
+
+    expect(screen.queryByText(/incl\. multi-arch/i)).not.toBeInTheDocument();
+  });
+
+  it('does not show a raw-count qualifier when raw counts match the collapsed counts', () => {
+    routerRenderer(
+      <ConformaSummaryBar
+        {...defaultProps}
+        totalViolationsRaw={defaultProps.totalViolations}
+        totalWarningsRaw={defaultProps.totalWarnings}
+        totalSuccessesRaw={defaultProps.totalSuccesses}
+      />,
+    );
+
+    expect(screen.queryByText(/incl\. multi-arch/i)).not.toBeInTheDocument();
+  });
+
+  it('shows a raw-count qualifier when collapsing hides real violations/warnings/successes', () => {
+    routerRenderer(
+      <ConformaSummaryBar
+        {...defaultProps}
+        totalViolationsRaw={12}
+        totalWarningsRaw={9}
+        totalSuccessesRaw={20}
+      />,
+    );
+
+    expect(screen.getByText('(12 incl. multi-arch)')).toBeInTheDocument();
+    expect(screen.getByText('(9 incl. multi-arch)')).toBeInTheDocument();
+    // totalSuccessesRaw equals totalSuccesses (20), so no qualifier for successes.
+    expect(screen.queryByText('(20 incl. multi-arch)')).not.toBeInTheDocument();
+  });
 });

--- a/src/components/Conforma/ConformaResultsTab/__tests__/conforma-grouping-utils.spec.ts
+++ b/src/components/Conforma/ConformaResultsTab/__tests__/conforma-grouping-utils.spec.ts
@@ -1,15 +1,50 @@
 import { CONFORMA_RESULT_STATUS, type ConformaResultRow } from '~/types/conforma';
-import { filterResults, groupByComponent, groupByRule } from '../conforma-grouping-utils';
+import {
+  collapseArchDuplicates,
+  countResultsByStatus,
+  filterResults,
+  getCommonImageName,
+  groupByComponent,
+  groupByRule,
+} from '../conforma-grouping-utils';
 
 const mockRow = (overrides: Partial<ConformaResultRow> = {}): ConformaResultRow => ({
   title: 'Test rule',
   description: 'Test description',
   status: CONFORMA_RESULT_STATUS.violations,
   component: 'test-component',
+  images: [],
   ...overrides,
 });
 
 describe('conforma-grouping-utils', () => {
+  describe('countResultsByStatus', () => {
+    it('counts violations, warnings, and successes', () => {
+      const rows = [
+        mockRow({ status: CONFORMA_RESULT_STATUS.violations }),
+        mockRow({ status: CONFORMA_RESULT_STATUS.violations }),
+        mockRow({ status: CONFORMA_RESULT_STATUS.warnings }),
+        mockRow({ status: CONFORMA_RESULT_STATUS.successes }),
+        mockRow({ status: CONFORMA_RESULT_STATUS.successes }),
+        mockRow({ status: CONFORMA_RESULT_STATUS.successes }),
+      ];
+
+      expect(countResultsByStatus(rows)).toEqual({
+        totalViolations: 2,
+        totalWarnings: 1,
+        totalSuccesses: 3,
+      });
+    });
+
+    it('returns zero counts for empty input', () => {
+      expect(countResultsByStatus([])).toEqual({
+        totalViolations: 0,
+        totalWarnings: 0,
+        totalSuccesses: 0,
+      });
+    });
+  });
+
   describe('groupByRule', () => {
     it('groups rows by title', () => {
       const rows = [
@@ -163,6 +198,223 @@ describe('conforma-grouping-utils', () => {
 
       expect(groups).toHaveLength(1);
       expect(groups[0].groupKey).toBe('api');
+    });
+  });
+
+  describe('collapseArchDuplicates', () => {
+    it('merges rows with the same title, msg, component, and status but different images', () => {
+      const rows = [
+        mockRow({ title: 'CVE rule', msg: 'CVE-2024-001', component: 'api', images: ['img@sha256:aaa'] }),
+        mockRow({ title: 'CVE rule', msg: 'CVE-2024-001', component: 'api', images: ['img@sha256:bbb'] }),
+        mockRow({ title: 'CVE rule', msg: 'CVE-2024-001', component: 'api', images: ['img@sha256:ccc'] }),
+      ];
+
+      const result = collapseArchDuplicates(rows);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].images).toEqual(['img@sha256:aaa', 'img@sha256:bbb', 'img@sha256:ccc']);
+    });
+
+    it('preserves distinct violations that differ in msg as separate rows', () => {
+      const rows = [
+        mockRow({ title: 'CVE rule', msg: 'CVE-2024-001', component: 'api', images: ['img@sha256:aaa'] }),
+        mockRow({ title: 'CVE rule', msg: 'CVE-2024-002', component: 'api', images: ['img@sha256:bbb'] }),
+      ];
+
+      const result = collapseArchDuplicates(rows);
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('preserves distinct violations that differ in component as separate rows', () => {
+      const rows = [
+        mockRow({ title: 'CVE rule', msg: 'CVE-2024-001', component: 'comp-a', images: ['img@sha256:aaa'] }),
+        mockRow({ title: 'CVE rule', msg: 'CVE-2024-001', component: 'comp-b', images: ['img@sha256:bbb'] }),
+      ];
+
+      const result = collapseArchDuplicates(rows);
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('sets images array with all unique digests', () => {
+      const rows = [
+        mockRow({ images: ['img@sha256:111'] }),
+        mockRow({ images: ['img@sha256:222'] }),
+      ];
+
+      const result = collapseArchDuplicates(rows);
+
+      expect(result[0].images).toEqual(['img@sha256:111', 'img@sha256:222']);
+    });
+
+    it('deduplicates identical image digests', () => {
+      const rows = [
+        mockRow({ images: ['img@sha256:aaa'] }),
+        mockRow({ images: ['img@sha256:aaa'] }),
+      ];
+
+      const result = collapseArchDuplicates(rows);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].images).toEqual(['img@sha256:aaa']);
+    });
+
+    it('returns the array unchanged when no duplicates exist', () => {
+      const rows = [
+        mockRow({ title: 'Rule A', component: 'comp-1', images: ['img@sha256:111'] }),
+        mockRow({ title: 'Rule B', component: 'comp-2', images: ['img@sha256:222'] }),
+      ];
+
+      const result = collapseArchDuplicates(rows);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].images).toEqual(['img@sha256:111']);
+      expect(result[1].images).toEqual(['img@sha256:222']);
+    });
+
+    it('handles rows with no image gracefully', () => {
+      const rows = [
+        mockRow({ images: [] }),
+        mockRow({ images: [] }),
+      ];
+
+      const result = collapseArchDuplicates(rows);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].images).toEqual([]);
+    });
+
+    it('returns an empty array for empty input', () => {
+      expect(collapseArchDuplicates([])).toEqual([]);
+    });
+
+    it('combines differing description and solution text instead of dropping them', () => {
+      const rows = [
+        mockRow({
+          title: 'CVE rule',
+          component: 'api',
+          description: 'Description for arm64',
+          solution: 'Solution for arm64',
+          images: ['img@sha256:arm64'],
+        }),
+        mockRow({
+          title: 'CVE rule',
+          component: 'api',
+          description: 'Description for amd64',
+          solution: 'Solution for amd64',
+          images: ['img@sha256:amd64'],
+        }),
+      ];
+
+      const result = collapseArchDuplicates(rows);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].description).toBe('Description for arm64\nDescription for amd64');
+      expect(result[0].solution).toBe('Solution for arm64\nSolution for amd64');
+    });
+
+    it('seeds single-image rows with a one-element images array', () => {
+      const rows = [mockRow({ images: ['img@sha256:only'] })];
+
+      const result = collapseArchDuplicates(rows);
+
+      expect(result[0].images).toEqual(['img@sha256:only']);
+    });
+
+    it('merges rows sharing the same code and real component name once arch-specific EC names are normalized', () => {
+      const rows = [
+        mockRow({
+          code: 'cve_scan.missing',
+          title: 'Missing CVE scan (image arm64)',
+          msg: 'CVE scan is missing',
+          component: 'comp-a',
+          images: ['img@sha256:arm64'],
+        }),
+        mockRow({
+          code: 'cve_scan.missing',
+          title: 'Missing CVE scan (image amd64)',
+          msg: 'CVE scan is missing',
+          component: 'comp-a',
+          images: ['img@sha256:amd64'],
+        }),
+      ];
+
+      const result = collapseArchDuplicates(rows);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].images).toEqual(['img@sha256:arm64', 'img@sha256:amd64']);
+      expect(result[0].title).toBe('Missing CVE scan');
+    });
+
+    it('does not merge rows with the same title but different code', () => {
+      const rows = [
+        mockRow({
+          code: 'rule.a',
+          title: 'Same Title',
+          msg: 'same msg',
+          component: 'comp-a',
+          images: ['img@sha256:aaa'],
+        }),
+        mockRow({
+          code: 'rule.b',
+          title: 'Same Title',
+          msg: 'same msg',
+          component: 'comp-a',
+          images: ['img@sha256:bbb'],
+        }),
+      ];
+
+      const result = collapseArchDuplicates(rows);
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('collapses rows where msg is undefined using empty-string sentinel', () => {
+      const rows: ConformaResultRow[] = [
+        mockRow({ title: 'rule', msg: undefined, component: 'comp', images: ['img@sha256:aaa'] }),
+        mockRow({ title: 'rule', msg: undefined, component: 'comp', images: ['img@sha256:bbb'] }),
+      ];
+
+      const result = collapseArchDuplicates(rows);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].images).toEqual(['img@sha256:aaa', 'img@sha256:bbb']);
+    });
+  });
+
+  describe('getCommonImageName', () => {
+    it('returns the shared repo prefix when all images share the same name', () => {
+      expect(
+        getCommonImageName([
+          'quay.io/org/img@sha256:aaa',
+          'quay.io/org/img@sha256:bbb',
+          'quay.io/org/img@sha256:ccc',
+        ]),
+      ).toBe('quay.io/org/img');
+    });
+
+    it('returns undefined when images have different repo names', () => {
+      expect(
+        getCommonImageName([
+          'quay.io/org/img-a@sha256:aaa',
+          'quay.io/org/img-b@sha256:bbb',
+        ]),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined for an empty array', () => {
+      expect(getCommonImageName([])).toBeUndefined();
+    });
+
+    it('returns the full string when images have no @ separator', () => {
+      expect(getCommonImageName(['quay.io/org/img', 'quay.io/org/img'])).toBe(
+        'quay.io/org/img',
+      );
+    });
+
+    it('returns the name for a single-element array', () => {
+      expect(getCommonImageName(['quay.io/org/img@sha256:only'])).toBe('quay.io/org/img');
     });
   });
 

--- a/src/components/Conforma/ConformaResultsTab/__tests__/useApplicationConformaResults.spec.ts
+++ b/src/components/Conforma/ConformaResultsTab/__tests__/useApplicationConformaResults.spec.ts
@@ -189,9 +189,6 @@ describe('useApplicationConformaResults', () => {
       allResults: [],
       totalComponents: 0,
       totalFailed: 0,
-      totalViolations: 0,
-      totalWarnings: 0,
-      totalSuccesses: 0,
       loaded: false,
       settling: false,
       error: undefined,
@@ -265,9 +262,6 @@ describe('useApplicationConformaResults', () => {
     await flushEffects();
 
     expect(result.current.loaded).toBe(true);
-    expect(result.current.totalViolations).toBe(1);
-    expect(result.current.totalWarnings).toBe(1);
-    expect(result.current.totalSuccesses).toBe(1);
     expect(result.current.totalFailed).toBe(1);
     expect(result.current.allResults).toHaveLength(3);
     expect(result.current.componentStatuses[0].status).toBe('fail');
@@ -288,7 +282,7 @@ describe('useApplicationConformaResults', () => {
     );
     expect(violation?.title).toBe('Missing CVE scan');
     expect(violation?.solution).toBe('Run a CVE scan');
-    expect(violation?.image).toBe('quay.io/test/image@sha256:abc');
+    expect(violation?.images).toEqual(['quay.io/test/image@sha256:abc']);
   });
 
   it('maps warning rows with solution field', async () => {
@@ -698,6 +692,62 @@ describe('useApplicationConformaResults', () => {
 
     expect(result.current.loaded).toBe(true);
     expect(result.current.settling).toBe(false);
+  });
+
+  it('overwrites the noisy per-image EC component name with the real K8s component name', async () => {
+    const multiArchResult: ConformaResult = {
+      components: [
+        {
+          containerImage: 'quay.io/test/image@sha256:arm64digest',
+          name: 'comp-a-arm64',
+          success: false,
+          violations: [
+            {
+              metadata: {
+                title: 'Missing CVE scan',
+                description: 'No CVE scan found',
+                collections: ['slsa3'],
+                code: 'cve_scan.missing',
+                solution: 'Run a CVE scan',
+              },
+              msg: 'CVE scan is missing',
+            },
+          ],
+        },
+        {
+          containerImage: 'quay.io/test/image@sha256:amd64digest',
+          name: 'comp-a-amd64',
+          success: false,
+          violations: [
+            {
+              metadata: {
+                title: 'Missing CVE scan',
+                description: 'No CVE scan found',
+                collections: ['slsa3'],
+                code: 'cve_scan.missing',
+                solution: 'Run a CVE scan',
+              },
+              msg: 'CVE scan is missing',
+            },
+          ],
+        },
+      ],
+    };
+    setupTaskRunPipeline();
+    mockResolveConforma.mockResolvedValue(multiArchResult);
+
+    const { result } = renderHook(() => useApplicationConformaResults('test-app'), {
+      wrapper: createWrapper(),
+    });
+
+    await flushEffects();
+
+    expect(result.current.allResults).toHaveLength(2);
+    expect(result.current.allResults.every((r) => r.component === 'comp-a')).toBe(true);
+    expect(result.current.allResults.map((r) => r.images)).toEqual([
+      ['quay.io/test/image@sha256:arm64digest'],
+      ['quay.io/test/image@sha256:amd64digest'],
+    ]);
   });
 
   it('preserves pipelineRunName on componentStatuses from TaskRun labels', async () => {

--- a/src/components/Conforma/ConformaResultsTab/conforma-fetchers.ts
+++ b/src/components/Conforma/ConformaResultsTab/conforma-fetchers.ts
@@ -26,7 +26,7 @@ const mapToUIConformaData = (
   msg: v.msg,
   collection: v.metadata?.collections,
   solution: v.metadata?.solution,
-  image: compResult.containerImage,
+  images: compResult.containerImage ? [compResult.containerImage] : [],
   code: v.metadata?.code,
 });
 

--- a/src/components/Conforma/ConformaResultsTab/conforma-grouping-utils.ts
+++ b/src/components/Conforma/ConformaResultsTab/conforma-grouping-utils.ts
@@ -12,6 +12,17 @@ export type GroupedConformaRow = {
   rows: ConformaResultRow[];
 };
 
+export const countResultsByStatus = (results: ConformaResultRow[]) =>
+  results.reduce(
+    (acc, r) => {
+      if (r.status === CONFORMA_RESULT_STATUS.violations) acc.totalViolations++;
+      else if (r.status === CONFORMA_RESULT_STATUS.warnings) acc.totalWarnings++;
+      else if (r.status === CONFORMA_RESULT_STATUS.successes) acc.totalSuccesses++;
+      return acc;
+    },
+    { totalViolations: 0, totalWarnings: 0, totalSuccesses: 0 },
+  );
+
 export const groupByRule = (results: ConformaResultRow[]): GroupedConformaRow[] => {
   const map = new Map<string, ConformaResultRow[]>();
 
@@ -93,3 +104,80 @@ export const filterResults = (
 
     return true;
   });
+
+/**
+ * Extracts the shared image name (everything before `@`) from an array of
+ * image references.  Returns `undefined` when the images do not share a
+ * common repository prefix or the array is empty.
+ */
+export const getCommonImageName = (images: string[]): string | undefined => {
+  if (images.length === 0) return undefined;
+  const names = images.map((img) => {
+    const atIdx = img.lastIndexOf('@');
+    return atIdx > 0 ? img.substring(0, atIdx) : img;
+  });
+  const first = names[0];
+  return names.every((n) => n === first) ? first : undefined;
+};
+
+/** Merges arch-variant titles by trimming divergent suffixes to a shared prefix. */
+const mergeTitles = (a: string, b: string): string => {
+  if (a === b) return a;
+
+  let i = 0;
+  const max = Math.min(a.length, b.length);
+  while (i < max && a[i] === b[i]) i++;
+
+  let prefix = a.substring(0, i);
+  const lastOpenParen = prefix.lastIndexOf('(');
+  const lastSpace = prefix.lastIndexOf(' ');
+
+  if (lastOpenParen !== -1 && i > lastOpenParen) {
+    prefix = prefix.substring(0, lastOpenParen);
+  } else if (lastSpace !== -1 && prefix.indexOf('(', lastSpace + 1) !== -1) {
+    prefix = prefix.substring(0, prefix.indexOf('(', lastSpace + 1));
+  } else if (lastSpace !== -1) {
+    prefix = prefix.substring(0, lastSpace);
+  }
+
+  prefix = prefix.trimEnd();
+  return prefix || a;
+};
+
+/**
+ * Merges rows that share the same title, msg, component, and status (i.e. the
+ * same policy violation but across different architecture images) into a single
+ * row.  The merged row carries an `images` array with every unique image digest
+ * from the group.  Rows without an image are handled gracefully — they collapse
+ * with other rows whose only difference is the image field.
+ */
+export const collapseArchDuplicates = (rows: ConformaResultRow[]): ConformaResultRow[] => {
+  const map = new Map<string, ConformaResultRow>();
+  for (const row of rows) {
+    const key = `${row.code ?? row.title}\0${row.msg ?? ''}\0${row.component}\0${row.status}`;
+    const existing = map.get(key);
+    if (existing) {
+      if (row.title !== existing.title) {
+        existing.title = mergeTitles(existing.title, row.title);
+      }
+      if (row.description && row.description !== existing.description) {
+        existing.description = existing.description
+          ? `${existing.description}\n${row.description}`
+          : row.description;
+      }
+      if (row.solution && row.solution !== existing.solution) {
+        existing.solution = existing.solution
+          ? `${existing.solution}\n${row.solution}`
+          : row.solution;
+      }
+      for (const image of row.images) {
+        if (!existing.images.includes(image)) {
+          existing.images = [...existing.images, image];
+        }
+      }
+    } else {
+      map.set(key, { ...row, images: [...row.images] });
+    }
+  }
+  return Array.from(map.values());
+};

--- a/src/components/Conforma/ConformaResultsTab/useApplicationConformaResults.ts
+++ b/src/components/Conforma/ConformaResultsTab/useApplicationConformaResults.ts
@@ -7,10 +7,7 @@ import { useComponents } from '~/hooks/useComponents';
 import { useTaskRunsV2 } from '~/hooks/useTaskRunsV2';
 import { useNamespace } from '~/shared/providers/Namespace';
 import type { TaskRunKind } from '~/types';
-import {
-  ComponentConformaResult,
-  CONFORMA_RESULT_STATUS,
-} from '~/types/conforma';
+import { ComponentConformaResult } from '~/types/conforma';
 import type {
   ApplicationConformaResults,
   ComponentConformaStatus,
@@ -28,9 +25,6 @@ const EMPTY_RESULTS: ApplicationConformaResults = {
   allResults: [],
   totalComponents: 0,
   totalFailed: 0,
-  totalViolations: 0,
-  totalWarnings: 0,
-  totalSuccesses: 0,
   loaded: false,
   settling: false,
   error: undefined,
@@ -205,22 +199,20 @@ export const useApplicationConformaResults = (
       };
     });
 
-    const mergedConformaRows: ComponentConformaResult[] = [];
-    for (const components of conformaByComponent.values()) {
-      mergedConformaRows.push(...components);
+    const allResults: ConformaResultRow[] = [];
+    for (const [realComponentName, components] of conformaByComponent.entries()) {
+      const rows = mapConformaResultData(components);
+      // The EC/Conforma report assigns its own per-image `name` to each
+      // components[] entry (see ComponentConformaResult), which is NOT the
+      // real K8s component name and can differ across architecture images
+      // of the same logical component. Overwrite it with the authoritative
+      // name so rows stay associated with the correct component regardless
+      // of how many arch-specific images were evaluated for it.
+      rows.forEach((row) => {
+        row.component = realComponentName;
+      });
+      allResults.push(...rows);
     }
-
-    const allResults: ConformaResultRow[] = mapConformaResultData(mergedConformaRows);
-
-    const { totalViolations, totalWarnings, totalSuccesses } = allResults.reduce(
-      (acc, r) => {
-        if (r.status === CONFORMA_RESULT_STATUS.violations) acc.totalViolations++;
-        else if (r.status === CONFORMA_RESULT_STATUS.warnings) acc.totalWarnings++;
-        else if (r.status === CONFORMA_RESULT_STATUS.successes) acc.totalSuccesses++;
-        return acc;
-      },
-      { totalViolations: 0, totalWarnings: 0, totalSuccesses: 0 },
-    );
 
     const totalComponents = componentStatuses.length;
     const totalFailed = componentStatuses.filter((c) => c.status === 'fail').length;
@@ -230,9 +222,6 @@ export const useApplicationConformaResults = (
       allResults,
       totalComponents,
       totalFailed,
-      totalViolations,
-      totalWarnings,
-      totalSuccesses,
       loaded,
       settling,
       error: aggregateError,

--- a/src/components/Conforma/ConformaTable/__tests__/ConformaExpandedRowContent.spec.tsx
+++ b/src/components/Conforma/ConformaTable/__tests__/ConformaExpandedRowContent.spec.tsx
@@ -11,6 +11,7 @@ const rowContent = {
   msg: 'Fail',
   timestamp: '2022-01-01T00:00:00Z',
   collection: ['abcd', 'efg'],
+  images: [],
 };
 
 const invalidContent = {
@@ -21,6 +22,7 @@ const invalidContent = {
   msg: null,
   timestamp: null,
   collection: null,
+  images: [],
 };
 
 describe('ConformaExpandedRowContent', () => {

--- a/src/components/Conforma/ConformaTable/__tests__/ConformaRow.spec.tsx
+++ b/src/components/Conforma/ConformaTable/__tests__/ConformaRow.spec.tsx
@@ -22,9 +22,10 @@ const dummySuccessRowData = {
   status: CONFORMA_RESULT_STATUS.successes,
   component: 'component-1',
   description: 'dummy description',
+  images: [],
 } as UIConformaData;
 
-const dumpFailRowData = {
+const dumpFailRowData: UIConformaData = {
   title: 'dummyTitle',
   status: CONFORMA_RESULT_STATUS.violations,
   component: 'component-1',
@@ -32,6 +33,7 @@ const dumpFailRowData = {
   msg: 'Fail',
   timestamp: '2022-01-01T00:00:00Z',
   collection: ['abcd', 'efg'],
+  images: [],
 };
 
 const customDummyData = {

--- a/src/components/Conforma/__data__/mockConformaLogsJson.ts
+++ b/src/components/Conforma/__data__/mockConformaLogsJson.ts
@@ -189,7 +189,7 @@ export const mockConformaUIData = [
     msg: 'CVE scan results not found',
     solution: 'solution for failure',
     collection: ['minimal'],
-    image: MOCK_CONTAINER_IMAGE,
+    images: [MOCK_CONTAINER_IMAGE],
     code: 'cve.missing_cve_scan_results',
   },
   {
@@ -202,7 +202,7 @@ export const mockConformaUIData = [
     msg: 'Pass',
     collection: ['minimal'],
     solution: undefined,
-    image: MOCK_CONTAINER_IMAGE,
+    images: [MOCK_CONTAINER_IMAGE],
     code: 'tasks.tasks_missing',
   },
 ];

--- a/src/types/conforma.ts
+++ b/src/types/conforma.ts
@@ -68,7 +68,12 @@ export type UIConformaData = {
   msg?: string;
   collection?: string[];
   solution?: string;
-  image?: string;
+  /**
+   * Affected image digest(s). Populated with a single-element array for a
+   * non-collapsed row, and with every unique digest in the group once
+   * `collapseArchDuplicates` has merged arch-duplicate rows together.
+   */
+  images: string[];
   /** Policy rule code — stable identifier used as primary group key. Optional for backward-compat. */
   code?: string;
 };
@@ -89,9 +94,6 @@ export type ApplicationConformaResults = {
   allResults: ConformaResultRow[];
   totalComponents: number;
   totalFailed: number;
-  totalViolations: number;
-  totalWarnings: number;
-  totalSuccesses: number;
   loaded: boolean;
   settling: boolean;
   error: unknown;


### PR DESCRIPTION
## Fixes 
Fixes: https://issues.redhat.com/browse/KFLUXSE-269

## Description
Conforma results can show the same policy violation once per architecture image. For a multi-arch component, a single CVE violation across 5 arch images produces 5 nearly identical rows inside an expanded group — noise, not signal.

This PR adds a "Collapse duplicates" switch to the Conforma results toolbar (on by default). When enabled, rows that share the same title, msg, component, and status — but differ only in image — are merged into one row. The merged row carries an images: string[] field with all affected digests, and the detail table shows "Affects N images" with a tooltip listing each digest.

The collapse step slots into the existing view pipeline between allResults and filterResults. No changes to the data-fetching hook. Summary bar violation/warning/success counts are derived from the collapsed view so totals reflect de-duplicated row counts.


New files:
None

Modified:
src/types/conforma.ts — add images?: string[] to UIConformaData
src/components/Conforma/ConformaResultsTab/conforma-grouping-utils.ts — add collapseArchDuplicates() pure function
src/components/Conforma/ConformaResultsTab/ConformaResultsToolbar.tsx — add "Collapse duplicates" Switch
src/components/Conforma/ConformaResultsTab/ConformaResultsTab.tsx — wire collapse state, pipeline step, and display counts
src/components/Conforma/ConformaResultsTab/ConformaGroupedTable.tsx — render "Affects N images" with tooltip in the Image cell
src/components/Conforma/ConformaResultsTab/__tests__/conforma-grouping-utils.spec.ts — unit tests for collapseArchDuplicates
src/components/Conforma/ConformaResultsTab/__tests__/ConformaResultsToolbar.spec.tsx — switch rendering and callback tests
src/components/Conforma/ConformaResultsTab/__tests__/ConformaGroupedTable.spec.tsx — multi-image and single-image cell tests
src/components/Conforma/ConformaResultsTab/__tests__/ConformaResultsTab.spec.tsx — integration tests for collapsed vs uncollapsed modes

* **New Features**

- Toolbar switch: Collapse duplicates (data-test="conforma-collapse-duplicates"), checked by default
- collapseArchDuplicates() merges arch-duplicate rows by title + msg + component + status
- Merged rows show "Affects N images" with a tooltip listing all image digests
- Summary bar counts update to reflect collapsed totals


## Type of change
- [x] Feature

## Screen shots / Gifs for design review 
<img width="1070" height="482" alt="image" src="https://github.com/user-attachments/assets/f5709dde-3bec-4f32-b110-f853eb1644fc" />
<img width="1181" height="536" alt="image" src="https://github.com/user-attachments/assets/dc541b6c-db54-4dcb-b230-34a17706de51" />
<img width="614" height="240" alt="image" src="https://github.com/user-attachments/assets/a839625b-6c5f-4031-abcf-8a5d0a343fd3" />
<img width="716" height="506" alt="image" src="https://github.com/user-attachments/assets/975174e0-bc8a-4269-ae97-8392ae145c41" />

<img width="1097" height="440" alt="image" src="https://github.com/user-attachments/assets/d586c089-1983-4d3d-9b90-9013f7c1f24a" />
<img width="1093" height="470" alt="image" src="https://github.com/user-attachments/assets/af7724d6-510a-4040-84ec-5c2ee9830cfa" />
<img width="1164" height="212" alt="image" src="https://github.com/user-attachments/assets/12963198-91a9-4b66-9fd4-19e60ea9f828" />


## How to test or reproduce?
Prerequisites: conforma-policy feature flag enabled; an application with Conforma results that include the same violation across multiple architecture images.

- Navigate to Application Details → Conforma results for an app with multi-arch violations.
- Confirm the toolbar shows Collapse duplicates and it is on by default.
- Expand a group that has arch-duplicate violations.
- Expected: one detail row per unique violation, with "Affects N images" in the Image column.
- Hover "Affects N images".
- Expected: tooltip lists all affected image digests.
- Turn Collapse duplicates off.
- Expected: the same group shows one row per architecture image, each with its own truncated digest.
- Confirm summary bar violation/warning/success counts change between collapsed and uncollapsed modes.

## Automated tests:

yarn test -- src/components/Conforma/ConformaResultsTab/__tests__/
yarn lint
yarn type-checks

### Manual testing — mock data (no cluster needed)

1. Start the dev server: yarn start
2. Navigate to any application's detail page and append ?mock=conforma to the URL
- e.g. https://localhost:8080/ns/<workspace>/applications/<app>/conforma-results?mock=conforma
3. Verify the Conforma Results tab renders:
- Summary bar with tooltips (hover each metric)
- Grouped expandable table (toggle "Group by: Rule" / "Group by: Component")
- Search, status filter, expand all / collapse all


What to verify:
 [ ] Conforma Results tab visible on Application Details (even when empty)
 [ ] Summary bar shows correct counts with vertical dividers and hover tooltips
 [ ] Count badges use PatternFly Label outline style (pill shape with colored border)
 [ ] Group by rule / component toggles table structure correctly
 [ ] Search and status filters work
 [ ] Expand all / Collapse all buttons work
 [ ] Empty state message when no results
 [ ] Loading spinner while fetching
 [ ] Error state when fetch fails
 [ ] Issues Dashboard shows "Conforma Policy Violations" card (behind feature flag)
 [ ] "View policy" links navigate to the correct application's Conforma Results tab

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [x] Code follows the style guidelines
- [x] Self-reviewed the code
- [x] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [x] Changes generate no new warnings
- [x] Added tests that prove this fix is effective or that the feature works
- [x] New and existing unit tests pass locally with new changes
- [x] Any dependent changes have been merged and published in downstream modules 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added a “Show multi-arch duplicates” toggle to switch between collapsed and individually displayed results.
  * Expanded the image column to summarize common repo prefixes, including tooltip details and “arch variants” / “Affects N images” indicators.

* **Bug Fixes**
  * Updated grouping/filtering so visible rows and the results summary stay consistent with the duplicate-display mode.
  * Improved the results summary to show “(N incl. multi-arch)” raw totals when they differ from collapsed counts.

* **Tests**
  * Expanded coverage for toggle behavior, image summary rendering, and accessibility (keyboard-focusable tooltip).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->