### PR TITLE
fix(KONFLUX-14515): handle invalid URLs in stripQueryStringParams

### DIFF
--- a/src/components/PipelineRun/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
+++ b/src/components/PipelineRun/PipelineRunDetailsView/tabs/PipelineRunDetailsTab.tsx
@@ -50,8 +50,9 @@ import {
   getPipelineRunStatusResults,
   pipelineRunStatus,
 } from '~/utils/pipeline-utils';
+import { getSourceUrl } from '~/utils/pipelinerun-utils';
 import RelatedPipelineRuns from '../RelatedPipelineRuns';
-import { getSourceUrl, getSBOMsFromTaskRuns } from '../utils/pipelinerun-utils';
+import { getSBOMsFromTaskRuns } from '../utils/pipelinerun-utils';
 import PipelineRunVisualization from '../visualization/PipelineRunVisualization';
 import { createPipelineRunSBOMsModal } from './PipelineRunSBOMsModal';
 import RunParamsList from './RunParamsList';

--- a/src/components/PipelineRun/PipelineRunDetailsView/utils/__tests__/pipelinerun-utils.spec.ts
+++ b/src/components/PipelineRun/PipelineRunDetailsView/utils/__tests__/pipelinerun-utils.spec.ts
@@ -1,13 +1,7 @@
 import '@testing-library/jest-dom';
-import { PipelineRunLabel } from '~/consts/pipelinerun';
-import { PipelineRunKind, TaskRunKind, TektonResourceLabel } from '~/types';
+import { TaskRunKind, TektonResourceLabel } from '~/types';
 import { SBOMResultKeys } from '~/utils/pipeline-utils';
-import {
-  getSourceUrl,
-  stripQueryStringParams,
-  getSBOMSha,
-  getSBOMsFromTaskRuns,
-} from '../pipelinerun-utils';
+import { getSBOMSha, getSBOMsFromTaskRuns } from '../pipelinerun-utils';
 
 describe('pipelinerun-utils', () => {
   const mockGenerateUrl = jest.fn((sha?: string) =>
@@ -19,118 +13,6 @@ describe('pipelinerun-utils', () => {
     mockGenerateUrl.mockImplementation((sha?: string) =>
       sha ? `https://sbom.example.com/${sha}` : undefined,
     );
-  });
-
-  describe('stripQueryStringParams', () => {
-    it('should remove query string parameters from URL', () => {
-      const url = 'https://github.com/user/repo?foo=bar&baz=qux';
-      const result = stripQueryStringParams(url);
-      expect(result).toBe('https://github.com/user/repo');
-    });
-
-    it('should return URL without query string if none exists', () => {
-      const url = 'https://github.com/user/repo';
-      const result = stripQueryStringParams(url);
-      expect(result).toBe('https://github.com/user/repo');
-    });
-
-    it('should handle URLs with hash fragments', () => {
-      const url = 'https://github.com/user/repo/tree/main?tab=readme#section';
-      const result = stripQueryStringParams(url);
-      expect(result).toBe('https://github.com/user/repo/tree/main');
-    });
-
-    it('should return undefined for empty or null URL', () => {
-      expect(stripQueryStringParams('')).toBeUndefined();
-      expect(stripQueryStringParams(null)).toBeUndefined();
-      expect(stripQueryStringParams(undefined)).toBeUndefined();
-    });
-
-    it('should preserve path segments', () => {
-      const url = 'https://gitlab.com/group/subgroup/project/tree/branch?ref=main';
-      const result = stripQueryStringParams(url);
-      expect(result).toBe('https://gitlab.com/group/subgroup/project/tree/branch');
-    });
-  });
-
-  describe('getSourceUrl', () => {
-    it('should return URL from PAC annotation when available', () => {
-      const pipelineRun = {
-        metadata: {
-          annotations: {
-            [PipelineRunLabel.COMMIT_FULL_REPO_URL_ANNOTATION]:
-              'https://github.com/user/repo?param=value',
-          },
-        },
-      } as unknown as PipelineRunKind;
-
-      const result = getSourceUrl(pipelineRun);
-      expect(result).toBe('https://github.com/user/repo');
-    });
-
-    it('should return URL from BuildService annotation when PAC annotation is not available', () => {
-      const pipelineRun = {
-        metadata: {
-          annotations: {
-            [PipelineRunLabel.BUILD_SERVICE_REPO_ANNOTATION]:
-              'https://gitlab.com/user/repo?param=value',
-          },
-        },
-      } as unknown as PipelineRunKind;
-
-      const result = getSourceUrl(pipelineRun);
-      expect(result).toBe('https://gitlab.com/user/repo');
-    });
-
-    it('should prefer PAC annotation over BuildService annotation', () => {
-      const pipelineRun = {
-        metadata: {
-          annotations: {
-            [PipelineRunLabel.COMMIT_FULL_REPO_URL_ANNOTATION]: 'https://github.com/pac/repo',
-            [PipelineRunLabel.BUILD_SERVICE_REPO_ANNOTATION]: 'https://gitlab.com/build/repo',
-          },
-        },
-      } as unknown as PipelineRunKind;
-
-      const result = getSourceUrl(pipelineRun);
-      expect(result).toBe('https://github.com/pac/repo');
-    });
-
-    it('should return undefined when no annotations are present', () => {
-      const pipelineRun = {
-        metadata: {
-          annotations: {},
-        },
-      } as PipelineRunKind;
-
-      const result = getSourceUrl(pipelineRun);
-      expect(result).toBeUndefined();
-    });
-
-    it('should return undefined for null or undefined pipelineRun', () => {
-      expect(getSourceUrl(null)).toBeUndefined();
-      expect(getSourceUrl(undefined)).toBeUndefined();
-    });
-
-    it('should return undefined when metadata is missing', () => {
-      const pipelineRun = {} as PipelineRunKind;
-      const result = getSourceUrl(pipelineRun);
-      expect(result).toBeUndefined();
-    });
-
-    it('should strip query parameters from the returned URL', () => {
-      const pipelineRun = {
-        metadata: {
-          annotations: {
-            [PipelineRunLabel.COMMIT_FULL_REPO_URL_ANNOTATION]:
-              'https://github.com/user/repo?foo=bar&baz=qux',
-          },
-        },
-      } as unknown as PipelineRunKind;
-
-      const result = getSourceUrl(pipelineRun);
-      expect(result).toBe('https://github.com/user/repo');
-    });
   });
 
   describe('getSBOMSha', () => {

--- a/src/components/PipelineRun/PipelineRunDetailsView/utils/pipelinerun-utils.ts
+++ b/src/components/PipelineRun/PipelineRunDetailsView/utils/pipelinerun-utils.ts
@@ -1,26 +1,5 @@
 import { isTaskV1Beta1, SBOMResultKeys } from '~/utils/pipeline-utils';
-import { PipelineRunLabel } from '../../../../consts/pipelinerun';
-import { PipelineRunKind, TaskRunKind, TektonResourceLabel } from '../../../../types';
-
-export const stripQueryStringParams = (url: string) => {
-  if (!url) return undefined;
-
-  const { origin, pathname } = new URL(url);
-  return `${origin}${pathname}`;
-};
-
-export const getSourceUrl = (pipelineRun: PipelineRunKind): string => {
-  if (!pipelineRun) {
-    return undefined;
-  }
-
-  const repoFromBuildServiceAnnotation =
-    pipelineRun.metadata?.annotations?.[PipelineRunLabel.BUILD_SERVICE_REPO_ANNOTATION];
-  const repoFromPACAnnotation =
-    pipelineRun.metadata?.annotations?.[PipelineRunLabel.COMMIT_FULL_REPO_URL_ANNOTATION];
-
-  return stripQueryStringParams(repoFromPACAnnotation || repoFromBuildServiceAnnotation);
-};
+import { TaskRunKind, TektonResourceLabel } from '../../../../types';
 
 export type TaskRunSBOM = {
   url?: string;

--- a/src/utils/__tests__/pipelinerun-utils.spec.ts
+++ b/src/utils/__tests__/pipelinerun-utils.spec.ts
@@ -1,8 +1,14 @@
+import { PipelineRunLabel } from '~/consts/pipelinerun';
 import { fetchResourceWithK8sAndKubeArchive } from '~/kubearchive/resource-utils';
 import { PipelineRunModel, TaskRunModel } from '~/models';
 import { PipelineRunKind, TaskRunKind } from '~/types';
 import { ResourceSource } from '~/types/k8s';
-import { QueryPipelineRunWithKubearchive, QueryTaskRunWithKubearchive } from '../pipelinerun-utils';
+import {
+  getSourceUrl,
+  QueryPipelineRunWithKubearchive,
+  QueryTaskRunWithKubearchive,
+  stripQueryStringParams,
+} from '../pipelinerun-utils';
 
 jest.mock('~/kubearchive/resource-utils', () => ({
   fetchResourceWithK8sAndKubeArchive: jest.fn(),
@@ -13,6 +19,68 @@ const fetchResourceWithK8sAndKubeArchiveMock = fetchResourceWithK8sAndKubeArchiv
 describe('pipelinerun-utils', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('stripQueryStringParams', () => {
+    it('should strip query params from a valid URL', () => {
+      expect(stripQueryStringParams('https://github.com/org/repo?token=abc')).toBe(
+        'https://github.com/org/repo',
+      );
+    });
+
+    it('should return the URL unchanged when there are no query params', () => {
+      expect(stripQueryStringParams('https://github.com/org/repo')).toBe(
+        'https://github.com/org/repo',
+      );
+    });
+
+    it('should return undefined for an empty string', () => {
+      expect(stripQueryStringParams('')).toBeUndefined();
+    });
+
+    it('should return undefined for an invalid URL', () => {
+      expect(stripQueryStringParams('not-a-url')).toBeUndefined();
+    });
+  });
+
+  describe('getSourceUrl', () => {
+    it('should return undefined when pipelineRun is undefined', () => {
+      expect(getSourceUrl(undefined)).toBeUndefined();
+    });
+
+    it('should prefer PAC annotation over build service annotation', () => {
+      const plr = {
+        metadata: {
+          annotations: {
+            [PipelineRunLabel.COMMIT_FULL_REPO_URL_ANNOTATION]: 'https://github.com/pac/repo?a=1',
+            [PipelineRunLabel.BUILD_SERVICE_REPO_ANNOTATION]: 'https://github.com/build/repo?b=2',
+          },
+        },
+      } as unknown as PipelineRunKind;
+      expect(getSourceUrl(plr)).toBe('https://github.com/pac/repo');
+    });
+
+    it('should fall back to build service annotation', () => {
+      const plr = {
+        metadata: {
+          annotations: {
+            [PipelineRunLabel.BUILD_SERVICE_REPO_ANNOTATION]: 'https://github.com/build/repo?b=2',
+          },
+        },
+      } as unknown as PipelineRunKind;
+      expect(getSourceUrl(plr)).toBe('https://github.com/build/repo');
+    });
+
+    it('should return undefined when annotation is an invalid URL', () => {
+      const plr = {
+        metadata: {
+          annotations: {
+            [PipelineRunLabel.COMMIT_FULL_REPO_URL_ANNOTATION]: 'not-a-url',
+          },
+        },
+      } as unknown as PipelineRunKind;
+      expect(getSourceUrl(plr)).toBeUndefined();
+    });
   });
 
   describe('QueryPipelineRunWithKubearchive', () => {

--- a/src/utils/commits-utils.ts
+++ b/src/utils/commits-utils.ts
@@ -50,7 +50,7 @@ export const createCommitObjectFromPLR = (plr: PipelineRunKind): Commit => {
     plr.metadata.annotations?.[PipelineRunLabel.TEST_REPO_ORG_LABEL];
   const shaURL =
     plr.metadata.annotations?.[PipelineRunLabel.COMMIT_URL_ANNOTATION] ||
-    `${repoURL}/commit/${commitSHA}`;
+    (repoURL ? `${repoURL}/commit/${commitSHA}` : undefined);
   const shaTitle =
     plr.metadata.annotations?.[PipelineRunLabel.COMMIT_SHA_TITLE_ANNOTATION] || 'manual build';
   const gitProvider =

--- a/src/utils/pipelinerun-utils.ts
+++ b/src/utils/pipelinerun-utils.ts
@@ -11,8 +11,12 @@ import { getPipelineRuns, getTaskRuns, createTektonResultQueryOptions, EQ } from
 export const stripQueryStringParams = (url: string) => {
   if (!url) return undefined;
 
-  const { origin, pathname } = new URL(url);
-  return `${origin}${pathname}`;
+  try {
+    const { origin, pathname } = new URL(url);
+    return `${origin}${pathname}`;
+  } catch {
+    return undefined;
+  }
 };
 
 export const getSourceUrl = (pipelineRun: PipelineRunKind): string => {

--- a/src/utils/pipelinerun-utils.ts
+++ b/src/utils/pipelinerun-utils.ts
@@ -8,7 +8,7 @@ import { PipelineRunKind } from '../types';
 import { K8sModelCommon, K8sResourceCommon } from '../types/k8s';
 import { getPipelineRuns, getTaskRuns, createTektonResultQueryOptions, EQ } from './tekton-results';
 
-export const stripQueryStringParams = (url: string) => {
+export const stripQueryStringParams = (url: string): string | undefined => {
   if (!url) return undefined;
 
   try {
@@ -19,7 +19,7 @@ export const stripQueryStringParams = (url: string) => {
   }
 };
 
-export const getSourceUrl = (pipelineRun: PipelineRunKind): string => {
+export const getSourceUrl = (pipelineRun: PipelineRunKind): string | undefined => {
   if (!pipelineRun) {
     return undefined;
   }


### PR DESCRIPTION
## Fixes
Fixes: https://issues.redhat.com/browse/KONFLUX-14515

## Description
`stripQueryStringParams` called `new URL()` without a try/catch, so any PipelineRun with a malformed or non-URL value in its repo annotation (`pipelinesascode.tekton.dev/repo-url` or `build.appstudio.openshift.io/repo`) would throw an unhandled error and crash the Pipeline Runs list and details views.

This PR wraps `new URL()` in a try/catch (returning `undefined` for invalid URLs), moves `stripQueryStringParams` and `getSourceUrl` from the details-view local utils to `src/utils/pipelinerun-utils.ts` (shared across both views), and adds unit tests covering the new invalid-URL code path.

## Type of change

- [x] Bugfix

## Screen shots / Gifs for design review

| Before | After |
|--------|-------|
| <img width="3024" height="1658" alt="plr-list-invalid-url-BEFORE" src="https://github.com/user-attachments/assets/8fc5247d-a449-4ac7-b21c-8822cd14daa1" /> | <img width="3024" height="1658" alt="plr-list-invalid-url-AFTER" src="https://github.com/user-attachments/assets/6deb4a85-0b4a-4fa5-8bf3-7e5dabf888f7" /> |

## How to test or reproduce?

1. In `src/utils/pipelinerun-utils.ts`, temporarily remove the try/catch to restore the original code:
   ```ts
   export const stripQueryStringParams = (url: string) => {
     if (!url) return undefined;
     const { origin, pathname } = new URL(url);
     return `${origin}${pathname}`;
   };
   ```
2. In `PipelineRunDetailsTab.tsx` or `PipelineRunsListView.tsx`, add a test call:
   ```ts
   console.log(getSourceUrl({
     metadata: {
       annotations: {
         'pipelinesascode.tekton.dev/repo-url': 'not-a-valid-url',
       },
     },
   } as any));
   ```
3. Navigate to the Pipeline Runs list — the page crashes with `TypeError: Invalid URL`
4. Revert the change to `stripQueryStringParams` (restore the try/catch) — the page renders normally

## Browser conformance:
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of source and commit links when URL data is missing or invalid, preventing broken or unexpected links.
  * URL cleanup now safely ignores invalid inputs instead of causing errors.
  * Commit links are now only shown when a repository URL is available.
  * Updated pipeline run details to focus on supported SBOM information, with unrelated link tests and helpers removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->