### PR TITLE
feat(KFLUXUI-1449): add Konflux theme with PF v6 tokens and high contrast mode

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="pf-v6-theme-konflux">
+<html lang="en" class="konflux-ui__theme">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="pf-v6-theme-konflux">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/assets/theme/global-background.svg
+++ b/src/assets/theme/global-background.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1851" height="1196" viewBox="0 0 1851 1196" fill="none">
+<g clip-path="url(#clip0_19356_19682)">
+<rect width="1851" height="1196" fill="url(#paint0_linear_19356_19682)"/>
+<g filter="url(#filter0_f_19356_19682)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M1102.43 904.428L749.184 292.595L137.351 645.837L175.198 711.391C349.386 1013.09 735.17 1116.46 1036.87 942.276L1102.43 904.428Z" fill="url(#paint1_linear_19356_19682)"/>
+</g>
+<g filter="url(#filter1_f_19356_19682)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M844.186 1868.49L1456.02 1515.25L1102.78 903.417L1037.22 941.264C735.521 1115.45 632.151 1501.24 806.338 1802.94L844.186 1868.49Z" fill="url(#paint2_linear_19356_19682)"/>
+</g>
+<g filter="url(#filter2_f_19356_19682)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M1714.19 550.415L1102.36 903.657L1455.6 1515.49L1521.16 1477.64C1822.86 1303.45 1926.23 917.67 1752.04 615.969L1714.19 550.415Z" fill="url(#paint3_linear_19356_19682)"/>
+</g>
+<g filter="url(#filter3_f_19356_19682)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M749.357 292.245L1102.6 904.078L1714.43 550.836L1676.58 485.282C1502.4 183.58 1116.61 80.2097 814.911 254.397L749.357 292.245Z" fill="url(#paint4_linear_19356_19682)"/>
+</g>
+<g filter="url(#filter4_f_19356_19682)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M396.775 -319.412L750.017 292.421L138.184 645.663L100.337 580.109C-73.8506 278.407 29.5201 -107.377 331.222 -281.565L396.775 -319.412Z" fill="url(#paint5_linear_19356_19682)"/>
+</g>
+</g>
+<defs>
+<filter id="filter0_f_19356_19682" x="112.752" y="267.995" width="1014.27" height="783.495" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="12.3" result="effect1_foregroundBlur_19356_19682"/>
+</filter>
+<filter id="filter1_f_19356_19682" x="697.123" y="878.817" width="783.495" height="1014.27" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="12.3" result="effect1_foregroundBlur_19356_19682"/>
+</filter>
+<filter id="filter2_f_19356_19682" x="1077.76" y="525.815" width="783.497" height="1014.27" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="12.3" result="effect1_foregroundBlur_19356_19682"/>
+</filter>
+<filter id="filter3_f_19356_19682" x="724.757" y="145.182" width="1014.27" height="783.495" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="12.3" result="effect1_foregroundBlur_19356_19682"/>
+</filter>
+<filter id="filter4_f_19356_19682" x="-8.87734" y="-344.012" width="783.495" height="1014.27" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="12.3" result="effect1_foregroundBlur_19356_19682"/>
+</filter>
+<linearGradient id="paint0_linear_19356_19682" x1="210.671" y1="-298.5" x2="1299.08" y2="1588.29" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FDE3D6"/>
+<stop offset="1" stop-color="white"/>
+</linearGradient>
+<linearGradient id="paint1_linear_19356_19682" x1="42.0705" y1="943.784" x2="1588.19" y2="1265.94" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FDE3D6"/>
+<stop offset="1" stop-color="#F2F2F2"/>
+</linearGradient>
+<linearGradient id="paint2_linear_19356_19682" x1="1781.09" y1="1503.62" x2="234.974" y2="1181.47" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FDE3D6"/>
+<stop offset="1" stop-color="white"/>
+</linearGradient>
+<linearGradient id="paint3_linear_19356_19682" x1="777.286" y1="915.285" x2="2323.4" y2="1237.44" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="#FDE3D6"/>
+</linearGradient>
+<linearGradient id="paint4_linear_19356_19682" x1="1114.23" y1="1229.15" x2="1436.38" y2="-316.967" gradientUnits="userSpaceOnUse">
+<stop stop-color="white"/>
+<stop offset="1" stop-color="#FDE3D6"/>
+</linearGradient>
+<linearGradient id="paint5_linear_19356_19682" x1="-167.485" y1="579.205" x2="326.579" y2="-920.851" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FDE3D6"/>
+<stop offset="1" stop-color="white"/>
+</linearGradient>
+<clipPath id="clip0_19356_19682">
+<rect width="1851" height="1196" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/konflux-theme.scss
+++ b/src/konflux-theme.scss
@@ -26,7 +26,7 @@ html.pf-v6-theme-dark {
 // ---------------------------------------------------------------------------
 // 2. Global Brand Color Override
 // ---------------------------------------------------------------------------
-:root:where(.pf-v6-theme-konflux) {
+:root:where(.konflux-ui__theme) {
   --pf-t--global--border--color--brand--accent--clicked: var(--konflux-brand-primary-clicked);
   --pf-t--global--border--color--brand--accent--default: var(--konflux-brand-primary);
   --pf-t--global--border--color--brand--accent--hover: var(--konflux-brand-primary-hover);

--- a/src/konflux-theme.scss
+++ b/src/konflux-theme.scss
@@ -1,0 +1,58 @@
+// Konflux Brand Theme
+// Overrides --pf-t--global--color--brand--* globally to Konflux orange.
+// For non-primary buttons, resets the global brand back to PF blue within
+// the button scope so secondary, link, tertiary variants stay PF default.
+// NOT overridden (stays PF default):
+//   --pf-t--global--border--color--hover/clicked (input borders)
+//   --pf-t--global--text--color--link--*          (links)
+//   --pf-t--global--focus-ring--color--*          (focus ring)
+
+// ---------------------------------------------------------------------------
+// 1. Konflux Brand Variables
+// ---------------------------------------------------------------------------
+:root {
+  --konflux-brand-primary: #fc783d;
+  --konflux-brand-primary-hover: #d36634;
+  --konflux-brand-primary-clicked: #b85a2e;
+  --konflux-icon-color: var(--pf-t--global--icon--color--regular);
+}
+
+html.pf-v6-theme-dark {
+  --konflux-brand-primary: #f97f4d;
+  --konflux-brand-primary-hover: #fb8f63;
+  --konflux-brand-primary-clicked: #f2722f;
+}
+
+// ---------------------------------------------------------------------------
+// 2. Global Brand Color Override
+// ---------------------------------------------------------------------------
+:root:where(.pf-v6-theme-konflux) {
+  --pf-t--global--border--color--brand--accent--clicked: var(--konflux-brand-primary-clicked);
+  --pf-t--global--border--color--brand--accent--default: var(--konflux-brand-primary);
+  --pf-t--global--border--color--brand--accent--hover: var(--konflux-brand-primary-hover);
+  --pf-t--global--color--brand--accent--clicked: var(--konflux-brand-primary-clicked);
+  --pf-t--global--color--brand--accent--default: var(--konflux-brand-primary);
+  --pf-t--global--color--brand--accent--hover: var(--konflux-brand-primary-hover);
+  --pf-t--global--icon--color--brand--default: var(--konflux-brand-primary);
+  --pf-t--global--icon--color--brand--hover: var(--konflux-brand-primary-hover);
+  --pf-t--global--icon--color--brand--clicked: var(--konflux-brand-primary-clicked);
+
+  .pf-v6-c-button.pf-m-primary {
+    --pf-v6-c-button--m-primary--BackgroundColor: var(--konflux-brand-primary);
+    --pf-v6-c-button--m-primary--hover--BackgroundColor: var(--konflux-brand-primary-hover);
+    --pf-v6-c-button--m-primary--m-clicked--BackgroundColor: var(--konflux-brand-primary-clicked);
+  }
+
+  .pf-v6-c-menu-toggle.pf-m-primary {
+    --pf-v6-c-menu-toggle--m-primary--BackgroundColor: var(--konflux-brand-primary);
+    --pf-v6-c-menu-toggle--m-primary--hover--BackgroundColor: var(--konflux-brand-primary-hover);
+    --pf-v6-c-menu-toggle--m-primary--expanded--BackgroundColor: var(
+      --konflux-brand-primary-clicked
+    );
+  }
+
+  // experimental theme not used anywhere yet, for future use
+  &:where(.pf-v6-theme-glass) {
+    --pf-t--global--background--image--glass: url(./assets/theme/global-background.svg);
+  }
+}

--- a/src/konflux-theme.scss
+++ b/src/konflux-theme.scss
@@ -1,15 +1,5 @@
-// Konflux Brand Theme
-// Overrides --pf-t--global--color--brand--* globally to Konflux orange.
-// For non-primary buttons, resets the global brand back to PF blue within
-// the button scope so secondary, link, tertiary variants stay PF default.
-// NOT overridden (stays PF default):
-//   --pf-t--global--border--color--hover/clicked (input borders)
-//   --pf-t--global--text--color--link--*          (links)
-//   --pf-t--global--focus-ring--color--*          (focus ring)
-
-// ---------------------------------------------------------------------------
-// 1. Konflux Brand Variables
-// ---------------------------------------------------------------------------
+// Konflux brand color variables and theme overrides.
+// Scoped under .konflux-ui__theme so the theme can be toggled.
 :root {
   --konflux-brand-primary: #fc783d;
   --konflux-brand-primary-hover: #d36634;
@@ -23,9 +13,7 @@ html.pf-v6-theme-dark {
   --konflux-brand-primary-clicked: #f2722f;
 }
 
-// ---------------------------------------------------------------------------
-// 2. Global Brand Color Override
-// ---------------------------------------------------------------------------
+// Brand accent and primary button/menu-toggle overrides
 :root:where(.konflux-ui__theme) {
   --pf-t--global--border--color--brand--accent--clicked: var(--konflux-brand-primary-clicked);
   --pf-t--global--border--color--brand--accent--default: var(--konflux-brand-primary);

--- a/src/main.scss
+++ b/src/main.scss
@@ -1,38 +1,5 @@
-:root {
-  --konflux-primary-color: #fc783d;
-  --konflux-primary-hover-color: #d36634;
-  --konflux-icon-color: var(--pf-t--global--icon--color--regular);
-}
-
-html.pf-v6-theme-dark {
-  --konflux-primary-color: #e05c3b;
-  --konflux-primary-hover-color: #b94c2a;
-}
+@import './konflux-theme';
 
 #root {
   height: 100%;
-
-  .pf-v6-c-button.pf-m-primary:not(.pf-m-disabled):not(.pf-m-aria-disabled) {
-    background-color: var(--konflux-primary-color);
-
-    &:hover {
-      background-color: var(--konflux-primary-hover-color);
-    }
-  }
-
-  .pf-v6-c-dropdown__toggle.pf-m-primary:not(.pf-m-disabled):not(.pf-m-aria-disabled) {
-    background-color: var(--konflux-primary-color);
-
-    &:hover {
-      background-color: var(--konflux-primary-hover-color);
-    }
-  }
-
-  .pf-v6-c-menu-toggle.pf-m-primary:not(.pf-m-disabled):not(.pf-m-aria-disabled) {
-    background-color: var(--konflux-primary-color);
-
-    &:hover {
-      background-color: var(--konflux-primary-hover-color);
-    }
-  }
 }

--- a/src/shared/theme/ThemeContext.tsx
+++ b/src/shared/theme/ThemeContext.tsx
@@ -1,41 +1,72 @@
 import React from 'react';
 import { useEventListener } from '../hooks/useEventListener';
+import { createKeyedJSONStorage } from '../utils/storage';
 import {
   THEME_SYSTEM,
   THEME_DARK,
   THEME_LIGHT,
+  CONTRAST_SYSTEM,
+  CONTRAST_DEFAULT,
+  CONTRAST_HIGH,
   PREFERS_COLOR_SCHEME_DARK,
+  PREFERS_CONTRAST_MORE,
+  FORCED_COLORS_ACTIVE,
+  CONTRAST_PREFERENCES,
   THEME_PREFERENCES,
 } from './const';
-import { Theme, ThemePreference } from './types';
+import { ContrastMode, ContrastPreference, Theme, ThemePreference } from './types';
 
 export type ThemeContextValue = {
   preference: ThemePreference;
+  contrastPreference: ContrastPreference;
   effectiveTheme: Theme;
+  effectiveContrast: ContrastMode;
   systemPreference: Theme;
   setThemePreference: (newPreference: ThemePreference) => void;
+  setContrastPreference: (newPreference: ContrastPreference) => void;
 };
+
+const themeStorage = createKeyedJSONStorage<ThemePreference>('konflux-theme-preference');
+const contrastStorage = createKeyedJSONStorage<ContrastPreference>('konflux-contrast-preference');
 
 export const ThemeContext = React.createContext<ThemeContextValue>({
   preference: 'system',
+  contrastPreference: 'system',
   effectiveTheme: 'light',
+  effectiveContrast: 'default',
   systemPreference: 'light',
   setThemePreference: () => {},
+  setContrastPreference: () => {},
 });
 
-const THEME_STORAGE_KEY = 'konflux-theme-preference';
 const DARK_THEME_CLASS = 'pf-v6-theme-dark';
+const HIGH_CONTRAST_CLASS = 'pf-v6-theme-high-contrast';
 
 const getSystemPreference = (): Theme => {
   return window.matchMedia(PREFERS_COLOR_SCHEME_DARK).matches ? THEME_DARK : THEME_LIGHT;
 };
 
+const getSystemContrastPreference = (): boolean => {
+  return (
+    window.matchMedia(PREFERS_CONTRAST_MORE).matches ||
+    window.matchMedia(FORCED_COLORS_ACTIVE).matches
+  );
+};
+
 const getStoredPreference = (): ThemePreference => {
-  const stored = localStorage.getItem(THEME_STORAGE_KEY);
-  if (stored && THEME_PREFERENCES.includes(stored as ThemePreference)) {
-    return stored as ThemePreference;
+  const stored = themeStorage.get();
+  if (stored && THEME_PREFERENCES.includes(stored)) {
+    return stored;
   }
   return THEME_SYSTEM;
+};
+
+const getStoredContrastPreference = (): ContrastPreference => {
+  const stored = contrastStorage.get();
+  if (stored && CONTRAST_PREFERENCES.includes(stored)) {
+    return stored;
+  }
+  return CONTRAST_SYSTEM;
 };
 
 const applyTheme = (theme: Theme) => {
@@ -47,17 +78,43 @@ const applyTheme = (theme: Theme) => {
   }
 };
 
+const applyContrast = (contrast: ContrastMode) => {
+  const htmlElement = document.documentElement;
+  if (contrast === CONTRAST_HIGH) {
+    htmlElement.classList.add(HIGH_CONTRAST_CLASS);
+  } else {
+    htmlElement.classList.remove(HIGH_CONTRAST_CLASS);
+  }
+};
+
 export const ThemeProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
   const [preference, setPreference] = React.useState<ThemePreference>(getStoredPreference);
+  const [contrastPreference, setContrastPrefState] = React.useState<ContrastPreference>(
+    getStoredContrastPreference,
+  );
   const [systemPreference, setSystemPreference] = React.useState<Theme>(getSystemPreference);
+  const [systemWantsHighContrast, setSystemWantsHighContrast] = React.useState<boolean>(
+    getSystemContrastPreference,
+  );
 
-  // Calculate the effective theme based on preference
+  // Calculate effective values
   const effectiveTheme = preference === THEME_SYSTEM ? systemPreference : preference;
+  const effectiveContrast: ContrastMode =
+    contrastPreference === CONTRAST_SYSTEM
+      ? systemWantsHighContrast
+        ? CONTRAST_HIGH
+        : CONTRAST_DEFAULT
+      : contrastPreference;
 
   React.useLayoutEffect(() => {
     applyTheme(effectiveTheme);
   }, [effectiveTheme]);
 
+  React.useLayoutEffect(() => {
+    applyContrast(effectiveContrast);
+  }, [effectiveContrast]);
+
+  // Listen for system color scheme changes
   useEventListener(
     'change',
     (e: MediaQueryListEvent) => {
@@ -66,18 +123,45 @@ export const ThemeProvider: React.FC<React.PropsWithChildren> = ({ children }) =
     window.matchMedia(PREFERS_COLOR_SCHEME_DARK),
   );
 
+  // Listen for system contrast preference changes
+  useEventListener(
+    'change',
+    (e: MediaQueryListEvent) => {
+      setSystemWantsHighContrast(e.matches);
+    },
+    window.matchMedia(PREFERS_CONTRAST_MORE),
+  );
+
+  useEventListener(
+    'change',
+    (e: MediaQueryListEvent) => {
+      if (e.matches) {
+        setSystemWantsHighContrast(true);
+      }
+    },
+    window.matchMedia(FORCED_COLORS_ACTIVE),
+  );
+
   const setThemePreference = (newPreference: ThemePreference) => {
     setPreference(newPreference);
-    localStorage.setItem(THEME_STORAGE_KEY, newPreference);
+    themeStorage.set(newPreference);
+  };
+
+  const setContrastPreference = (newPreference: ContrastPreference) => {
+    setContrastPrefState(newPreference);
+    contrastStorage.set(newPreference);
   };
 
   return (
     <ThemeContext.Provider
       value={{
         preference,
+        contrastPreference,
         effectiveTheme,
+        effectiveContrast,
         systemPreference,
         setThemePreference,
+        setContrastPreference,
       }}
     >
       {children}

--- a/src/shared/theme/ThemeDropdown.tsx
+++ b/src/shared/theme/ThemeDropdown.tsx
@@ -1,17 +1,31 @@
 import React, { useState } from 'react';
 import {
+  Divider,
   Dropdown,
+  DropdownGroup,
   DropdownItem,
   DropdownList,
   Flex,
+  FlexItem,
   MenuToggle,
   MenuToggleElement,
 } from '@patternfly/react-core';
+import { AdjustIcon } from '@patternfly/react-icons/dist/esm/icons/adjust-icon';
 import { CogIcon } from '@patternfly/react-icons/dist/esm/icons/cog-icon';
+import { EyeIcon } from '@patternfly/react-icons/dist/esm/icons/eye-icon';
 import { MoonIcon } from '@patternfly/react-icons/dist/esm/icons/moon-icon';
 import { SunIcon } from '@patternfly/react-icons/dist/esm/icons/sun-icon';
-import { THEME_SYSTEM, THEME_DARK, THEME_LIGHT, THEME_LABELS } from './const';
-import { ThemePreference } from './types';
+import {
+  THEME_SYSTEM,
+  THEME_DARK,
+  THEME_LIGHT,
+  CONTRAST_SYSTEM,
+  CONTRAST_DEFAULT,
+  CONTRAST_HIGH,
+  THEME_PREFERENCE_LABELS,
+  CONTRAST_PREFERENCE_LABELS,
+} from './const';
+import { ContrastMode, ContrastPreference, Theme, ThemePreference } from './types';
 import { useTheme } from './useTheme';
 
 interface ThemeDropdownProps {
@@ -21,8 +35,8 @@ interface ThemeDropdownProps {
   showText?: boolean;
 }
 
-const getThemeIcon = (theme: ThemePreference, effectiveTheme: 'dark' | 'light') => {
-  switch (theme) {
+const getColorSchemeIcon = (preference: ThemePreference, effectiveTheme: Theme) => {
+  switch (preference) {
     case THEME_DARK:
       return <MoonIcon />;
     case THEME_LIGHT:
@@ -30,12 +44,32 @@ const getThemeIcon = (theme: ThemePreference, effectiveTheme: 'dark' | 'light') 
     case THEME_SYSTEM:
       return effectiveTheme === THEME_DARK ? <MoonIcon /> : <SunIcon />;
     default:
-      return <CogIcon />;
+      return <SunIcon />;
+  }
+};
+
+const getContrastIcon = (preference: ContrastPreference, effectiveContrast: ContrastMode) => {
+  switch (preference) {
+    case CONTRAST_HIGH:
+      return <AdjustIcon />;
+    case CONTRAST_DEFAULT:
+      return <EyeIcon />;
+    case CONTRAST_SYSTEM:
+      return effectiveContrast === CONTRAST_HIGH ? <AdjustIcon /> : <EyeIcon />;
+    default:
+      return <EyeIcon />;
   }
 };
 
 export const ThemeDropdown: React.FC<ThemeDropdownProps> = ({ className, showText = false }) => {
-  const { preference, effectiveTheme, setThemePreference } = useTheme();
+  const {
+    preference,
+    contrastPreference,
+    effectiveTheme,
+    effectiveContrast,
+    setThemePreference,
+    setContrastPreference,
+  } = useTheme();
   const [isOpen, setIsOpen] = useState(false);
 
   const onToggleClick = () => {
@@ -46,19 +80,23 @@ export const ThemeDropdown: React.FC<ThemeDropdownProps> = ({ className, showTex
     _event: React.MouseEvent<Element, MouseEvent> | undefined,
     value: string | number | undefined,
   ) => {
-    if (value && typeof value === 'string') {
-      setThemePreference(value as ThemePreference);
+    if (!value || typeof value !== 'string') {
+      return;
     }
-    setIsOpen(false);
+
+    // Values are prefixed to distinguish groups
+    if (value === 'brand-theme') {
+      return; // Handled by the Switch onChange directly
+    } else if (value.startsWith('theme:')) {
+      setThemePreference(value.replace('theme:', '') as ThemePreference);
+    } else if (value.startsWith('contrast:')) {
+      setContrastPreference(value.replace('contrast:', '') as ContrastPreference);
+    }
+    // Don't close on select -- user may want to change both groups
   };
 
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
-      style={{
-        border: 'var(--pf-t--global--text--color--subtle)',
-        borderRadius: 'var(--pf-t--global--border--radius--large)',
-      }}
-      variant="plainText"
       ref={toggleRef}
       onClick={onToggleClick}
       isExpanded={isOpen}
@@ -67,8 +105,15 @@ export const ThemeDropdown: React.FC<ThemeDropdownProps> = ({ className, showTex
       data-test="theme-dropdown-toggle"
     >
       <Flex gap={{ default: 'gapSm' }} alignItems={{ default: 'alignItemsCenter' }}>
-        {getThemeIcon(preference, effectiveTheme)}
-        {showText && THEME_LABELS[preference]}
+        <FlexItem>
+          {getColorSchemeIcon(preference, effectiveTheme)}{' '}
+          {showText && <span>{THEME_PREFERENCE_LABELS[preference]}</span>}
+        </FlexItem>
+        <FlexItem>|</FlexItem>
+        <FlexItem>
+          {getContrastIcon(contrastPreference, effectiveContrast)}{' '}
+          {showText && <span>{CONTRAST_PREFERENCE_LABELS[contrastPreference]}</span>}
+        </FlexItem>
       </Flex>
     </MenuToggle>
   );
@@ -81,35 +126,69 @@ export const ThemeDropdown: React.FC<ThemeDropdownProps> = ({ className, showTex
       toggle={toggle}
       data-test="theme-dropdown"
     >
-      <DropdownList>
-        <DropdownItem
-          value={THEME_SYSTEM}
-          isSelected={preference === THEME_SYSTEM}
-          data-test="theme-system"
-          icon={<CogIcon />}
-          description="Follow system preference"
-        >
-          {THEME_LABELS[THEME_SYSTEM]}
-        </DropdownItem>
-        <DropdownItem
-          value={THEME_LIGHT}
-          isSelected={preference === THEME_LIGHT}
-          data-test="theme-light"
-          icon={<SunIcon />}
-          description="Always use light mode"
-        >
-          {THEME_LABELS[THEME_LIGHT]}
-        </DropdownItem>
-        <DropdownItem
-          value={THEME_DARK}
-          isSelected={preference === THEME_DARK}
-          data-test="theme-dark"
-          icon={<MoonIcon />}
-          description="Always use dark mode"
-        >
-          {THEME_LABELS[THEME_DARK]}
-        </DropdownItem>
-      </DropdownList>
+      <DropdownGroup label="Color scheme">
+        <DropdownList>
+          <DropdownItem
+            value="theme:system"
+            isSelected={preference === THEME_SYSTEM}
+            data-test="theme-system"
+            icon={<CogIcon />}
+            description="Follow system preference"
+          >
+            {THEME_PREFERENCE_LABELS[THEME_SYSTEM]}
+          </DropdownItem>
+          <DropdownItem
+            value="theme:light"
+            isSelected={preference === THEME_LIGHT}
+            data-test="theme-light"
+            icon={<SunIcon />}
+            description="Always use light mode"
+          >
+            {THEME_PREFERENCE_LABELS[THEME_LIGHT]}
+          </DropdownItem>
+          <DropdownItem
+            value="theme:dark"
+            isSelected={preference === THEME_DARK}
+            data-test="theme-dark"
+            icon={<MoonIcon />}
+            description="Always use dark mode"
+          >
+            {THEME_PREFERENCE_LABELS[THEME_DARK]}
+          </DropdownItem>
+        </DropdownList>
+      </DropdownGroup>
+      <Divider />
+      <DropdownGroup label="Contrast mode">
+        <DropdownList>
+          <DropdownItem
+            value="contrast:system"
+            isSelected={contrastPreference === CONTRAST_SYSTEM}
+            data-test="contrast-system"
+            icon={<CogIcon />}
+            description="Follow system preference"
+          >
+            {CONTRAST_PREFERENCE_LABELS[CONTRAST_SYSTEM]}
+          </DropdownItem>
+          <DropdownItem
+            value="contrast:default"
+            isSelected={contrastPreference === CONTRAST_DEFAULT}
+            data-test="contrast-default"
+            icon={<EyeIcon />}
+            description="Standard contrast for most users"
+          >
+            {CONTRAST_PREFERENCE_LABELS[CONTRAST_DEFAULT]}
+          </DropdownItem>
+          <DropdownItem
+            value="contrast:high-contrast"
+            isSelected={contrastPreference === CONTRAST_HIGH}
+            data-test="contrast-high"
+            icon={<AdjustIcon />}
+            description="Increased contrast with stronger borders"
+          >
+            {CONTRAST_PREFERENCE_LABELS[CONTRAST_HIGH]}
+          </DropdownItem>
+        </DropdownList>
+      </DropdownGroup>
     </Dropdown>
   );
 };

--- a/src/shared/theme/__tests__/useTheme.spec.tsx
+++ b/src/shared/theme/__tests__/useTheme.spec.tsx
@@ -1,11 +1,20 @@
 import { renderHook, act } from '@testing-library/react';
 import { useEventListener } from '../../hooks/useEventListener';
-import { THEME_SYSTEM, THEME_DARK, THEME_LIGHT } from '../const';
+import {
+  THEME_SYSTEM,
+  THEME_DARK,
+  THEME_LIGHT,
+  CONTRAST_SYSTEM,
+  CONTRAST_DEFAULT,
+  CONTRAST_HIGH,
+} from '../const';
 import { ThemeProvider } from '../ThemeContext';
 import { useTheme } from '../useTheme';
 
 const THEME_STORAGE_KEY = 'konflux-theme-preference';
+const CONTRAST_STORAGE_KEY = 'konflux-contrast-preference';
 const DARK_THEME_CLASS = 'pf-v6-theme-dark';
+const HIGH_CONTRAST_CLASS = 'pf-v6-theme-high-contrast';
 
 // Mock localStorage
 const mockLocalStorage = {
@@ -42,8 +51,16 @@ beforeEach(() => {
   mockMatchMedia.mockClear();
   mockUseEventListener.mockClear();
 
+  // Default: light system preference, no contrast preference
+  mockMatchMedia.mockReturnValue({
+    matches: false,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  });
+
   // Clear any existing classes
   document.documentElement.classList.remove(DARK_THEME_CLASS);
+  document.documentElement.classList.remove(HIGH_CONTRAST_CLASS);
 });
 
 const TestWrapper = ({ children }) => <ThemeProvider>{children}</ThemeProvider>;
@@ -51,31 +68,38 @@ const TestWrapper = ({ children }) => <ThemeProvider>{children}</ThemeProvider>;
 describe('useTheme', () => {
   it('should initialize with system preference by default', () => {
     mockLocalStorage.getItem.mockReturnValue(null);
-    mockMatchMedia.mockReturnValue({
-      matches: false,
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
-    });
 
     const { result } = renderHook(() => useTheme(), { wrapper: TestWrapper });
 
     expect(result.current.preference).toBe(THEME_SYSTEM);
     expect(result.current.systemPreference).toBe(THEME_LIGHT);
     expect(result.current.effectiveTheme).toBe(THEME_LIGHT);
+    expect(result.current.contrastPreference).toBe(CONTRAST_SYSTEM);
+    expect(result.current.effectiveContrast).toBe(CONTRAST_DEFAULT);
   });
 
   it('should load stored preference from localStorage', () => {
-    mockLocalStorage.getItem.mockReturnValue(THEME_DARK);
-    mockMatchMedia.mockReturnValue({
-      matches: false,
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
+    mockLocalStorage.getItem.mockImplementation((key: string) => {
+      if (key === THEME_STORAGE_KEY) return JSON.stringify(THEME_DARK);
+      return null;
     });
 
     const { result } = renderHook(() => useTheme(), { wrapper: TestWrapper });
 
     expect(result.current.preference).toBe(THEME_DARK);
     expect(result.current.effectiveTheme).toBe(THEME_DARK);
+  });
+
+  it('should load stored contrast preference from localStorage', () => {
+    mockLocalStorage.getItem.mockImplementation((key: string) => {
+      if (key === CONTRAST_STORAGE_KEY) return JSON.stringify(CONTRAST_HIGH);
+      return null;
+    });
+
+    const { result } = renderHook(() => useTheme(), { wrapper: TestWrapper });
+
+    expect(result.current.contrastPreference).toBe(CONTRAST_HIGH);
+    expect(result.current.effectiveContrast).toBe(CONTRAST_HIGH);
   });
 
   it('should detect dark system preference', () => {
@@ -93,11 +117,9 @@ describe('useTheme', () => {
   });
 
   it('should apply dark theme class when effective theme is dark', () => {
-    mockLocalStorage.getItem.mockReturnValue(THEME_DARK);
-    mockMatchMedia.mockReturnValue({
-      matches: false,
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
+    mockLocalStorage.getItem.mockImplementation((key: string) => {
+      if (key === THEME_STORAGE_KEY) return JSON.stringify(THEME_DARK);
+      return null;
     });
 
     renderHook(() => useTheme(), { wrapper: TestWrapper });
@@ -106,11 +128,9 @@ describe('useTheme', () => {
   });
 
   it('should remove dark theme class when effective theme is light', () => {
-    mockLocalStorage.getItem.mockReturnValue(THEME_LIGHT);
-    mockMatchMedia.mockReturnValue({
-      matches: false,
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
+    mockLocalStorage.getItem.mockImplementation((key: string) => {
+      if (key === THEME_STORAGE_KEY) return JSON.stringify(THEME_LIGHT);
+      return null;
     });
 
     renderHook(() => useTheme(), { wrapper: TestWrapper });
@@ -118,13 +138,30 @@ describe('useTheme', () => {
     expect(document.documentElement.classList.contains(DARK_THEME_CLASS)).toBe(false);
   });
 
-  it('should save preference to localStorage when changed', () => {
-    mockLocalStorage.getItem.mockReturnValue(THEME_SYSTEM);
-    mockMatchMedia.mockReturnValue({
-      matches: false,
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
+  it('should apply high contrast class when contrast preference is high-contrast', () => {
+    mockLocalStorage.getItem.mockImplementation((key: string) => {
+      if (key === CONTRAST_STORAGE_KEY) return JSON.stringify(CONTRAST_HIGH);
+      return null;
     });
+
+    renderHook(() => useTheme(), { wrapper: TestWrapper });
+
+    expect(document.documentElement.classList.contains(HIGH_CONTRAST_CLASS)).toBe(true);
+  });
+
+  it('should remove high contrast class when contrast preference is default', () => {
+    mockLocalStorage.getItem.mockImplementation((key: string) => {
+      if (key === CONTRAST_STORAGE_KEY) return JSON.stringify(CONTRAST_DEFAULT);
+      return null;
+    });
+
+    renderHook(() => useTheme(), { wrapper: TestWrapper });
+
+    expect(document.documentElement.classList.contains(HIGH_CONTRAST_CLASS)).toBe(false);
+  });
+
+  it('should save preference to localStorage when changed', () => {
+    mockLocalStorage.getItem.mockReturnValue(null);
 
     const { result } = renderHook(() => useTheme(), { wrapper: TestWrapper });
 
@@ -132,42 +169,98 @@ describe('useTheme', () => {
       result.current.setThemePreference(THEME_DARK);
     });
 
-    expect(mockLocalStorage.setItem).toHaveBeenCalledWith(THEME_STORAGE_KEY, THEME_DARK);
+    expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+      THEME_STORAGE_KEY,
+      JSON.stringify(THEME_DARK),
+    );
     expect(result.current.preference).toBe(THEME_DARK);
   });
 
-  it('should listen for system preference changes', () => {
-    let eventHandler: ((e: MediaQueryListEvent) => void) | undefined;
-
-    // Mock useEventListener to capture the event handler
-    mockUseEventListener.mockImplementation((eventName, handler, target) => {
-      if (eventName === 'change' && target?.matches !== undefined) {
-        eventHandler = handler;
-      }
-    });
-
-    mockLocalStorage.getItem.mockReturnValue(THEME_SYSTEM);
-    mockMatchMedia.mockReturnValue({
-      matches: false,
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
-    });
+  it('should save contrast preference to localStorage when changed', () => {
+    mockLocalStorage.getItem.mockReturnValue(null);
 
     const { result } = renderHook(() => useTheme(), { wrapper: TestWrapper });
 
-    // Simulate system preference change
     act(() => {
-      eventHandler?.({ matches: true } as MediaQueryListEvent);
+      result.current.setContrastPreference(CONTRAST_HIGH);
+    });
+
+    expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+      CONTRAST_STORAGE_KEY,
+      JSON.stringify(CONTRAST_HIGH),
+    );
+    expect(result.current.contrastPreference).toBe(CONTRAST_HIGH);
+  });
+
+  it('should listen for system preference changes', () => {
+    const eventHandlers: Record<string, ((e: MediaQueryListEvent) => void)[]> = {};
+
+    mockUseEventListener.mockImplementation(
+      (eventName: string, handler: (e: MediaQueryListEvent) => void) => {
+        if (!eventHandlers[eventName]) {
+          eventHandlers[eventName] = [];
+        }
+        eventHandlers[eventName].push(handler);
+      },
+    );
+
+    mockLocalStorage.getItem.mockReturnValue(null);
+
+    const { result } = renderHook(() => useTheme(), { wrapper: TestWrapper });
+
+    // Simulate system preference change to dark
+    act(() => {
+      eventHandlers.change?.[0]?.({ matches: true } as MediaQueryListEvent);
     });
 
     expect(result.current.systemPreference).toBe(THEME_DARK);
     expect(result.current.effectiveTheme).toBe(THEME_DARK);
+  });
 
-    // Verify useEventListener was called with correct parameters
-    expect(mockUseEventListener).toHaveBeenCalledWith(
-      'change',
-      expect.any(Function),
-      expect.objectContaining({ matches: false }),
+  it('should auto-enable high contrast when system prefers it and contrast is set to system', () => {
+    const eventHandlers: ((e: MediaQueryListEvent) => void)[] = [];
+
+    mockUseEventListener.mockImplementation(
+      (_eventName: string, handler: (e: MediaQueryListEvent) => void) => {
+        eventHandlers.push(handler);
+      },
     );
+
+    mockLocalStorage.getItem.mockReturnValue(null);
+
+    const { result } = renderHook(() => useTheme(), { wrapper: TestWrapper });
+
+    // Simulate system prefers-contrast: more change
+    // The second handler is for prefers-contrast
+    act(() => {
+      eventHandlers[1]?.({ matches: true } as MediaQueryListEvent);
+    });
+
+    expect(result.current.effectiveContrast).toBe(CONTRAST_HIGH);
+  });
+
+  it('should not auto-enable high contrast when contrast is explicitly set to default', () => {
+    mockLocalStorage.getItem.mockImplementation((key: string) => {
+      if (key === CONTRAST_STORAGE_KEY) return JSON.stringify(CONTRAST_DEFAULT);
+      return null;
+    });
+
+    const eventHandlers: ((e: MediaQueryListEvent) => void)[] = [];
+
+    mockUseEventListener.mockImplementation(
+      (_eventName: string, handler: (e: MediaQueryListEvent) => void) => {
+        eventHandlers.push(handler);
+      },
+    );
+
+    const { result } = renderHook(() => useTheme(), { wrapper: TestWrapper });
+
+    // Simulate system prefers-contrast: more change
+    act(() => {
+      eventHandlers[1]?.({ matches: true } as MediaQueryListEvent);
+    });
+
+    // Should remain default because user explicitly chose default, not system
+    expect(result.current.effectiveContrast).toBe(CONTRAST_DEFAULT);
   });
 });

--- a/src/shared/theme/const.ts
+++ b/src/shared/theme/const.ts
@@ -3,14 +3,29 @@ export const THEME_SYSTEM = 'system';
 export const THEME_DARK = 'dark';
 export const THEME_LIGHT = 'light';
 
-// Media query constant
+// Contrast preference constants
+export const CONTRAST_SYSTEM = 'system';
+export const CONTRAST_DEFAULT = 'default';
+export const CONTRAST_HIGH = 'high-contrast';
+
+// Media query constants
 export const PREFERS_COLOR_SCHEME_DARK = '(prefers-color-scheme: dark)';
+export const PREFERS_CONTRAST_MORE = '(prefers-contrast: more)';
+export const FORCED_COLORS_ACTIVE = '(forced-colors: active)';
 
-// Theme preferences array for validation
+// Validation arrays
 export const THEME_PREFERENCES = [THEME_SYSTEM, THEME_DARK, THEME_LIGHT] as const;
+export const CONTRAST_PREFERENCES = [CONTRAST_SYSTEM, CONTRAST_DEFAULT, CONTRAST_HIGH] as const;
 
-export const THEME_LABELS = {
+// Labels
+export const THEME_PREFERENCE_LABELS = {
   [THEME_SYSTEM]: 'System',
-  [THEME_DARK]: 'Dark',
   [THEME_LIGHT]: 'Light',
+  [THEME_DARK]: 'Dark',
+} as const;
+
+export const CONTRAST_PREFERENCE_LABELS = {
+  [CONTRAST_SYSTEM]: 'System',
+  [CONTRAST_DEFAULT]: 'Default',
+  [CONTRAST_HIGH]: 'High Contrast',
 } as const;

--- a/src/shared/theme/index.ts
+++ b/src/shared/theme/index.ts
@@ -1,10 +1,16 @@
 export { useTheme } from './useTheme';
 export { ThemeDropdown } from './ThemeDropdown';
-export type { ThemePreference } from './types';
+export type { ThemePreference, ContrastMode, ContrastPreference } from './types';
 export {
   THEME_SYSTEM,
   THEME_DARK,
   THEME_LIGHT,
+  CONTRAST_SYSTEM,
+  CONTRAST_DEFAULT,
+  CONTRAST_HIGH,
   PREFERS_COLOR_SCHEME_DARK,
+  PREFERS_CONTRAST_MORE,
+  FORCED_COLORS_ACTIVE,
   THEME_PREFERENCES,
+  CONTRAST_PREFERENCES,
 } from './const';

--- a/src/shared/theme/types.ts
+++ b/src/shared/theme/types.ts
@@ -1,2 +1,4 @@
 export type Theme = 'dark' | 'light';
 export type ThemePreference = 'system' | Theme;
+export type ContrastMode = 'default' | 'high-contrast';
+export type ContrastPreference = 'system' | ContrastMode;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,10 +33,10 @@ export default {
             options: {
               typescript: true,
               replaceAttrValues: {
-                '#FC783D': 'var(--konflux-primary-color)',
-                '#fc783d': 'var(--konflux-primary-color)',
-                '#D36634': 'var(--konflux-primary-hover-color)',
-                '#d36634': 'var(--konflux-primary-hover-color)',
+                '#FC783D': 'var(--konflux-brand-primary)',
+                '#fc783d': 'var(--konflux-brand-primary)',
+                '#D36634': 'var(--konflux-brand-primary-hover)',
+                '#d36634': 'var(--konflux-brand-primary-hover)',
               },
               svgoConfig: {
                 plugins: [


### PR DESCRIPTION
## Fixes
<!-- No Jira ticket associated -->
https://redhat.atlassian.net/browse/KFLUXUI-1449

## Description

Replaces the manual CSS class overrides in `main.scss` (which targeted `.pf-v6-c-button.pf-m-primary` etc.) with a proper PatternFly v6 design token-based theme system. Introduces `konflux-theme.scss` that`.

The ThemeDropdown now has two groups: color scheme (System/Light/Dark) and contrast mode (System/Default/High Contrast), with persistence via `createKeyedJSONStorage`.

## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review
<img width="344" height="497" alt="image" src="https://github.com/user-attachments/assets/2e25be64-5920-4bee-a385-8b10eab7f237" />

<img width="1368" height="915" alt="image" src="https://github.com/user-attachments/assets/073752fb-d12b-413c-820e-bb2d46612726" />
<img width="1368" height="920" alt="image" src="https://github.com/user-attachments/assets/0c9c8cf6-25f5-4b84-aa8f-68fc225eb1a6" />
### ==================== High contrast ====================
<img width="1370" height="919" alt="image" src="https://github.com/user-attachments/assets/15da3a01-24c0-448f-bf09-2ff979635b29" />
<img width="1366" height="913" alt="image" src="https://github.com/user-attachments/assets/eb87db88-3668-4ec0-bcf1-6a3769c3104f" />



## How to test or reproduce?

1. Start the dev server (`yarn start`)
2. Verify primary buttons are Konflux orange in light and dark mode
3. Verify non-primary buttons (link, secondary, tertiary) use default PF blue
4. Open the theme dropdown in the header — should show two groups: Color scheme and Contrast mode
5. Toggle between System/Light/Dark and verify theme switches correctly
6. Toggle between System/Default/High Contrast and verify borders appear in high contrast mode
7. Check all 4 combinations: light, dark, light+HC, dark+HC

## Browser conformance:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
