### PR TITLE
fix(KFLUXUI-1462): fix log viewer toolbar issues

### DIFF
--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.scss
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.scss
@@ -1,3 +1,8 @@
+// override backdrop overflow so portaled popovers are visible
+#hacDev-modal-container:has(> .pf-v6-c-popover) {
+  overflow: visible;
+}
+
 .log-viewer__container > .pf-v6-c-log-viewer__header {
   overflow: visible;
 

--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.scss
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.scss
@@ -1,3 +1,15 @@
+.log-viewer__container > .pf-v6-c-log-viewer__header {
+  overflow: visible;
+
+  .pf-v6-c-check__label {
+    white-space: nowrap;
+  }
+
+  .pf-v6-c-toolbar__group.pf-m-align-end {
+    flex-wrap: wrap;
+  }
+}
+
 .log-viewer {
   &--fullscreen {
     padding: var(--pf-t--global--spacer--sm);

--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
@@ -107,7 +107,6 @@ const LogViewer: React.FC<Props> = ({
   const [isFullscreen, fullscreenRef, fullscreenToggle, isFullscreenSupported] =
     useFullscreen<HTMLDivElement>();
   const [downloadAllStatus, setDownloadAllStatus] = React.useState(false);
-  const [showShortcutHint, setShowShortcutHint] = React.useState(false);
 
   const downloadData = React.useMemo(() => {
     return sections
@@ -257,8 +256,9 @@ const LogViewer: React.FC<Props> = ({
                   <ToolbarItem>
                     <Popover
                       aria-label="Keyboard shortcuts"
-                      isVisible={showShortcutHint}
-                      shouldClose={() => setShowShortcutHint(false)}
+                      appendTo={() =>
+                        document.getElementById('hacDev-modal-container') || document.body
+                      }
                       bodyContent={
                         <KeyboardShortcutHint
                           shortcuts={LOG_VIEWER_SHORTCUTS}
@@ -272,7 +272,6 @@ const LogViewer: React.FC<Props> = ({
                         icon={<OutlinedKeyboardIcon />}
                         variant="plain"
                         aria-label="Show keyboard shortcuts"
-                        onClick={() => setShowShortcutHint((prev) => !prev)}
                       />
                     </Popover>
                   </ToolbarItem>


### PR DESCRIPTION
## Fixes
- https://issues.redhat.com/browse/KFLUXUI-1462
- https://issues.redhat.com/browse/KFLUXUI-1463

## Description
- **KFLUXUI-1462**: Fix "Dark theme" checkbox label truncated in log viewer toolbar. Added `white-space: nowrap` and `flex-wrap` on the toolbar group.
- **KFLUXUI-1463**: Fix keyboard shortcuts popover not visible inside modal. The popover was hidden behind the modal backdrop due to `overflow: hidden` on the modal container. Added a CSS `:has()` override.

## Type of change

- [x] Bugfix

## Screen shots / Gifs for design review

### KFLUXUI-1462
**Before:**

<img width="1184" height="720" alt="pf-v6-log-viewer-theme-checkbox-BEFORE" src="https://github.com/user-attachments/assets/691f0613-7ba3-435d-bed0-cf2de224354f" />

**After:**
<img width="1158" height="708" alt="pf-v6-log-viewer-theme-checkbox-AFTER" src="https://github.com/user-attachments/assets/bc587144-be89-4d40-bf4c-bc76a707f985" />


### KFLUXUI-1463
**Before:**

https://github.com/user-attachments/assets/5ac5af0b-2c08-4546-be42-075ef5dfecf7


**After:**

https://github.com/user-attachments/assets/55ebdb60-116a-4e00-b0f1-3867c6a3b629


## How to test or reproduce?
- Open the Build Log Viewer modal from a component's latest build
- Verify the "Dark theme" checkbox label is not truncated
- Click the keyboard icon button and verify the shortcuts popover is visible

## Browser conformance:
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge