### PR TITLE
fix(KFLUXUI-1475): fix missing page padding in PipelineRuns and Release Monitor

### DIFF
--- a/src/components/PipelineRunsPage/PipelineRunsPage.tsx
+++ b/src/components/PipelineRunsPage/PipelineRunsPage.tsx
@@ -243,7 +243,7 @@ export const PipelineRunsPage: React.FC = () => {
         </FilterToolbar>
       }
     >
-      <PageSection hasBodyWrapper={false} isFilled={false}>
+      <PageSection isFilled={false}>
         <FilterToolbar
           configs={filterConfigs}
           options={optionsMap}

--- a/src/components/PipelineRunsPage/PipelineRunsPage.tsx
+++ b/src/components/PipelineRunsPage/PipelineRunsPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Bullseye, Spinner } from '@patternfly/react-core';
+import { Bullseye, PageSection, Spinner } from '@patternfly/react-core';
 import ColumnManagement from '~/components/ColumnManagement/ColumnManagement';
 import { PipelineRunLabel } from '~/consts/pipelinerun';
 import { FeatureFlagIndicator } from '~/feature-flags/FeatureFlagIndicator';
@@ -243,40 +243,46 @@ export const PipelineRunsPage: React.FC = () => {
         </FilterToolbar>
       }
     >
-      <FilterToolbar
-        configs={filterConfigs}
-        options={optionsMap}
-        groups={{
-          resource: { variant: 'filter-group' },
-          attributes: { variant: 'filter-group' },
-          archive: { variant: 'filter-group' },
-        }}
-      >
-        <ColumnManagement columns={columns} columnStateKey={columnStateKey} showColumnManagement />
-      </FilterToolbar>
-      {hasRequiredFilters ? (
-        <TableContainer
-          data={filteredData}
-          unfilteredData={pipelineRuns}
-          loaded={plrLoaded}
-          emptyState={<FilteredEmptyState onClearFilters={clearAll} />}
-          loadError={plrError as Error | undefined}
-          noDataState={<PipelineRunsEmptyState />}
+      <PageSection hasBodyWrapper={false} isFilled={false}>
+        <FilterToolbar
+          configs={filterConfigs}
+          options={optionsMap}
+          groups={{
+            resource: { variant: 'filter-group' },
+            attributes: { variant: 'filter-group' },
+            archive: { variant: 'filter-group' },
+          }}
         >
-          <Table
-            data={filteredData}
+          <ColumnManagement
             columns={columns}
-            getRowId={(row) => row.metadata?.uid ?? row.metadata?.name ?? ''}
-            aria-label="Pipeline runs"
             columnStateKey={columnStateKey}
-            hasNextPage={hasNextPage}
-            isFetchingNextPage={isFetchingNextPage}
-            fetchNextPage={getNextPage}
+            showColumnManagement
           />
-        </TableContainer>
-      ) : (
-        <PipelineRunsEmptyState />
-      )}
+        </FilterToolbar>
+        {hasRequiredFilters ? (
+          <TableContainer
+            data={filteredData}
+            unfilteredData={pipelineRuns}
+            loaded={plrLoaded}
+            emptyState={<FilteredEmptyState onClearFilters={clearAll} />}
+            loadError={plrError as Error | undefined}
+            noDataState={<PipelineRunsEmptyState />}
+          >
+            <Table
+              data={filteredData}
+              columns={columns}
+              getRowId={(row) => row.metadata?.uid ?? row.metadata?.name ?? ''}
+              aria-label="Pipeline runs"
+              columnStateKey={columnStateKey}
+              hasNextPage={hasNextPage}
+              isFetchingNextPage={isFetchingNextPage}
+              fetchNextPage={getNextPage}
+            />
+          </TableContainer>
+        ) : (
+          <PipelineRunsEmptyState />
+        )}
+      </PageSection>
     </PageLayout>
   );
 };

--- a/src/components/ReleaseMonitor/ReleaseMonitorListView.tsx
+++ b/src/components/ReleaseMonitor/ReleaseMonitorListView.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Flex, FlexItem, Label, pluralize } from '@patternfly/react-core';
+import { Flex, FlexItem, Label, PageSection, pluralize } from '@patternfly/react-core';
 import { SortByDirection } from '@patternfly/react-table';
 import { FilterContext } from '~/components/Filter/generic/FilterContext';
 import { MENU_DIVIDER } from '~/components/Filter/generic/MultiSelect';
@@ -480,75 +480,77 @@ const ReleaseMonitorListView: React.FunctionComponent = () => {
       title="Release Monitor"
       description="The dashboard to monitor the releases you care about"
     >
-      {/* Fetch Releases and ReleasePlans from origin namespaces */}
-      {loaded &&
-        namespacesToFetch.map((nsName) => (
-          <React.Fragment key={`origin-${nsName}`}>
-            <ReleasesInNamespace
-              namespace={nsName}
-              onReleasesLoaded={handleReleasesLoaded}
-              onError={handleError}
-            />
-            <ReleasePlansInNamespace
-              namespace={nsName}
-              onReleasePlansLoaded={handleReleasePlansLoaded}
-              onError={handleError}
-            />
-          </React.Fragment>
-        ))}
-      {/* Fetch ReleasePlanAdmissions from target namespaces only */}
-      {targetNamespaces.map((targetNs) => (
-        <ReleasePlanAdmissionsInNamespace
-          key={`rpa-${targetNs}`}
-          namespace={targetNs}
-          onReleasePlanAdmissionsLoaded={handleReleasePlanAdmissionsLoaded}
-          onError={handleError}
-        />
-      ))}
-      {(isFiltered ||
-        releases.length > 0 ||
-        namespacesToFetch.length > 0 ||
-        (loaded && namespaces.length > NAMESPACE_THRESHOLD)) && (
-        <>
-          <MonitoredReleasesFilterToolbar
-            filters={filters}
-            setFilters={handleSetFilters}
-            onClearFilters={onClearFilters}
-            statusOptions={filterOptions.statusOptions}
-            applicationOptions={filterOptions.applicationOptions}
-            releasePlanOptions={filterOptions.releasePlanOptions}
-            namespaceOptions={filterOptions.namespaceOptions}
-            componentOptions={filterOptions.componentOptions}
-            productOptions={filterOptions.productOptions}
-            productVersionOptions={filterOptions.productVersionOptions}
+      <PageSection hasBodyWrapper={false} isFilled={false}>
+        {/* Fetch Releases and ReleasePlans from origin namespaces */}
+        {loaded &&
+          namespacesToFetch.map((nsName) => (
+            <React.Fragment key={`origin-${nsName}`}>
+              <ReleasesInNamespace
+                namespace={nsName}
+                onReleasesLoaded={handleReleasesLoaded}
+                onError={handleError}
+              />
+              <ReleasePlansInNamespace
+                namespace={nsName}
+                onReleasePlansLoaded={handleReleasePlansLoaded}
+                onError={handleError}
+              />
+            </React.Fragment>
+          ))}
+        {/* Fetch ReleasePlanAdmissions from target namespaces only */}
+        {targetNamespaces.map((targetNs) => (
+          <ReleasePlanAdmissionsInNamespace
+            key={`rpa-${targetNs}`}
+            namespace={targetNs}
+            onReleasePlanAdmissionsLoaded={handleReleasePlanAdmissionsLoaded}
+            onError={handleError}
           />
-          <Flex justifyContent={{ default: 'justifyContentFlexEnd' }} className="pf-v6-u-mr-xl">
-            <FlexItem>
-              <Label
-                color="blue"
-                className="pf-v6-u-font-weight-bold"
-                data-test="release-count-label"
-              >
-                {pluralize(displayData.length, 'release')}
-              </Label>
-            </FlexItem>
-          </Flex>
-        </>
-      )}
+        ))}
+        {(isFiltered ||
+          releases.length > 0 ||
+          namespacesToFetch.length > 0 ||
+          (loaded && namespaces.length > NAMESPACE_THRESHOLD)) && (
+          <>
+            <MonitoredReleasesFilterToolbar
+              filters={filters}
+              setFilters={handleSetFilters}
+              onClearFilters={onClearFilters}
+              statusOptions={filterOptions.statusOptions}
+              applicationOptions={filterOptions.applicationOptions}
+              releasePlanOptions={filterOptions.releasePlanOptions}
+              namespaceOptions={filterOptions.namespaceOptions}
+              componentOptions={filterOptions.componentOptions}
+              productOptions={filterOptions.productOptions}
+              productVersionOptions={filterOptions.productVersionOptions}
+            />
+            <Flex justifyContent={{ default: 'justifyContentFlexEnd' }} className="pf-v6-u-mr-xl">
+              <FlexItem>
+                <Label
+                  color="blue"
+                  className="pf-v6-u-font-weight-bold"
+                  data-test="release-count-label"
+                >
+                  {pluralize(displayData.length, 'release')}
+                </Label>
+              </FlexItem>
+            </Flex>
+          </>
+        )}
 
-      <Table
-        virtualize
-        data={displayData}
-        unfilteredData={unfilteredDisplayData}
-        EmptyMsg={EmptyMsg}
-        NoDataEmptyMsg={
-          shouldShowNamespaceSelector ? SelectNamespaceEmptyState : MonitoredReleaseEmptyState
-        }
-        aria-label="Release List"
-        Header={ReleasesListHeader}
-        Row={ReleaseListRow}
-        loaded={!loading || releases.length > 0}
-      />
+        <Table
+          virtualize
+          data={displayData}
+          unfilteredData={unfilteredDisplayData}
+          EmptyMsg={EmptyMsg}
+          NoDataEmptyMsg={
+            shouldShowNamespaceSelector ? SelectNamespaceEmptyState : MonitoredReleaseEmptyState
+          }
+          aria-label="Release List"
+          Header={ReleasesListHeader}
+          Row={ReleaseListRow}
+          loaded={!loading || releases.length > 0}
+        />
+      </PageSection>
     </PageLayout>
   );
 };

--- a/src/components/ReleaseMonitor/ReleaseMonitorListView.tsx
+++ b/src/components/ReleaseMonitor/ReleaseMonitorListView.tsx
@@ -480,7 +480,7 @@ const ReleaseMonitorListView: React.FunctionComponent = () => {
       title="Release Monitor"
       description="The dashboard to monitor the releases you care about"
     >
-      <PageSection hasBodyWrapper={false} isFilled={false}>
+      <PageSection isFilled={false}>
         {/* Fetch Releases and ReleasePlans from origin namespaces */}
         {loaded &&
           namespacesToFetch.map((nsName) => (


### PR DESCRIPTION
## Fixes
- https://issues.redhat.com/browse/KFLUXUI-1475
- https://issues.redhat.com/browse/KFLUXUI-1476

## Description
Wrap page content in PageSection to restore padding lost in PF v6 migration.

- **KFLUXUI-1475**: PipelineRuns page
- **KFLUXUI-1476**: Release Monitor page

## Type of change

- [x] Bugfix

## Screen shots / Gifs for design review

### KFLUXUI-1475 — PipelineRuns page
**Before:**
<img width="3020" height="1638" alt="pipeline-runs-page-missing-padding" src="https://github.com/user-attachments/assets/9fa14526-c963-46fb-ba6b-29cc657de465" />

**After:**
<img width="1920" height="1018" alt="pipeline-runs-page-missing-padding-FIX" src="https://github.com/user-attachments/assets/fdc70add-f54a-41ea-b74d-178d6dd8807c" />


### KFLUXUI-1476 — Release Monitor page
**Before:**
<img width="3022" height="1644" alt="release-monitor-page-missing-padding" src="https://github.com/user-attachments/assets/39491246-db2d-4ae6-9b48-50133e97af35" />

**After:**
<img width="1920" height="1005" alt="release-monitor-page-missing-padding-FIX" src="https://github.com/user-attachments/assets/4b9cb4ac-15b8-4a9c-9950-b53069267913" />


## How to test or reproduce?
- Navigate to the PipelineRuns page and verify content has proper padding
- Navigate to the Release Monitor page and verify content has proper padding

## Browser conformance:
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge