### PR TITLE
feat(KONFLUX-14794): show PipelineTask description for skipped tasks in PLR details

### DIFF
--- a/src/components/PipelineRun/PipelineRunDetailsView/sidepanels/TaskRunDetails.tsx
+++ b/src/components/PipelineRun/PipelineRunDetailsView/sidepanels/TaskRunDetails.tsx
@@ -17,9 +17,23 @@ import ScanDescriptionListGroup from '../tabs/ScanDescriptionListGroup';
 type Props = {
   taskRun?: TaskRunKind;
   status: runStatus;
+  description?: string;
 };
 
-const TaskRunDetails: React.FC<React.PropsWithChildren<Props>> = ({ taskRun, status }) => {
+const TaskDescriptionGroup: React.FC<{ content: string }> = ({ content }) => (
+  <DescriptionListGroup>
+    <DescriptionListTerm>Description</DescriptionListTerm>
+    <DescriptionListDescription>
+      <SyncMarkdownView content={content} inline />
+    </DescriptionListDescription>
+  </DescriptionListGroup>
+);
+
+const TaskRunDetails: React.FC<React.PropsWithChildren<Props>> = ({
+  taskRun,
+  status,
+  description,
+}) => {
   const results = isTaskV1Beta1(taskRun) ? taskRun?.status?.taskResults : taskRun?.status?.results;
   const specParams = taskRun?.spec?.params;
   return (
@@ -43,17 +57,19 @@ const TaskRunDetails: React.FC<React.PropsWithChildren<Props>> = ({ taskRun, sta
             </DescriptionListGroup>
           </DescriptionList>
           <DescriptionList className="pf-v5-u-mt-lg">
-            <DescriptionListGroup>
-              <DescriptionListTerm>Description</DescriptionListTerm>
-              <DescriptionListDescription>
-                <SyncMarkdownView content={taskRun?.status?.taskSpec?.description || '-'} inline />
-              </DescriptionListDescription>
-            </DescriptionListGroup>
+            <TaskDescriptionGroup content={taskRun?.status?.taskSpec?.description || '-'} />
             <ScanDescriptionListGroup taskRuns={[taskRun]} hideIfNotFound />
           </DescriptionList>
         </>
       ) : (
-        'This task was skipped.'
+        <>
+          <p>This task was skipped.</p>
+          {description?.trim() ? (
+            <DescriptionList className="pf-v5-u-mt-lg">
+              <TaskDescriptionGroup content={description} />
+            </DescriptionList>
+          ) : null}
+        </>
       )}
       {results?.length ? (
         <>

--- a/src/components/PipelineRun/PipelineRunDetailsView/sidepanels/TaskRunPanel.tsx
+++ b/src/components/PipelineRun/PipelineRunDetailsView/sidepanels/TaskRunPanel.tsx
@@ -61,7 +61,11 @@ const TaskRunPanel: React.FC<React.PropsWithChildren<Props>> = ({ taskNode, onCl
         <Tabs defaultActiveKey="details" unmountOnExit className="">
           <Tab title="Details" eventKey="details">
             <DrawerPanelBody>
-              <TaskRunDetails taskRun={taskRun} status={status} />
+              <TaskRunDetails
+                taskRun={taskRun}
+                status={status}
+                description={task?.description}
+              />
             </DrawerPanelBody>
           </Tab>
           <Tab title="Logs" eventKey="logs">

--- a/src/components/PipelineRun/PipelineRunDetailsView/sidepanels/__tests__/TaskRunDetails.spec.tsx
+++ b/src/components/PipelineRun/PipelineRunDetailsView/sidepanels/__tests__/TaskRunDetails.spec.tsx
@@ -16,6 +16,29 @@ describe('TaskRunDetails', () => {
   it('should handle skipped tasks', () => {
     const { container } = render(<TaskRunDetails status={runStatus.Skipped} />);
     expect(container).toHaveTextContent('This task was skipped.');
+    expect(container).not.toHaveTextContent('Description');
+  });
+
+  it('should not display description for whitespace-only skipped task descriptions', () => {
+    const { container } = render(
+      <TaskRunDetails status={runStatus.Skipped} description="   " />,
+    );
+    expect(container).toHaveTextContent('This task was skipped.');
+    expect(container).not.toHaveTextContent('Description');
+  });
+
+  it('should display pipeline task description for skipped tasks', () => {
+    const result = render(
+      <TaskRunDetails
+        status={runStatus.Skipped}
+        description="Reserve a Konflux EaaS namespace and kubeconfig secret."
+      />,
+    );
+    expect(result.getByText('This task was skipped.')).toBeInTheDocument();
+    expect(result.getByText('Description')).toBeInTheDocument();
+    expect(
+      result.getByText('Reserve a Konflux EaaS namespace and kubeconfig secret.'),
+    ).toBeInTheDocument();
   });
 
   it('should display task description', () => {

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -43,6 +43,7 @@ export type PipelineResult = {
 
 export type PipelineTask = {
   name: string;
+  description?: string;
   params?: PipelineTaskParam[];
   runAfter?: string[];
   taskRef?: PipelineTaskRef;


### PR DESCRIPTION
Render `PipelineTask.description` in the PLR Details side panel when a task is skipped by Tekton `when:` (no TaskRun).

- Keep "This task was skipped." and add a Description block when the pipeline spec defines one
- Pass `task.description` from `TaskRunPanel` into `TaskRunDetails`
- Add `description?: string` to `PipelineTask` in `src/types/pipeline.ts`
- Extract `TaskDescriptionGroup` for shared description markup on executed and skipped paths
- Unit tests in `TaskRunDetails.spec.tsx` (skipped with/without/whitespace-only description)

https://redhat.atlassian.net/browse/KONFLUX-14794

Verified on local cluster - see how skipped tasks have a description:

<img width="2203" height="491" alt="image" src="https://github.com/user-attachments/assets/301c3cdc-daf0-4ada-a5f1-c8fd7c6ff53b" />

<img width="2251" height="490" alt="image" src="https://github.com/user-attachments/assets/ebaa68d8-cd9e-4836-89cc-1d9527d89df1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task details now show task descriptions when available, including for skipped tasks.
  * Descriptions support formatted markdown content for better readability.
* **Bug Fixes**
  * Skipped tasks now avoid showing an empty description section when no meaningful description is provided.
  * Whitespace-only descriptions are treated as empty and hidden.
* **Tests**
  * Added coverage for skipped-task description display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->