### PR TITLE
fix(KFLUXUI-1444): align filter toolbars and page content with table edge

### DIFF
--- a/src/components/Applications/ApplicationListView.tsx
+++ b/src/components/Applications/ApplicationListView.tsx
@@ -84,7 +84,7 @@ const ApplicationListView: React.FC<React.PropsWithChildren<unknown>> = () => {
         title="Applications"
         description="An application is 1 or more components running together for building and releasing."
       >
-        <PageSection hasBodyWrapper={false} padding={{ default: 'noPadding' }} isFilled>
+        <PageSection hasBodyWrapper={false} isFilled>
           {!applications || applications.length === 0 ? (
             <AppEmptyState
               className="pf-v6-u-mx-lg"

--- a/src/components/Components/LinkedSecretsListView/LinkedSecretsToolbar.tsx
+++ b/src/components/Components/LinkedSecretsListView/LinkedSecretsToolbar.tsx
@@ -10,6 +10,7 @@ export const LinkedSecretsToolbar: React.FC = () => {
       data-test="linked-secrets-list-toolbar"
       clearFiltersButtonText="Clear filters"
       clearAllFilters={() => setNameFilter('')}
+      className="pf-v6-u-py-md"
     >
       <ToolbarContent>
         <ToolbarItem>

--- a/src/components/ComponentsPage/ComponentsPage.tsx
+++ b/src/components/ComponentsPage/ComponentsPage.tsx
@@ -24,7 +24,7 @@ const ComponentsPage: React.FC = () => {
           </>
         }
       >
-        <PageSection hasBodyWrapper={false} padding={{ default: 'noPadding' }} isFilled>
+        <PageSection hasBodyWrapper={false} isFilled>
           <AppEmptyState
             className="pf-v6-u-mx-lg"
             isXl

--- a/src/components/Filter/toolbars/BaseTextFIlterToolbar.tsx
+++ b/src/components/Filter/toolbars/BaseTextFIlterToolbar.tsx
@@ -43,7 +43,6 @@ export const BaseTextFilterToolbar: React.FC<BaseTextFilterToolbarProps> = ({
   showSearchInput = true,
   noLeftPadding = false,
   searchOptions = [],
-  className,
 }) => {
   const [isOpen, setIsOpen] = React.useState<boolean>(false);
   const [searchOption, setSearchOption] = React.useState<string>(searchOptions?.[0] ?? '');
@@ -99,12 +98,7 @@ export const BaseTextFilterToolbar: React.FC<BaseTextFilterToolbarProps> = ({
   );
 
   return (
-    <Toolbar
-      data-test={dataTest}
-      inset={{ default: 'insetLg' }}
-      clearAllFilters={onClearFilters}
-      className={className}
-    >
+    <Toolbar data-test={dataTest} clearAllFilters={onClearFilters} className="pf-v6-u-py-md">
       <ToolbarContent style={{ paddingLeft: noLeftPadding ? '0' : undefined }}>
         {showSearchInput && (
           <ToolbarItem className="pf-v6-u-ml-0">

--- a/src/components/Filter/toolbars/ReleasesFilterToolbar.tsx
+++ b/src/components/Filter/toolbars/ReleasesFilterToolbar.tsx
@@ -38,8 +38,8 @@ export const ReleasesFilterToolbar: React.FC<Props> = ({
   const [filterType, setFilterType] = React.useState(dropdownItems[0]);
 
   return (
-    <Toolbar data-test="releases-filter-toolbar">
-      <ToolbarContent className="pf-v6-u-pl-0">
+    <Toolbar data-test="releases-filter-toolbar" className="pf-v6-u-py-md">
+      <ToolbarContent>
         <ToolbarGroup align={{ default: 'alignStart' }}>
           <ToolbarItem>
             <InputGroup>

--- a/src/components/NamespaceList/NamespaceListView.tsx
+++ b/src/components/NamespaceList/NamespaceListView.tsx
@@ -70,7 +70,7 @@ const NamespaceListView: React.FC<React.PropsWithChildren<unknown>> = () => {
   return (
     <>
       <PageLayout title="Namespaces" description="A namespace contains 1 or more applications">
-        <PageSection hasBodyWrapper={false} padding={{ default: 'noPadding' }} isFilled>
+        <PageSection hasBodyWrapper={false} isFilled>
           {!namespaces || namespaces.length === 0 ? (
             <AppEmptyState
               className="pf-v6-u-mx-lg"

--- a/src/components/Releases/ReleaseArtifactsTab/ReleaseArtifactsToolbar.tsx
+++ b/src/components/Releases/ReleaseArtifactsTab/ReleaseArtifactsToolbar.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 export const ReleaseArtifactsToolbar: React.FC<Props> = ({ value, onSearchInputChange }) => {
   return (
-    <Toolbar>
+    <Toolbar className="pf-v6-u-py-md">
       <ToolbarContent>
         <ToolbarItem className="pf-v6-u-ml-0">
           <SearchInput

--- a/src/components/Releases/ReleasesListView.tsx
+++ b/src/components/Releases/ReleasesListView.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useParams } from 'react-router-dom';
-import { PageSection, Title, Spinner, Bullseye } from '@patternfly/react-core';
+import { Title, Spinner, Bullseye } from '@patternfly/react-core';
 import { SortByDirection } from '@patternfly/react-table';
 import { textMatch } from '~/utils/text-filter-utils';
 import { SESSION_STORAGE_KEYS } from '../../consts/constants';
@@ -129,7 +129,7 @@ const ReleasesListView: React.FC = () => {
   }
 
   return (
-    <PageSection hasBodyWrapper={false} padding={{ default: 'noPadding' }} isFilled>
+    <>
       <Title size="lg" headingLevel="h3" className="pf-v6-c-title pf-v6-u-mt-lg pf-v6-u-mb-sm">
         Releases
       </Title>
@@ -198,7 +198,7 @@ const ReleasesListView: React.FC = () => {
           description="Selected columns will be displayed in the releases table."
         />
       </>
-    </PageSection>
+    </>
   );
 };
 

--- a/src/components/Snapshots/SnapshotsListView/SnapshotsListView.tsx
+++ b/src/components/Snapshots/SnapshotsListView/SnapshotsListView.tsx
@@ -2,13 +2,10 @@ import * as React from 'react';
 import {
   Bullseye,
   EmptyStateBody,
-  PageSection,
   Spinner,
   Title,
   Content,
-  ContentVariants,
   Flex,
-  FlexItem,
   Switch,
   Select,
   MenuToggle,
@@ -142,19 +139,12 @@ const SnapshotsListView: React.FC<React.PropsWithChildren<SnapshotsListViewProps
   const isFiltered = nameFilter || releasableFilter || commitMessageFilter || showMergedOnly;
 
   return (
-    <PageSection hasBodyWrapper={false} padding={{ default: 'noPadding' }} isFilled>
-      <Flex
-        justifyContent={{ default: 'justifyContentSpaceBetween' }}
-        alignItems={{ default: 'alignItemsCenter' }}
-      >
-        <FlexItem>
-          <Title size="lg" headingLevel="h3" className="pf-v6-c-title pf-v6-u-mt-lg pf-v6-u-mb-sm">
-            Snapshots
-          </Title>
-        </FlexItem>
-      </Flex>
+    <>
+      <Title size="lg" headingLevel="h3" className="pf-v6-c-title pf-v6-u-mt-lg pf-v6-u-mb-sm">
+        Snapshots
+      </Title>
 
-      <Content component={ContentVariants.p}>
+      <Content>
         A snapshot is a point-in-time, immutable record of an application&apos;s container images.{' '}
         <ExternalLink href={LEARN_MORE_SNAPSHOTS}>Learn more</ExternalLink>
       </Content>
@@ -173,7 +163,7 @@ const SnapshotsListView: React.FC<React.PropsWithChildren<SnapshotsListViewProps
         </AppEmptyState>
       ) : (
         <>
-          <Flex spaceItems={{ default: 'spaceItemsNone' }} className="pf-v5-u-mt-sm">
+          <Flex spaceItems={{ default: 'spaceItemsMd' }}>
             <Select
               toggle={(toggleRef) => (
                 <MenuToggle
@@ -215,7 +205,6 @@ const SnapshotsListView: React.FC<React.PropsWithChildren<SnapshotsListViewProps
               onClearFilters={onClearFilters}
               totalColumns={snapshotColumns.length}
               noLeftPadding={true}
-              className="pf-v5-u-py-xs"
             >
               <Switch
                 id="show-merged-snapshots-only-switch"
@@ -250,7 +239,7 @@ const SnapshotsListView: React.FC<React.PropsWithChildren<SnapshotsListViewProps
           )}
         </>
       )}
-    </PageSection>
+    </>
   );
 };
 

--- a/src/components/Snapshots/SnapshotsListView/SnapshotsListView.tsx
+++ b/src/components/Snapshots/SnapshotsListView/SnapshotsListView.tsx
@@ -209,7 +209,6 @@ const SnapshotsListView: React.FC<React.PropsWithChildren<SnapshotsListViewProps
               <Switch
                 id="show-merged-snapshots-only-switch"
                 label="Hide Pull Request Snapshots"
-                className="pf-v5-u-py-xs"
                 isChecked={showMergedOnly}
                 onChange={(_event, checked) =>
                   setFilters({ ...unparsedFilters, showMergedOnly: checked })
@@ -218,7 +217,6 @@ const SnapshotsListView: React.FC<React.PropsWithChildren<SnapshotsListViewProps
               <Switch
                 id="releasable"
                 label="Show only releasable snapshots"
-                className="pf-v5-u-py-xs"
                 isChecked={releasableFilter}
                 onChange={(_event, checked) =>
                   setFilters({ ...unparsedFilters, releasable: checked })


### PR DESCRIPTION
## Fixes

- https://issues.redhat.com/browse/KFLUXUI-1444
- https://redhat.atlassian.net/browse/KFLUXUI-1420
- https://redhat.atlassian.net/browse/KFLUXUI-1418

## Description

Fixes filter toolbar and page content misalignment with the table edge across multiple list views.

- Remove `inset` prop from `BaseTextFilterToolbar` and apply consistent `pf-v6-u-py-md` spacing to all filter toolbars
- Remove `padding={{ default: 'noPadding' }}` from `PageSection` on Applications, Components, and Namespaces pages so default padding is restored
- Remove unnecessary `PageSection` / `Flex` wrappers from Snapshots and Releases list views
- Clean up leftover `pf-v5-*` utility classes

## Type of change

- [x] Bugfix

## Screenshots for design review

### Activity → Pipeline runs
| Before | After |
|--------|-------|
| <img width="3018" height="1650" alt="filter-toolbar-table-alignement-BEFORE" src="https://github.com/user-attachments/assets/7deb5ceb-233b-4e74-aa88-068c3d164edf" /> | <img width="3022" height="1652" alt="filter-toolbar-table-alignement-AFTER" src="https://github.com/user-attachments/assets/0fd96a1e-9847-4666-80d8-9989c2d7bd4a" /> |

## How to test or reproduce?

- Check that the filter toolbar is flush with the table edge on: Pipeline runs, Snapshots, Releases, Applications, Components, Namespaces, and Linked secrets pages

## Browser conformance
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge