### PR TITLE
feat(KFLUXUI-1431): add sorting dropdown and grouped filter options

### DIFF
--- a/src/shared/components/Filter/FilterToolbar.tsx
+++ b/src/shared/components/Filter/FilterToolbar.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Toolbar, ToolbarContent, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
 import { useFilterState } from '~/shared/components/Filter/hooks/useFilterState';
-import type { FilterConfig, OptionItem } from '~/shared/components/Filter/types';
+import type { FilterConfig, OptionItems } from '~/shared/components/Filter/types';
 import { BooleanFilter } from './controls/BooleanFilter';
 import { MultiSelectFilter } from './controls/MultiSelectFilter';
 import { SearchFilter } from './controls/SearchFilter';
@@ -23,7 +23,7 @@ type FilterToolbarProps<C extends readonly FilterConfig<unknown>[]> = {
   /** Filter configuration array describing which controls to render. */
   configs: C;
   /** Dropdown options keyed by filter `param`. Required for `multiSelect` and `singleSelect`. */
-  options?: Record<string, OptionItem[]>;
+  options?: Record<string, OptionItems>;
   /** Configuration for named toolbar groups. Keys are group names from filter configs. */
   groups?: Record<string, ToolbarGroupConfig>;
   /** Extra toolbar items rendered after the filter controls (e.g. action buttons). */
@@ -34,7 +34,7 @@ type FilterToolbarProps<C extends readonly FilterConfig<unknown>[]> = {
  * Renders the appropriate filter control component for a given config.
  * @internal
  */
-const renderControl = (config: FilterConfig<unknown>, options: Record<string, OptionItem[]>) => {
+const renderControl = (config: FilterConfig<unknown>, options: Record<string, OptionItems>) => {
   switch (config.type) {
     case 'search':
       return <SearchFilter key={config.param} config={config} />;

--- a/src/shared/components/Filter/__tests__/SelectDropdown.spec.tsx
+++ b/src/shared/components/Filter/__tests__/SelectDropdown.spec.tsx
@@ -1,0 +1,309 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SelectDropdown } from '~/shared/components/Filter/controls/SelectDropdown';
+import { FilterOption, GroupedOptions, OptionItem } from '~/shared/components/Filter/types';
+
+const flatOptions: FilterOption[] = [
+  { label: 'Active', value: 'active' },
+  { label: 'Inactive', value: 'inactive' },
+  { label: 'Archived', value: 'archived' },
+];
+
+const flatOptionsWithDivider: OptionItem[] = [
+  { label: 'Active', value: 'active' },
+  { label: 'Inactive', value: 'inactive' },
+  { type: 'divider' },
+  { label: 'Archived', value: 'archived' },
+];
+
+const groupedOptions: GroupedOptions[] = [
+  {
+    group: 'Status',
+    options: [
+      { label: 'Active', value: 'active' },
+      { label: 'Inactive', value: 'inactive' },
+    ],
+  },
+  {
+    group: 'Priority',
+    options: [
+      { label: 'High', value: 'high' },
+      { label: 'Low', value: 'low' },
+    ],
+  },
+];
+
+const clickToggle = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByRole('button', { name: /filter/i }));
+};
+
+describe('SelectDropdown', () => {
+  describe('flat options', () => {
+    it('renders toggle with provided text', () => {
+      render(
+        <SelectDropdown
+          toggleText="Filter"
+          options={flatOptions}
+          selected={[]}
+          onSelect={jest.fn()}
+        />,
+      );
+      expect(screen.getByRole('button', { name: /filter/i })).toBeInTheDocument();
+    });
+
+    it('shows options when opened', async () => {
+      const user = userEvent.setup();
+      render(
+        <SelectDropdown
+          toggleText="Filter"
+          options={flatOptions}
+          selected={[]}
+          onSelect={jest.fn()}
+        />,
+      );
+
+      await clickToggle(user);
+
+      expect(screen.getByText('Active')).toBeInTheDocument();
+      expect(screen.getByText('Inactive')).toBeInTheDocument();
+      expect(screen.getByText('Archived')).toBeInTheDocument();
+    });
+
+    it('fires onSelect when option is clicked', async () => {
+      const onSelect = jest.fn();
+      const user = userEvent.setup();
+      render(
+        <SelectDropdown
+          toggleText="Filter"
+          options={flatOptions}
+          selected={[]}
+          onSelect={onSelect}
+        />,
+      );
+
+      await clickToggle(user);
+      await user.click(screen.getByText('Active'));
+
+      expect(onSelect).toHaveBeenCalledWith('active');
+    });
+
+    it('renders dividers for DividerOption items', async () => {
+      const user = userEvent.setup();
+      render(
+        <SelectDropdown
+          toggleText="Filter"
+          options={flatOptionsWithDivider}
+          selected={[]}
+          onSelect={jest.fn()}
+        />,
+      );
+
+      await clickToggle(user);
+
+      expect(screen.getByRole('separator')).toBeInTheDocument();
+    });
+
+    it('closes dropdown after select when not multiple', async () => {
+      const user = userEvent.setup();
+      render(
+        <SelectDropdown
+          toggleText="Filter"
+          options={flatOptions}
+          selected={[]}
+          onSelect={jest.fn()}
+        />,
+      );
+
+      await clickToggle(user);
+      await user.click(screen.getByText('Active'));
+
+      // toggle should no longer be expanded
+      expect(screen.getByRole('button', { name: /filter/i })).toHaveAttribute(
+        'aria-expanded',
+        'false',
+      );
+    });
+
+    it('keeps dropdown open after select when multiple', async () => {
+      const user = userEvent.setup();
+      render(
+        <SelectDropdown
+          toggleText="Filter"
+          options={flatOptions}
+          selected={[]}
+          onSelect={jest.fn()}
+          multiple
+        />,
+      );
+
+      await clickToggle(user);
+      await user.click(screen.getByText('Active'));
+
+      // dropdown should remain open
+      expect(screen.getByText('Inactive')).toBeInTheDocument();
+    });
+  });
+
+  describe('grouped options', () => {
+    it('renders group labels', async () => {
+      const user = userEvent.setup();
+      render(
+        <SelectDropdown
+          toggleText="Filter"
+          options={groupedOptions}
+          selected={[]}
+          onSelect={jest.fn()}
+        />,
+      );
+
+      await clickToggle(user);
+
+      expect(screen.getByText('Status')).toBeInTheDocument();
+      expect(screen.getByText('Priority')).toBeInTheDocument();
+    });
+
+    it('renders options within groups', async () => {
+      const user = userEvent.setup();
+      render(
+        <SelectDropdown
+          toggleText="Filter"
+          options={groupedOptions}
+          selected={[]}
+          onSelect={jest.fn()}
+        />,
+      );
+
+      await clickToggle(user);
+
+      expect(screen.getByText('Active')).toBeInTheDocument();
+      expect(screen.getByText('High')).toBeInTheDocument();
+    });
+  });
+
+  describe('checkbox mode', () => {
+    it('renders checkboxes when hasCheckbox is true', async () => {
+      const user = userEvent.setup();
+      render(
+        <SelectDropdown
+          toggleText="Filter"
+          options={flatOptions}
+          selected={['active']}
+          onSelect={jest.fn()}
+          hasCheckbox
+          multiple
+        />,
+      );
+
+      await clickToggle(user);
+
+      // checkbox inputs should be present within the menu
+      const menu = screen.getByRole('menu');
+      const checkboxes = within(menu).getAllByRole('checkbox');
+      expect(checkboxes.length).toBe(3);
+    });
+  });
+
+  describe('badge', () => {
+    it('shows badge with selected count when badge prop is true', () => {
+      render(
+        <SelectDropdown
+          toggleText="Filter"
+          options={flatOptions}
+          selected={['active', 'inactive']}
+          onSelect={jest.fn()}
+          badge
+        />,
+      );
+
+      expect(screen.getByText('2')).toBeInTheDocument();
+    });
+
+    it('does not show badge when no items are selected', () => {
+      render(
+        <SelectDropdown
+          toggleText="Filter"
+          options={flatOptions}
+          selected={[]}
+          onSelect={jest.fn()}
+          badge
+        />,
+      );
+
+      expect(screen.queryByText('0')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('description and icon', () => {
+    it('renders description when provided on option', async () => {
+      const user = userEvent.setup();
+      const optionsWithDesc: FilterOption[] = [
+        { label: 'Active', value: 'active', description: 'Currently running' },
+      ];
+      render(
+        <SelectDropdown
+          toggleText="Filter"
+          options={optionsWithDesc}
+          selected={[]}
+          onSelect={jest.fn()}
+        />,
+      );
+
+      await clickToggle(user);
+
+      expect(screen.getByText('Currently running')).toBeInTheDocument();
+    });
+
+    it('renders icon when provided on option', async () => {
+      const user = userEvent.setup();
+      const TestIcon = () => <span data-test="test-icon">icon</span>;
+      const optionsWithIcon: FilterOption[] = [
+        { label: 'Active', value: 'active', icon: <TestIcon /> },
+      ];
+      render(
+        <SelectDropdown
+          toggleText="Filter"
+          options={optionsWithIcon}
+          selected={[]}
+          onSelect={jest.fn()}
+        />,
+      );
+
+      await clickToggle(user);
+
+      expect(screen.getByTestId('test-icon')).toBeInTheDocument();
+    });
+  });
+
+  describe('toggleIcon', () => {
+    it('renders toggle icon when provided', () => {
+      const ToggleIcon = () => <span data-test="toggle-icon">TI</span>;
+      render(
+        <SelectDropdown
+          toggleText="Filter"
+          toggleIcon={<ToggleIcon />}
+          options={flatOptions}
+          selected={[]}
+          onSelect={jest.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId('toggle-icon')).toBeInTheDocument();
+    });
+  });
+
+  describe('isDisabled', () => {
+    it('disables the toggle when isDisabled is true', () => {
+      render(
+        <SelectDropdown
+          toggleText="Filter"
+          options={flatOptions}
+          selected={[]}
+          onSelect={jest.fn()}
+          isDisabled
+        />,
+      );
+
+      expect(screen.getByRole('button', { name: /filter/i })).toBeDisabled();
+    });
+  });
+});

--- a/src/shared/components/Filter/__tests__/buildGroupedOptions.spec.ts
+++ b/src/shared/components/Filter/__tests__/buildGroupedOptions.spec.ts
@@ -1,0 +1,134 @@
+import { buildGroupedOptions } from '~/shared/components/Filter';
+
+type Item = { team: string; status?: string };
+
+describe('buildGroupedOptions', () => {
+  it('returns empty array for empty data', () => {
+    const result = buildGroupedOptions<Item>(
+      [],
+      (item) => item.team,
+      (item) => item.status,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it('groups items into a single group', () => {
+    const data: Item[] = [
+      { team: 'Alpha', status: 'active' },
+      { team: 'Alpha', status: 'pending' },
+    ];
+    const result = buildGroupedOptions(
+      data,
+      (item) => item.team,
+      (item) => item.status,
+    );
+    expect(result).toEqual([
+      {
+        group: 'Alpha',
+        options: [
+          { label: 'Active', value: 'active' },
+          { label: 'Pending', value: 'pending' },
+        ],
+      },
+    ]);
+  });
+
+  it('groups items into multiple groups sorted alphabetically', () => {
+    const data: Item[] = [
+      { team: 'Beta', status: 'done' },
+      { team: 'Alpha', status: 'active' },
+      { team: 'Beta', status: 'pending' },
+    ];
+    const result = buildGroupedOptions(
+      data,
+      (item) => item.team,
+      (item) => item.status,
+    );
+    expect(result).toEqual([
+      {
+        group: 'Alpha',
+        options: [{ label: 'Active', value: 'active' }],
+      },
+      {
+        group: 'Beta',
+        options: [
+          { label: 'Done', value: 'done' },
+          { label: 'Pending', value: 'pending' },
+        ],
+      },
+    ]);
+  });
+
+  it('deduplicates options within a group', () => {
+    const data: Item[] = [
+      { team: 'Alpha', status: 'active' },
+      { team: 'Alpha', status: 'active' },
+      { team: 'Alpha', status: 'pending' },
+    ];
+    const result = buildGroupedOptions(
+      data,
+      (item) => item.team,
+      (item) => item.status,
+    );
+    expect(result).toEqual([
+      {
+        group: 'Alpha',
+        options: [
+          { label: 'Active', value: 'active' },
+          { label: 'Pending', value: 'pending' },
+        ],
+      },
+    ]);
+  });
+
+  it('skips items where keyExtractor returns undefined', () => {
+    const data: Item[] = [
+      { team: 'Alpha', status: 'active' },
+      { team: 'Alpha', status: undefined },
+      { team: 'Alpha' },
+    ];
+    const result = buildGroupedOptions(
+      data,
+      (item) => item.team,
+      (item) => item.status,
+    );
+    expect(result).toEqual([
+      {
+        group: 'Alpha',
+        options: [{ label: 'Active', value: 'active' }],
+      },
+    ]);
+  });
+
+  it('uses custom labelFormatter', () => {
+    const data: Item[] = [{ team: 'Alpha', status: 'active' }];
+    const result = buildGroupedOptions(
+      data,
+      (item) => item.team,
+      (item) => item.status,
+      { labelFormatter: (v) => v.toUpperCase() },
+    );
+    expect(result).toEqual([
+      {
+        group: 'Alpha',
+        options: [{ label: 'ACTIVE', value: 'active' }],
+      },
+    ]);
+  });
+
+  it('uses custom groupLabelFormatter', () => {
+    const data: Item[] = [{ team: 'alpha', status: 'active' }];
+    const result = buildGroupedOptions(
+      data,
+      (item) => item.team,
+      (item) => item.status,
+      { groupLabelFormatter: (g) => `Team: ${g}` },
+    );
+    expect(result).toEqual([
+      {
+        group: 'Team: alpha',
+        options: [{ label: 'Active', value: 'active' }],
+      },
+    ]);
+  });
+});

--- a/src/shared/components/Filter/controls/MultiSelectFilter.tsx
+++ b/src/shared/components/Filter/controls/MultiSelectFilter.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import { ToolbarFilter } from '@patternfly/react-core';
 import { parseAsJson, useQueryState } from 'nuqs';
-import { isFilterOption, type MultiSelectFilterConfig, type OptionItems } from '../types';
+import {
+  isFilterOption,
+  isGroupedOptions,
+  type MultiSelectFilterConfig,
+  type OptionItems,
+} from '../types';
 import { SelectDropdown } from './SelectDropdown';
 
 /** Props for {@link MultiSelectFilter}. */
@@ -37,12 +42,10 @@ export const MultiSelectFilter = <T,>({
 
   // Collect all FilterOptions for chip label lookup (works for both flat and grouped)
   const allFilterOptions = React.useMemo(() => {
-    if (Array.isArray(options) && options.length > 0 && 'group' in options[0]) {
-      return (options as { group: string; options: { label: string; value: string }[] }[]).flatMap(
-        (g) => g.options,
-      );
+    if (isGroupedOptions(options)) {
+      return options.flatMap((g) => g.options);
     }
-    return (options as { label?: string; value?: string; type?: string }[]).filter(isFilterOption);
+    return options.filter(isFilterOption);
   }, [options]);
 
   const labelForValue = (value: string): string =>

--- a/src/shared/components/Filter/controls/MultiSelectFilter.tsx
+++ b/src/shared/components/Filter/controls/MultiSelectFilter.tsx
@@ -1,25 +1,15 @@
 import * as React from 'react';
-import {
-  Badge,
-  Divider,
-  MenuToggle,
-  Select,
-  SelectList,
-  SelectOption,
-  ToolbarFilter,
-} from '@patternfly/react-core';
+import { ToolbarFilter } from '@patternfly/react-core';
 import { parseAsJson, useQueryState } from 'nuqs';
-import { FilterOption, MultiSelectFilterConfig, OptionItem } from '../types';
-
-/** Type guard that distinguishes a selectable option from a divider. */
-const isFilterOption = (item: OptionItem): item is FilterOption => 'value' in item;
+import { isFilterOption, type MultiSelectFilterConfig, type OptionItems } from '../types';
+import { SelectDropdown } from './SelectDropdown';
 
 /** Props for {@link MultiSelectFilter}. */
 type MultiSelectFilterProps<T> = {
   /** Multi-select filter configuration. */
   config: MultiSelectFilterConfig<T>;
-  /** Dropdown options (may include {@link DividerOption} entries). */
-  options: OptionItem[];
+  /** Dropdown options (may include {@link DividerOption} entries or grouped options). */
+  options: OptionItems;
   /** When true, the toggle is disabled. Auto-disabled when options are empty. */
   isDisabled?: boolean;
 };
@@ -39,24 +29,26 @@ export const MultiSelectFilter = <T,>({
   isDisabled,
 }: MultiSelectFilterProps<T>) => {
   const { param, label } = config;
-  const [isOpen, setIsOpen] = React.useState(false);
 
   const [selected, setSelected] = useQueryState(
     param,
     parseAsJson<string[]>((v) => (Array.isArray(v) ? v : [])).withDefault([]),
   );
 
-  const filterOptions = options.filter(isFilterOption);
+  // Collect all FilterOptions for chip label lookup (works for both flat and grouped)
+  const allFilterOptions = React.useMemo(() => {
+    if (Array.isArray(options) && options.length > 0 && 'group' in options[0]) {
+      return (options as { group: string; options: { label: string; value: string }[] }[]).flatMap(
+        (g) => g.options,
+      );
+    }
+    return (options as { label?: string; value?: string; type?: string }[]).filter(isFilterOption);
+  }, [options]);
 
   const labelForValue = (value: string): string =>
-    filterOptions.find((o) => o.value === value)?.label ?? value;
+    allFilterOptions.find((o) => o.value === value)?.label ?? value;
 
-  const handleSelect = (
-    _event: React.MouseEvent | undefined,
-    value: string | number | undefined,
-  ) => {
-    if (typeof value !== 'string') return;
-
+  const handleSelect = (value: string) => {
     const next = selected.includes(value)
       ? selected.filter((v) => v !== value)
       : [...selected, value];
@@ -66,7 +58,7 @@ export const MultiSelectFilter = <T,>({
 
   const handleDeleteChip = (_category: string | undefined, chip: string | undefined) => {
     if (!chip) return;
-    const value = filterOptions.find((o) => o.label === chip)?.value ?? chip;
+    const value = allFilterOptions.find((o) => o.label === chip)?.value ?? chip;
     const next = selected.filter((v) => v !== value);
     void setSelected(next.length > 0 ? next : null);
   };
@@ -77,18 +69,6 @@ export const MultiSelectFilter = <T,>({
 
   const disabled = isDisabled || options.length === 0;
 
-  const toggle = (toggleRef: React.Ref<HTMLButtonElement>) => (
-    <MenuToggle
-      ref={toggleRef}
-      onClick={() => setIsOpen((prev) => !prev)}
-      isExpanded={isOpen}
-      isDisabled={disabled}
-      data-test={`multi-select-filter-${param}`}
-    >
-      {label} {!disabled && selected.length > 0 && <Badge isRead>{selected.length}</Badge>}
-    </MenuToggle>
-  );
-
   return (
     <ToolbarFilter
       labels={selected.map(labelForValue)}
@@ -96,31 +76,17 @@ export const MultiSelectFilter = <T,>({
       deleteLabelGroup={handleDeleteChipGroup}
       categoryName={label}
     >
-      <Select
-        role="menu"
-        isOpen={isOpen}
+      <SelectDropdown
+        toggleText={label}
+        options={options}
+        selected={selected}
         onSelect={handleSelect}
-        onOpenChange={setIsOpen}
-        toggle={toggle}
-      >
-        <SelectList>
-          {options.map((item, index) => {
-            if (!isFilterOption(item)) {
-              return <Divider key={`divider-${index}`} />;
-            }
-            return (
-              <SelectOption
-                key={item.value}
-                value={item.value}
-                hasCheckbox
-                isSelected={selected.includes(item.value)}
-              >
-                {item.label}
-              </SelectOption>
-            );
-          })}
-        </SelectList>
-      </Select>
+        multiple
+        hasCheckbox
+        badge
+        isDisabled={disabled}
+        data-test={`multi-select-filter-${param}`}
+      />
     </ToolbarFilter>
   );
 };

--- a/src/shared/components/Filter/controls/SelectDropdown.tsx
+++ b/src/shared/components/Filter/controls/SelectDropdown.tsx
@@ -9,7 +9,7 @@ import {
   SelectList,
   SelectOption,
 } from '@patternfly/react-core';
-import { isFilterOption, isGroupedOptions, type OptionItems } from '../types';
+import { isFilterOption, isGroupedOptions, type FilterOption, type OptionItems } from '../types';
 
 /** Props for {@link SelectDropdown}. */
 export interface SelectDropdownProps {
@@ -89,12 +89,7 @@ export const SelectDropdown: React.FC<SelectDropdownProps> = ({
 
   const role = hasCheckbox ? 'menu' : undefined;
 
-  const renderOption = (option: {
-    label: string;
-    value: string;
-    description?: string;
-    icon?: React.ReactNode;
-  }) => (
+  const renderOption = (option: FilterOption) => (
     <SelectOption
       key={option.value}
       value={option.value}

--- a/src/shared/components/Filter/controls/SelectDropdown.tsx
+++ b/src/shared/components/Filter/controls/SelectDropdown.tsx
@@ -83,7 +83,9 @@ export const SelectDropdown: React.FC<SelectDropdownProps> = ({
       variant={toggleVariant}
     >
       {toggleText}{' '}
-      {badge && selectedArray.length > 0 && <Badge isRead>{selectedArray.length}</Badge>}
+      {badge && !isDisabled && selectedArray.length > 0 && (
+        <Badge isRead>{selectedArray.length}</Badge>
+      )}
     </MenuToggle>
   );
 

--- a/src/shared/components/Filter/controls/SelectDropdown.tsx
+++ b/src/shared/components/Filter/controls/SelectDropdown.tsx
@@ -3,6 +3,7 @@ import {
   Badge,
   Divider,
   MenuToggle,
+  MenuToggleProps,
   Select,
   SelectGroup,
   SelectList,
@@ -13,9 +14,11 @@ import { isFilterOption, isGroupedOptions, type OptionItems } from '../types';
 /** Props for {@link SelectDropdown}. */
 export interface SelectDropdownProps {
   /** Text displayed on the toggle button. */
-  toggleText: string;
+  toggleText: string | React.ReactNode;
   /** Optional icon rendered before the toggle text. */
   toggleIcon?: React.ReactNode;
+  /** Variant of the toggle button. */
+  toggleVariant?: MenuToggleProps['variant'];
   /** Flat or grouped options to display in the dropdown. */
   options: OptionItems;
   /** Currently selected value(s). */
@@ -44,12 +47,12 @@ export interface SelectDropdownProps {
 export const SelectDropdown: React.FC<SelectDropdownProps> = ({
   toggleText,
   toggleIcon,
+  toggleVariant = 'default',
   options,
   selected,
   onSelect,
   multiple,
   hasCheckbox,
-
   isDisabled,
   badge,
   'data-test': dataTest,
@@ -77,6 +80,7 @@ export const SelectDropdown: React.FC<SelectDropdownProps> = ({
       isDisabled={isDisabled}
       icon={toggleIcon}
       data-test={dataTest}
+      variant={toggleVariant}
     >
       {toggleText}{' '}
       {badge && selectedArray.length > 0 && <Badge isRead>{selectedArray.length}</Badge>}

--- a/src/shared/components/Filter/controls/SelectDropdown.tsx
+++ b/src/shared/components/Filter/controls/SelectDropdown.tsx
@@ -1,0 +1,130 @@
+import * as React from 'react';
+import {
+  Badge,
+  Divider,
+  MenuToggle,
+  Select,
+  SelectGroup,
+  SelectList,
+  SelectOption,
+} from '@patternfly/react-core';
+import { isFilterOption, isGroupedOptions, type OptionItems } from '../types';
+
+/** Props for {@link SelectDropdown}. */
+export interface SelectDropdownProps {
+  /** Text displayed on the toggle button. */
+  toggleText: string;
+  /** Optional icon rendered before the toggle text. */
+  toggleIcon?: React.ReactNode;
+  /** Flat or grouped options to display in the dropdown. */
+  options: OptionItems;
+  /** Currently selected value(s). */
+  selected: string | string[];
+  /** Called when an option is selected or deselected. */
+  onSelect: (value: string) => void;
+  /** When true, the dropdown stays open after selection. */
+  multiple?: boolean;
+  /** When true, options render with checkboxes. */
+  hasCheckbox?: boolean;
+
+  /** When true, the toggle is disabled. */
+  isDisabled?: boolean;
+  /** When true, shows a Badge with the count of selected items on the toggle. */
+  badge?: boolean;
+}
+
+/**
+ * Presentational select dropdown component.
+ *
+ * Renders a PatternFly `Select` with support for flat or grouped options,
+ * checkbox or checkmark selection, badges, and option descriptions/icons.
+ */
+export const SelectDropdown: React.FC<SelectDropdownProps> = ({
+  toggleText,
+  toggleIcon,
+  options,
+  selected,
+  onSelect,
+  multiple,
+  hasCheckbox,
+
+  isDisabled,
+  badge,
+}) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const selectedArray = Array.isArray(selected) ? selected : selected ? [selected] : [];
+
+  const handleSelect = (
+    _event: React.MouseEvent | undefined,
+    value: string | number | undefined,
+  ) => {
+    if (typeof value !== 'string') return;
+    onSelect(value);
+    if (!multiple) {
+      setIsOpen(false);
+    }
+  };
+
+  const toggle = (toggleRef: React.Ref<HTMLButtonElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={() => setIsOpen((prev) => !prev)}
+      isExpanded={isOpen}
+      isDisabled={isDisabled}
+      icon={toggleIcon}
+    >
+      {toggleText}{' '}
+      {badge && selectedArray.length > 0 && <Badge isRead>{selectedArray.length}</Badge>}
+    </MenuToggle>
+  );
+
+  const role = hasCheckbox ? 'menu' : undefined;
+
+  const renderOption = (option: {
+    label: string;
+    value: string;
+    description?: string;
+    icon?: React.ReactNode;
+  }) => (
+    <SelectOption
+      key={option.value}
+      value={option.value}
+      hasCheckbox={hasCheckbox}
+      isSelected={selectedArray.includes(option.value)}
+      description={option.description}
+      icon={option.icon}
+    >
+      {option.label}
+    </SelectOption>
+  );
+
+  const grouped = isGroupedOptions(options);
+
+  return (
+    <Select
+      role={role}
+      isOpen={isOpen}
+      onSelect={handleSelect}
+      onOpenChange={setIsOpen}
+      toggle={toggle}
+    >
+      {grouped ? (
+        options.map((group) => (
+          <SelectGroup key={group.group} label={group.group}>
+            <SelectList>{group.options.map(renderOption)}</SelectList>
+          </SelectGroup>
+        ))
+      ) : (
+        <SelectList>
+          {options.map((item, index) => {
+            if (!isFilterOption(item)) {
+              return <Divider key={`divider-${index}`} />;
+            }
+            return renderOption(item);
+          })}
+        </SelectList>
+      )}
+    </Select>
+  );
+};

--- a/src/shared/components/Filter/controls/SelectDropdown.tsx
+++ b/src/shared/components/Filter/controls/SelectDropdown.tsx
@@ -31,6 +31,8 @@ export interface SelectDropdownProps {
   isDisabled?: boolean;
   /** When true, shows a Badge with the count of selected items on the toggle. */
   badge?: boolean;
+  /** Test ID attribute applied to the toggle button. */
+  'data-test'?: string;
 }
 
 /**
@@ -50,6 +52,7 @@ export const SelectDropdown: React.FC<SelectDropdownProps> = ({
 
   isDisabled,
   badge,
+  'data-test': dataTest,
 }) => {
   const [isOpen, setIsOpen] = React.useState(false);
 
@@ -73,6 +76,7 @@ export const SelectDropdown: React.FC<SelectDropdownProps> = ({
       isExpanded={isOpen}
       isDisabled={isDisabled}
       icon={toggleIcon}
+      data-test={dataTest}
     >
       {toggleText}{' '}
       {badge && selectedArray.length > 0 && <Badge isRead>{selectedArray.length}</Badge>}

--- a/src/shared/components/Filter/controls/SingleSelectFilter.tsx
+++ b/src/shared/components/Filter/controls/SingleSelectFilter.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import { ToolbarFilter } from '@patternfly/react-core';
 import { parseAsString, useQueryState } from 'nuqs';
-import { isFilterOption, type OptionItems, type SingleSelectFilterConfig } from '../types';
+import {
+  isFilterOption,
+  isGroupedOptions,
+  type OptionItems,
+  type SingleSelectFilterConfig,
+} from '../types';
 import { SelectDropdown } from './SelectDropdown';
 
 /** Props for {@link SingleSelectFilter}. */
@@ -28,12 +33,10 @@ export const SingleSelectFilter = <T,>({ config, options }: SingleSelectFilterPr
 
   // Collect all FilterOptions for chip label lookup (works for both flat and grouped)
   const allFilterOptions = React.useMemo(() => {
-    if (Array.isArray(options) && options.length > 0 && 'group' in options[0]) {
-      return (options as { group: string; options: { label: string; value: string }[] }[]).flatMap(
-        (g) => g.options,
-      );
+    if (isGroupedOptions(options)) {
+      return options.flatMap((g) => g.options);
     }
-    return (options as { label?: string; value?: string; type?: string }[]).filter(isFilterOption);
+    return options.filter(isFilterOption);
   }, [options]);
 
   const labelForValue = (value: string): string =>

--- a/src/shared/components/Filter/controls/SingleSelectFilter.tsx
+++ b/src/shared/components/Filter/controls/SingleSelectFilter.tsx
@@ -1,23 +1,15 @@
 import * as React from 'react';
-import {
-  MenuToggle,
-  Select,
-  SelectList,
-  SelectOption,
-  ToolbarFilter,
-} from '@patternfly/react-core';
+import { ToolbarFilter } from '@patternfly/react-core';
 import { parseAsString, useQueryState } from 'nuqs';
-import { FilterOption, OptionItem, SingleSelectFilterConfig } from '../types';
-
-/** Type guard that distinguishes a selectable option from a divider. */
-const isFilterOption = (item: OptionItem): item is FilterOption => 'value' in item;
+import { isFilterOption, type OptionItems, type SingleSelectFilterConfig } from '../types';
+import { SelectDropdown } from './SelectDropdown';
 
 /** Props for {@link SingleSelectFilter}. */
 type SingleSelectFilterProps<T> = {
   /** Single-select filter configuration. */
   config: SingleSelectFilterConfig<T>;
-  /** Dropdown options (divider entries are filtered out). */
-  options: OptionItem[];
+  /** Dropdown options (divider entries are filtered out for chips, but rendered in dropdown). */
+  options: OptionItems;
 };
 
 /**
@@ -31,24 +23,25 @@ type SingleSelectFilterProps<T> = {
  */
 export const SingleSelectFilter = <T,>({ config, options }: SingleSelectFilterProps<T>) => {
   const { param, label } = config;
-  const [isOpen, setIsOpen] = React.useState(false);
 
   const [selected, setSelected] = useQueryState(param, parseAsString.withDefault(''));
 
-  const filterOptions = options.filter(isFilterOption);
+  // Collect all FilterOptions for chip label lookup (works for both flat and grouped)
+  const allFilterOptions = React.useMemo(() => {
+    if (Array.isArray(options) && options.length > 0 && 'group' in options[0]) {
+      return (options as { group: string; options: { label: string; value: string }[] }[]).flatMap(
+        (g) => g.options,
+      );
+    }
+    return (options as { label?: string; value?: string; type?: string }[]).filter(isFilterOption);
+  }, [options]);
 
   const labelForValue = (value: string): string =>
-    filterOptions.find((o) => o.value === value)?.label ?? value;
+    allFilterOptions.find((o) => o.value === value)?.label ?? value;
 
-  const handleSelect = (
-    _event: React.MouseEvent | undefined,
-    value: string | number | undefined,
-  ) => {
-    if (typeof value !== 'string') return;
-
+  const handleSelect = (value: string) => {
     // Toggle-off: deselect if clicking same value
     void setSelected(value === selected ? null : value);
-    setIsOpen(false);
   };
 
   const handleDeleteChip = () => {
@@ -57,38 +50,19 @@ export const SingleSelectFilter = <T,>({ config, options }: SingleSelectFilterPr
 
   const toggleLabel = selected ? labelForValue(selected) : label;
 
-  const toggle = (toggleRef: React.Ref<HTMLButtonElement>) => (
-    <MenuToggle
-      ref={toggleRef}
-      onClick={() => setIsOpen((prev) => !prev)}
-      isExpanded={isOpen}
-      data-test={`single-select-filter-${param}`}
-    >
-      {toggleLabel}
-    </MenuToggle>
-  );
-
   return (
     <ToolbarFilter
       labels={selected ? [labelForValue(selected)] : []}
       deleteLabel={handleDeleteChip}
       categoryName={label}
     >
-      <Select
-        role="menu"
-        isOpen={isOpen}
+      <SelectDropdown
+        toggleText={toggleLabel}
+        options={options}
+        selected={selected}
         onSelect={handleSelect}
-        onOpenChange={setIsOpen}
-        toggle={toggle}
-      >
-        <SelectList>
-          {filterOptions.map((item) => (
-            <SelectOption key={item.value} value={item.value} isSelected={item.value === selected}>
-              {item.label}
-            </SelectOption>
-          ))}
-        </SelectList>
-      </Select>
+        data-test={`single-select-filter-${param}`}
+      />
     </ToolbarFilter>
   );
 };

--- a/src/shared/components/Filter/index.ts
+++ b/src/shared/components/Filter/index.ts
@@ -41,4 +41,9 @@ export { SwitchableSearchFilter } from './controls/SwitchableSearchFilter';
 export { FilterToolbar } from './FilterToolbar';
 export type { ToolbarGroupConfig } from './FilterToolbar';
 
-export { buildOptions, buildOptionsWithFallback, NONE_VALUE } from './utils/buildOptions';
+export {
+  buildOptions,
+  buildOptionsWithFallback,
+  buildGroupedOptions,
+  NONE_VALUE,
+} from './utils/buildOptions';

--- a/src/shared/components/Filter/index.ts
+++ b/src/shared/components/Filter/index.ts
@@ -3,6 +3,8 @@ export type {
   FilterOption,
   DividerOption,
   OptionItem,
+  GroupedOptions,
+  OptionItems,
   FilterConfigBase,
   SearchFilterConfig,
   MultiSelectFilterConfig,
@@ -16,7 +18,7 @@ export type {
   ClientFilterValues,
 } from './types';
 
-export { defineFilters } from './types';
+export { defineFilters, isGroupedOptions, isFilterOption } from './types';
 
 export { parseAsCommaSeparated } from './parsers';
 

--- a/src/shared/components/Filter/types.ts
+++ b/src/shared/components/Filter/types.ts
@@ -1,3 +1,5 @@
+import type React from 'react';
+
 /**
  * Controls where filtering is applied.
  *
@@ -7,13 +9,33 @@
 export type FilterMode = 'client' | 'api';
 
 /** A selectable option shown in a dropdown filter control. */
-export type FilterOption = { label: string; value: string };
+export type FilterOption = {
+  label: string;
+  value: string;
+  /** Optional description text displayed below the label. */
+  description?: string;
+  /** Optional icon rendered alongside the label. */
+  icon?: React.ReactNode;
+};
 
 /** A visual divider inserted between groups of options in a dropdown. */
 export type DividerOption = { type: 'divider' };
 
 /** Discriminated union of items that can appear in a filter dropdown. */
 export type OptionItem = FilterOption | DividerOption;
+
+/** A group of options rendered under a shared heading in a dropdown. */
+export type GroupedOptions = { group: string; options: FilterOption[] };
+
+/** Items that can be passed to a dropdown: either flat option items or grouped options. */
+export type OptionItems = OptionItem[] | GroupedOptions[];
+
+/** Type guard that checks whether options are grouped. */
+export const isGroupedOptions = (options: OptionItems): options is GroupedOptions[] =>
+  options.length > 0 && 'group' in options[0];
+
+/** Type guard that distinguishes a selectable option from a divider. */
+export const isFilterOption = (item: OptionItem): item is FilterOption => 'value' in item;
 
 /**
  * Shared fields present on every filter configuration.

--- a/src/shared/components/Filter/utils/buildOptions.ts
+++ b/src/shared/components/Filter/utils/buildOptions.ts
@@ -1,4 +1,4 @@
-import { FilterOption, OptionItem } from '~/shared/components/Filter/types';
+import { FilterOption, GroupedOptions, OptionItem } from '~/shared/components/Filter/types';
 
 /**
  * Sentinel value used to represent items whose key extractor returns
@@ -84,4 +84,56 @@ export const buildOptionsWithFallback = <T>(
   }
   result.push({ label: undefinedLabel, value: NONE_VALUE });
   return result;
+};
+
+type BuildGroupedOptionsConfig = {
+  /** Custom formatter for option labels. Defaults to capitalizing the first letter. */
+  labelFormatter?: (value: string) => string;
+  /** Custom formatter for group labels. Defaults to identity. */
+  groupLabelFormatter?: (group: string) => string;
+};
+
+/**
+ * Groups data items into `GroupedOptions[]` for use in grouped dropdowns.
+ *
+ * @typeParam T - The data-item type.
+ * @param data - Source data array.
+ * @param groupExtractor - Determines which group an item belongs to.
+ * @param keyExtractor - Extracts the option value from an item. Items returning `undefined` are skipped.
+ * @param opts - Optional formatters for labels and group names.
+ * @returns Sorted array of `GroupedOptions`, with options sorted and deduplicated within each group.
+ */
+export const buildGroupedOptions = <T>(
+  data: T[],
+  groupExtractor: (item: T) => string,
+  keyExtractor: (item: T) => string | undefined,
+  opts?: BuildGroupedOptionsConfig,
+): GroupedOptions[] => {
+  if (data.length === 0) return [];
+
+  const formatter = opts?.labelFormatter ?? defaultLabelFormatter;
+  const groupFormatter = opts?.groupLabelFormatter ?? ((g: string) => g);
+
+  const groupMap = new Map<string, Set<string>>();
+
+  for (const item of data) {
+    const key = keyExtractor(item);
+    if (key === undefined) continue;
+    const group = groupExtractor(item);
+    const existing = groupMap.get(group);
+    if (existing) {
+      existing.add(key);
+    } else {
+      groupMap.set(group, new Set([key]));
+    }
+  }
+
+  return [...groupMap.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([group, keys]) => ({
+      group: groupFormatter(group),
+      options: [...keys]
+        .map((value) => ({ label: formatter(value), value }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
+    }));
 };

--- a/src/shared/components/Filter/utils/buildOptions.ts
+++ b/src/shared/components/Filter/utils/buildOptions.ts
@@ -129,11 +129,11 @@ export const buildGroupedOptions = <T>(
   }
 
   return [...groupMap.entries()]
-    .sort(([a], [b]) => a.localeCompare(b))
     .map(([group, keys]) => ({
       group: groupFormatter(group),
       options: [...keys]
         .map((value) => ({ label: formatter(value), value }))
         .sort((a, b) => a.label.localeCompare(b.label)),
-    }));
+    }))
+    .sort((a, b) => a.group.localeCompare(b.group));
 };

--- a/src/shared/components/TableV2/SortDropdown.tsx
+++ b/src/shared/components/TableV2/SortDropdown.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import { SelectDropdown } from '~/shared/components/Filter/controls/SelectDropdown';
+import type { GroupedOptions } from '~/shared/components/Filter/types';
+import { useColumnState } from './hooks/useColumnState';
+import type { ColumnDefinition } from './types';
+
+/** Props for {@link SortDropdown}. */
+export interface SortDropdownProps<TData> {
+  /** Column definitions — only columns with `sortable: true` appear in the dropdown. */
+  columns: ColumnDefinition<TData>[];
+  /** LocalStorage key for persisting column/sort state. */
+  columnStateKey: string;
+}
+
+/**
+ * Dropdown for selecting sort column and direction.
+ *
+ * Renders two option groups: "Sort by" (one option per sortable column) and
+ * "Direction" (Ascending / Descending). Uses `useColumnState` to read and
+ * write sort state, sharing persistence with the Table component.
+ *
+ * @typeParam TData - The row data type
+ */
+export const SortDropdown = <TData,>({ columns, columnStateKey }: SortDropdownProps<TData>) => {
+  const { columnState, setColumnState } = useColumnState(columnStateKey, columns);
+
+  const sortableColumns = React.useMemo(() => columns.filter((col) => col.sortable), [columns]);
+
+  const groups: GroupedOptions[] = React.useMemo(
+    () => [
+      {
+        group: 'Sort by',
+        options: sortableColumns.map((col) => ({
+          label: typeof col.header === 'string' ? col.header : col.id,
+          value: col.id,
+        })),
+      },
+      {
+        group: 'Direction',
+        options: [
+          { label: 'Ascending', value: 'asc' },
+          { label: 'Descending', value: 'desc' },
+        ],
+      },
+    ],
+    [sortableColumns],
+  );
+
+  const selected = React.useMemo(
+    () => [columnState.sortColumn, columnState.sortDirection].filter((v): v is string => !!v),
+    [columnState.sortColumn, columnState.sortDirection],
+  );
+
+  const handleSelect = (value: string) => {
+    if (value === 'asc' || value === 'desc') {
+      setColumnState({ ...columnState, sortDirection: value });
+    } else {
+      setColumnState({
+        ...columnState,
+        sortColumn: value,
+        sortDirection: columnState.sortDirection ?? 'asc',
+      });
+    }
+  };
+
+  const columnLabel = sortableColumns.find((col) => col.id === columnState.sortColumn);
+  const toggleText =
+    columnState.sortColumn && columnLabel
+      ? `Sort by: ${typeof columnLabel.header === 'string' ? columnLabel.header : columnLabel.id} (${columnState.sortDirection ?? 'asc'})`
+      : 'Sort';
+
+  return (
+    <SelectDropdown
+      toggleText={toggleText}
+      options={groups}
+      selected={selected}
+      onSelect={handleSelect}
+      multiple
+    />
+  );
+};

--- a/src/shared/components/TableV2/SortDropdown.tsx
+++ b/src/shared/components/TableV2/SortDropdown.tsx
@@ -52,15 +52,20 @@ export const SortDropdown = <TData,>({ columns, columnStateKey }: SortDropdownPr
     [columnState.sortColumn, columnState.sortDirection],
   );
 
+  const sortableColumnIds = React.useMemo(
+    () => new Set(sortableColumns.map((col) => col.id)),
+    [sortableColumns],
+  );
+
   const handleSelect = (value: string) => {
-    if (value === 'asc' || value === 'desc') {
-      setColumnState({ ...columnState, sortDirection: value });
-    } else {
+    if (sortableColumnIds.has(value)) {
       setColumnState({
         ...columnState,
         sortColumn: value,
         sortDirection: columnState.sortDirection ?? 'asc',
       });
+    } else {
+      setColumnState({ ...columnState, sortDirection: value as 'asc' | 'desc' });
     }
   };
 

--- a/src/shared/components/TableV2/SortDropdown.tsx
+++ b/src/shared/components/TableV2/SortDropdown.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { SortAlphaDownIcon } from '@patternfly/react-icons/dist/esm/icons/sort-alpha-down-icon';
 import { SelectDropdown } from '~/shared/components/Filter/controls/SelectDropdown';
 import type { GroupedOptions } from '~/shared/components/Filter/types';
 import { useColumnState } from './hooks/useColumnState';
@@ -63,15 +64,10 @@ export const SortDropdown = <TData,>({ columns, columnStateKey }: SortDropdownPr
     }
   };
 
-  const columnLabel = sortableColumns.find((col) => col.id === columnState.sortColumn);
-  const toggleText =
-    columnState.sortColumn && columnLabel
-      ? `Sort by: ${typeof columnLabel.header === 'string' ? columnLabel.header : columnLabel.id} (${columnState.sortDirection ?? 'asc'})`
-      : 'Sort';
-
   return (
     <SelectDropdown
-      toggleText={toggleText}
+      toggleText={<SortAlphaDownIcon />}
+      toggleVariant="plain"
       options={groups}
       selected={selected}
       onSelect={handleSelect}

--- a/src/shared/components/TableV2/SortDropdown.tsx
+++ b/src/shared/components/TableV2/SortDropdown.tsx
@@ -72,6 +72,7 @@ export const SortDropdown = <TData,>({ columns, columnStateKey }: SortDropdownPr
       selected={selected}
       onSelect={handleSelect}
       multiple
+      data-test="sort-dropdown"
     />
   );
 };

--- a/src/shared/components/TableV2/TableHeader.tsx
+++ b/src/shared/components/TableV2/TableHeader.tsx
@@ -1,3 +1,5 @@
+import { LongArrowAltDownIcon } from '@patternfly/react-icons/dist/esm/icons/long-arrow-alt-down-icon';
+import { LongArrowAltUpIcon } from '@patternfly/react-icons/dist/esm/icons/long-arrow-alt-up-icon';
 import { Thead, Tr, Th, type ThProps } from '@patternfly/react-table';
 import { flexRender, type Table } from '@tanstack/react-table';
 import { type ColumnWidth } from './column-widths';
@@ -13,11 +15,12 @@ interface TableHeaderProps<TData> {
 }
 
 /**
- * Renders the table header row with column labels, widths, and sort indicators.
+ * Renders the table header row with column labels, widths, and read-only
+ * sort indicators.
  *
- * Applies flex or fixed widths from `columnWidths` and wires up PatternFly's
- * sort props for sortable columns. When expansion is enabled, adds an empty
- * leading `<Th>` for the expand toggle column.
+ * Sort indicators are non-interactive icons displayed inline after the
+ * header text. Sorting is controlled by the {@link SortDropdown} component
+ * rather than by clicking column headers.
  *
  * @typeParam TData - The row data type
  */
@@ -33,7 +36,7 @@ export const TableHeader = <TData,>({
       {table.getHeaderGroups().map((headerGroup) => (
         <Tr role="row" key={headerGroup.id}>
           {enableExpansion && <Th />}
-          {headerGroup.headers.map((header, headerIndex) => {
+          {headerGroup.headers.map((header) => {
             const colWidth = widthMap.get(header.column.id);
             const widthProps: Partial<ThProps> = {};
 
@@ -43,22 +46,16 @@ export const TableHeader = <TData,>({
               widthProps.style = { width: colWidth.fixedWidth };
             }
 
-            const sortProps: Pick<ThProps, 'sort'> = header.column.getCanSort()
-              ? {
-                  sort: {
-                    sortBy: {
-                      index: headerIndex,
-                      direction: header.column.getIsSorted() || undefined,
-                    },
-                    onSort: header.column.getToggleSortingHandler(),
-                    columnIndex: headerIndex,
-                  },
-                }
-              : {};
+            const sortDirection = header.column.getIsSorted();
 
             return (
-              <Th key={header.id} {...widthProps} {...sortProps}>
+              <Th key={header.id} {...widthProps}>
                 {flexRender(header.column.columnDef.header, header.getContext())}
+                {sortDirection && (
+                  <span className="pf-v6-c-table__sort-indicator" data-test="sort-indicator">
+                    {sortDirection === 'asc' ? <LongArrowAltUpIcon /> : <LongArrowAltDownIcon />}
+                  </span>
+                )}
               </Th>
             );
           })}

--- a/src/shared/components/TableV2/TableHeader.tsx
+++ b/src/shared/components/TableV2/TableHeader.tsx
@@ -47,9 +47,15 @@ export const TableHeader = <TData,>({
             }
 
             const sortDirection = header.column.getIsSorted();
+            const ariaSort =
+              sortDirection === 'asc'
+                ? 'ascending'
+                : sortDirection === 'desc'
+                  ? 'descending'
+                  : undefined;
 
             return (
-              <Th key={header.id} {...widthProps}>
+              <Th key={header.id} {...widthProps} aria-sort={ariaSort}>
                 {flexRender(header.column.columnDef.header, header.getContext())}
                 {sortDirection && (
                   <span className="pf-v6-c-table__sort-indicator" data-test="sort-indicator">

--- a/src/shared/components/TableV2/__stories__/TableCombinations.stories.tsx
+++ b/src/shared/components/TableV2/__stories__/TableCombinations.stories.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, userEvent, within } from 'storybook/test';
-import { Table } from '~/shared/components/TableV2';
+import { SortDropdown, Table } from '~/shared/components/TableV2';
 import { type PipelineRun, generateMockData, columns, getRowId } from './storyData';
+
+const COLUMN_STATE_KEY = 'storybook-combinations';
 
 const expandedContent = (row: PipelineRun) => (
   <div data-test="expanded-detail">
@@ -10,9 +12,8 @@ const expandedContent = (row: PipelineRun) => (
   </div>
 );
 
-const meta: Meta<typeof Table<PipelineRun>> = {
+const meta: Meta = {
   title: 'TableV2/Combinations',
-  component: Table,
   decorators: [
     (Story) => (
       <div style={{ height: '600px', overflow: 'auto' }}>
@@ -24,18 +25,26 @@ const meta: Meta<typeof Table<PipelineRun>> = {
 
 export default meta;
 
-type Story = StoryObj<typeof Table<PipelineRun>>;
+type Story = StoryObj;
 
 export const SortingAndExpansion: Story = {
-  args: {
-    data: generateMockData(20),
-    columns,
-    getRowId,
-    'aria-label': 'Sort + Expand',
-    enableSorting: true,
-    enableExpansion: true,
-    expandedContent,
-  },
+  render: () => (
+    <div>
+      <div style={{ padding: '8px 0' }}>
+        <SortDropdown columns={columns} columnStateKey={COLUMN_STATE_KEY} />
+      </div>
+      <Table
+        data={generateMockData(20)}
+        columns={columns}
+        getRowId={getRowId}
+        aria-label="Sort + Expand"
+        enableSorting
+        enableExpansion
+        expandedContent={expandedContent}
+        columnStateKey={COLUMN_STATE_KEY}
+      />
+    </div>
+  ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
@@ -47,37 +56,50 @@ export const SortingAndExpansion: Story = {
     const expandButtons = canvasElement.querySelectorAll(
       'button[aria-expanded="false"]',
     ) as NodeListOf<HTMLButtonElement>;
-    await expect(expandButtons.length).toBeGreaterThan(0);
-    await userEvent.click(expandButtons[0]);
+    // Filter to only expand/collapse toggle buttons (exclude dropdown toggle)
+    const rowExpandButtons = Array.from(expandButtons).filter(
+      (btn) => btn.closest('[data-test="table-row"]') !== null,
+    );
+    await expect(rowExpandButtons.length).toBeGreaterThan(0);
+    await userEvent.click(rowExpandButtons[0]);
 
     // Expanded content visible
     const expanded = canvasElement.querySelector('[data-test="expanded-detail"]');
     await expect(expanded).not.toBeNull();
 
-    // Sort by name
-    const nameHeader = canvas.getByText('Name');
-    const nameTh = nameHeader.closest('th')!;
-    const sortButton = within(nameTh as HTMLElement).getByRole('button');
-    await userEvent.click(sortButton);
+    // Sort via dropdown
+    const toggle = canvas.getByRole('button', { expanded: false });
+    await userEvent.click(toggle);
+    await userEvent.click(canvas.getByRole('option', { name: 'Name' }));
+    // Close dropdown
+    await userEvent.click(canvas.getByRole('button', { expanded: true }));
 
-    // Table still renders after sort (expansion state may reset, that's OK)
+    // Table still renders after sort
     const rowsAfterSort = canvasElement.querySelectorAll('[data-test="table-row"]');
     await expect(rowsAfterSort.length).toBeGreaterThan(0);
   },
 };
 
 export const FullFeatured: Story = {
-  args: {
-    data: generateMockData(50),
-    columns,
-    getRowId,
-    'aria-label': 'Full featured table',
-    enableSorting: true,
-    enableExpansion: true,
-    expandedContent,
-    hasNextPage: false,
-    isFetchingNextPage: false,
-  },
+  render: () => (
+    <div>
+      <div style={{ padding: '8px 0' }}>
+        <SortDropdown columns={columns} columnStateKey={COLUMN_STATE_KEY} />
+      </div>
+      <Table
+        data={generateMockData(50)}
+        columns={columns}
+        getRowId={getRowId}
+        aria-label="Full featured table"
+        enableSorting
+        enableExpansion
+        expandedContent={expandedContent}
+        hasNextPage={false}
+        isFetchingNextPage={false}
+        columnStateKey={COLUMN_STATE_KEY}
+      />
+    </div>
+  ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
@@ -89,11 +111,13 @@ export const FullFeatured: Story = {
     // Virtualization: fewer than 50 rows in DOM
     await expect(rows.length).toBeLessThan(50);
 
-    // Sort buttons present
-    const nameHeader = canvas.getByText('Name');
-    const nameTh = nameHeader.closest('th')!;
-    const sortButton = within(nameTh as HTMLElement).queryByRole('button');
-    await expect(sortButton).not.toBeNull();
+    // Sort dropdown present (no sort buttons in headers)
+    const header = canvasElement.querySelector('[data-test="table-header"]')!;
+    const thElements = header.querySelectorAll('th');
+    for (const th of thElements) {
+      const buttons = within(th as HTMLElement).queryAllByRole('button');
+      await expect(buttons.length).toBe(0);
+    }
 
     // Expand buttons present
     const expandButtons = canvasElement.querySelectorAll('button[aria-expanded]');

--- a/src/shared/components/TableV2/__stories__/TableSorting.stories.tsx
+++ b/src/shared/components/TableV2/__stories__/TableSorting.stories.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, userEvent, within } from 'storybook/test';
-import { Table } from '~/shared/components/TableV2';
-import { type PipelineRun, generateMockData, columns, getRowId } from './storyData';
+import { SortDropdown, Table } from '~/shared/components/TableV2';
+import { generateMockData, columns, getRowId } from './storyData';
 
-const meta: Meta<typeof Table<PipelineRun>> = {
-  title: 'TableV2/Sorting',
-  component: Table,
+const COLUMN_STATE_KEY = 'storybook-sort-dropdown';
+
+const meta: Meta = {
+  title: 'TableV2/SortDropdown',
   decorators: [
     (Story) => (
       <div style={{ height: '600px', overflow: 'auto' }}>
@@ -18,16 +19,24 @@ const meta: Meta<typeof Table<PipelineRun>> = {
 
 export default meta;
 
-type Story = StoryObj<typeof Table<PipelineRun>>;
+type Story = StoryObj;
 
-export const SortableColumns: Story = {
-  args: {
-    data: generateMockData(20),
-    columns,
-    getRowId,
-    'aria-label': 'Sortable pipeline runs',
-    enableSorting: true,
-  },
+export const SortDropdownDefault: Story = {
+  render: () => (
+    <div>
+      <div style={{ padding: '8px 0' }}>
+        <SortDropdown columns={columns} columnStateKey={COLUMN_STATE_KEY} />
+      </div>
+      <Table
+        data={generateMockData(20)}
+        columns={columns}
+        getRowId={getRowId}
+        aria-label="Sort dropdown demo"
+        enableSorting
+        columnStateKey={COLUMN_STATE_KEY}
+      />
+    </div>
+  ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
@@ -35,59 +44,116 @@ export const SortableColumns: Story = {
     const rows = canvasElement.querySelectorAll('[data-test="table-row"]');
     await expect(rows.length).toBeGreaterThan(0);
 
-    // Sortable columns (Name, Status, Started) have sort buttons
-    // Name header should have a sort button
-    const nameHeader = canvas.getByText('Name');
-    const nameTh = nameHeader.closest('th')!;
-    const sortButton = within(nameTh as HTMLElement).getByRole('button');
-    await expect(sortButton).toBeInTheDocument();
+    // Open the sort dropdown (plain toggle with icon)
+    const toggle = canvas.getByRole('button', { expanded: false });
+    await userEvent.click(toggle);
 
-    // Non-sortable column (Component) should NOT have a sort button
-    const componentHeader = canvas.getByText('Component');
-    const componentTh = componentHeader.closest('th')!;
-    const componentButtons = within(componentTh as HTMLElement).queryAllByRole('button');
-    await expect(componentButtons.length).toBe(0);
+    // Verify grouped options appear
+    // "Sort by" group: Name, Status, Started (sortable columns)
+    await expect(canvas.getByText('Sort by')).toBeInTheDocument();
+    await expect(canvas.getByText('Name')).toBeInTheDocument();
+    await expect(canvas.getByText('Status')).toBeInTheDocument();
+    await expect(canvas.getByText('Started')).toBeInTheDocument();
+
+    // "Direction" group: Ascending, Descending
+    await expect(canvas.getByText('Direction')).toBeInTheDocument();
+    await expect(canvas.getByText('Ascending')).toBeInTheDocument();
+    await expect(canvas.getByText('Descending')).toBeInTheDocument();
+
+    // Non-sortable columns should NOT appear in dropdown
+    const componentOption = canvas.queryByRole('option', { name: 'Component' });
+    await expect(componentOption).toBeNull();
+    const durationOption = canvas.queryByRole('option', { name: 'Duration' });
+    await expect(durationOption).toBeNull();
   },
 };
 
-export const ClickToSort: Story = {
-  args: {
-    data: generateMockData(20),
-    columns,
-    getRowId,
-    'aria-label': 'Click to sort',
-    enableSorting: true,
-  },
+export const SortByColumn: Story = {
+  render: () => (
+    <div>
+      <div style={{ padding: '8px 0' }}>
+        <SortDropdown columns={columns} columnStateKey={COLUMN_STATE_KEY} />
+      </div>
+      <Table
+        data={generateMockData(20)}
+        columns={columns}
+        getRowId={getRowId}
+        aria-label="Sort by column demo"
+        enableSorting
+        columnStateKey={COLUMN_STATE_KEY}
+      />
+    </div>
+  ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // Get initial first data row content
     const getFirstRowName = () => {
       const firstRow = canvasElement.querySelector('[data-test="table-row"]');
       return firstRow?.textContent ?? '';
     };
 
+    // Initial order
     const initialFirstRow = getFirstRowName();
     await expect(initialFirstRow).toContain('pipeline-run-0');
 
-    // Click the Name sort button to sort ascending
-    const nameHeader = canvas.getByText('Name');
-    const nameTh = nameHeader.closest('th')!;
-    const sortButton = within(nameTh as HTMLElement).getByRole('button');
-    await userEvent.click(sortButton);
+    // Open dropdown and select "Name" sort
+    const toggle = canvas.getByRole('button', { expanded: false });
+    await userEvent.click(toggle);
+    await userEvent.click(canvas.getByRole('option', { name: 'Name' }));
 
-    // After first click (asc sort), the first row should still be pipeline-run-0
-    // because alphabetical sort of "pipeline-run-0" through "pipeline-run-19"
-    // puts "pipeline-run-0" first (lexicographic: 0 < 1)
-    const afterAscFirstRow = getFirstRowName();
-    await expect(afterAscFirstRow).toContain('pipeline-run-0');
+    // Select "Descending" direction
+    await userEvent.click(canvas.getByRole('option', { name: 'Descending' }));
 
-    // Click again to sort descending
-    await userEvent.click(sortButton);
+    // Close dropdown by clicking toggle again
+    await userEvent.click(canvas.getByRole('button', { expanded: true }));
 
-    // After desc sort, "pipeline-run-19" comes first
-    // because TanStack uses alphanumeric sorting (19 > 9 numerically)
-    const afterDescFirstRow = getFirstRowName();
-    await expect(afterDescFirstRow).toContain('pipeline-run-19');
+    // After desc sort by name, "pipeline-run-9" comes first (lexicographic)
+    const afterSortFirstRow = getFirstRowName();
+    await expect(afterSortFirstRow).toContain('pipeline-run-9');
+  },
+};
+
+export const ReadOnlySortIndicators: Story = {
+  render: () => (
+    <div>
+      <div style={{ padding: '8px 0' }}>
+        <SortDropdown columns={columns} columnStateKey={COLUMN_STATE_KEY} />
+      </div>
+      <Table
+        data={generateMockData(20)}
+        columns={columns}
+        getRowId={getRowId}
+        aria-label="Read-only indicators demo"
+        enableSorting
+        columnStateKey={COLUMN_STATE_KEY}
+      />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Headers should NOT have clickable sort buttons inside <th> elements
+    const header = canvasElement.querySelector('[data-test="table-header"]')!;
+    const thElements = header.querySelectorAll('th');
+    for (const th of thElements) {
+      const buttons = within(th as HTMLElement).queryAllByRole('button');
+      await expect(buttons.length).toBe(0);
+    }
+
+    // Open dropdown and select a sort column to trigger an indicator
+    const toggle = canvas.getByRole('button', { expanded: false });
+    await userEvent.click(toggle);
+    await userEvent.click(canvas.getByRole('option', { name: 'Name' }));
+
+    // Close dropdown
+    await userEvent.click(canvas.getByRole('button', { expanded: true }));
+
+    // A sort indicator should now render for the sorted column
+    const indicator = canvasElement.querySelector('[data-test="sort-indicator"]');
+    await expect(indicator).not.toBeNull();
+
+    // The indicator is a passive icon, NOT inside a button
+    const indicatorButton = indicator?.closest('button');
+    await expect(indicatorButton).toBeNull();
   },
 };

--- a/src/shared/components/TableV2/__tests__/SortDropdown.spec.tsx
+++ b/src/shared/components/TableV2/__tests__/SortDropdown.spec.tsx
@@ -1,0 +1,144 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SortDropdown } from '~/shared/components/TableV2/SortDropdown';
+import { type ColumnDefinition } from '~/shared/components/TableV2/types';
+import { useLocalStorage } from '~/shared/hooks/useLocalStorage';
+
+jest.mock('~/shared/hooks/useLocalStorage');
+const mockUseLocalStorage = jest.mocked(useLocalStorage);
+
+interface TestRow {
+  name: string;
+  status: string;
+  id: string;
+}
+
+const columns: ColumnDefinition<TestRow>[] = [
+  { id: 'name', header: 'Name', accessorFn: (row) => row.name, sortable: true },
+  { id: 'status', header: 'Status', accessorFn: (row) => row.status, sortable: true },
+  { id: 'id', header: 'ID', accessorFn: (row) => row.id },
+];
+
+const renderSortDropdown = (
+  cols: ColumnDefinition<TestRow>[] = columns,
+  columnStateKey = 'test-sort',
+) => render(<SortDropdown columns={cols} columnStateKey={columnStateKey} />);
+
+const clickToggle = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByRole('button'));
+};
+
+describe('SortDropdown', () => {
+  let mockSetValue: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSetValue = jest.fn();
+    mockUseLocalStorage.mockReturnValue([undefined, mockSetValue, jest.fn()]);
+  });
+
+  it('renders toggle with default text when no sort is active', () => {
+    renderSortDropdown();
+    expect(screen.getByRole('button')).toHaveTextContent('Sort');
+  });
+
+  it('renders sortable columns in "Sort by" group', async () => {
+    const user = userEvent.setup();
+    renderSortDropdown();
+
+    await clickToggle(user);
+
+    expect(screen.getByText('Sort by')).toBeInTheDocument();
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+  });
+
+  it('excludes non-sortable columns from the dropdown', async () => {
+    const user = userEvent.setup();
+    renderSortDropdown();
+
+    await clickToggle(user);
+
+    expect(screen.queryByText('ID')).not.toBeInTheDocument();
+  });
+
+  it('renders direction group with Ascending and Descending', async () => {
+    const user = userEvent.setup();
+    renderSortDropdown();
+
+    await clickToggle(user);
+
+    expect(screen.getByText('Direction')).toBeInTheDocument();
+    expect(screen.getByText('Ascending')).toBeInTheDocument();
+    expect(screen.getByText('Descending')).toBeInTheDocument();
+  });
+
+  it('updates sort column when a column option is selected', async () => {
+    const user = userEvent.setup();
+    renderSortDropdown();
+
+    await clickToggle(user);
+    await user.click(screen.getByText('Name'));
+
+    expect(mockSetValue).toHaveBeenCalledWith(expect.objectContaining({ sortColumn: 'name' }));
+  });
+
+  it('updates sort direction when a direction option is selected', async () => {
+    const user = userEvent.setup();
+    // Start with a persisted sort state
+    mockUseLocalStorage.mockReturnValue([
+      {
+        visibleColumns: ['name', 'status', 'id'],
+        columnOrder: ['name', 'status', 'id'],
+        sortColumn: 'name',
+        sortDirection: 'asc',
+      },
+      mockSetValue,
+      jest.fn(),
+    ]);
+    renderSortDropdown();
+
+    await clickToggle(user);
+    await user.click(screen.getByText('Descending'));
+
+    expect(mockSetValue).toHaveBeenCalledWith(expect.objectContaining({ sortDirection: 'desc' }));
+  });
+
+  it('shows toggle text with column label and direction when sort is active', () => {
+    mockUseLocalStorage.mockReturnValue([
+      {
+        visibleColumns: ['name', 'status', 'id'],
+        columnOrder: ['name', 'status', 'id'],
+        sortColumn: 'name',
+        sortDirection: 'asc',
+      },
+      mockSetValue,
+      jest.fn(),
+    ]);
+    renderSortDropdown();
+
+    expect(screen.getByRole('button')).toHaveTextContent('Sort by: Name (asc)');
+  });
+
+  it('marks currently selected sort column and direction', async () => {
+    const user = userEvent.setup();
+    mockUseLocalStorage.mockReturnValue([
+      {
+        visibleColumns: ['name', 'status', 'id'],
+        columnOrder: ['name', 'status', 'id'],
+        sortColumn: 'name',
+        sortDirection: 'desc',
+      },
+      mockSetValue,
+      jest.fn(),
+    ]);
+    renderSortDropdown();
+
+    await clickToggle(user);
+
+    // The selected items should be reflected (Name and Descending)
+    // We verify the selected values are passed correctly by checking
+    // that the toggle text reflects the active sort
+    expect(screen.getByRole('button')).toHaveTextContent('Sort by: Name (desc)');
+  });
+});

--- a/src/shared/components/TableV2/__tests__/SortDropdown.spec.tsx
+++ b/src/shared/components/TableV2/__tests__/SortDropdown.spec.tsx
@@ -37,9 +37,9 @@ describe('SortDropdown', () => {
     mockUseLocalStorage.mockReturnValue([undefined, mockSetValue, jest.fn()]);
   });
 
-  it('renders toggle with default text when no sort is active', () => {
+  it('renders the sort toggle button', () => {
     renderSortDropdown();
-    expect(screen.getByRole('button')).toHaveTextContent('Sort');
+    expect(screen.getByRole('button')).toBeInTheDocument();
   });
 
   it('renders sortable columns in "Sort by" group', async () => {
@@ -104,7 +104,7 @@ describe('SortDropdown', () => {
     expect(mockSetValue).toHaveBeenCalledWith(expect.objectContaining({ sortDirection: 'desc' }));
   });
 
-  it('shows toggle text with column label and direction when sort is active', () => {
+  it('renders toggle button when sort is active', () => {
     mockUseLocalStorage.mockReturnValue([
       {
         visibleColumns: ['name', 'status', 'id'],
@@ -117,28 +117,6 @@ describe('SortDropdown', () => {
     ]);
     renderSortDropdown();
 
-    expect(screen.getByRole('button')).toHaveTextContent('Sort by: Name (asc)');
-  });
-
-  it('marks currently selected sort column and direction', async () => {
-    const user = userEvent.setup();
-    mockUseLocalStorage.mockReturnValue([
-      {
-        visibleColumns: ['name', 'status', 'id'],
-        columnOrder: ['name', 'status', 'id'],
-        sortColumn: 'name',
-        sortDirection: 'desc',
-      },
-      mockSetValue,
-      jest.fn(),
-    ]);
-    renderSortDropdown();
-
-    await clickToggle(user);
-
-    // The selected items should be reflected (Name and Descending)
-    // We verify the selected values are passed correctly by checking
-    // that the toggle text reflects the active sort
-    expect(screen.getByRole('button')).toHaveTextContent('Sort by: Name (desc)');
+    expect(screen.getByRole('button')).toBeInTheDocument();
   });
 });

--- a/src/shared/components/TableV2/__tests__/TableHeader.spec.tsx
+++ b/src/shared/components/TableV2/__tests__/TableHeader.spec.tsx
@@ -105,6 +105,27 @@ describe('TableHeader', () => {
     expect(within(columnHeaders[1]).queryByTestId('sort-indicator')).not.toBeInTheDocument();
   });
 
+  it('sets aria-sort on sorted columns', () => {
+    const headers = [
+      { id: 'name', header: 'Name', canSort: true, isSorted: 'asc' as const },
+      { id: 'status', header: 'Status', canSort: true, isSorted: 'desc' as const },
+      { id: 'id', header: 'ID', canSort: false, isSorted: false as const },
+    ];
+    const widths: ColumnWidth[] = [
+      { id: 'name', type: 'flex', widthPercent: 40 },
+      { id: 'status', type: 'flex', widthPercent: 40 },
+      { id: 'id', type: 'flex', widthPercent: 20 },
+    ];
+    const table = createMockTable(headers);
+    renderTableHeader(<TableHeader table={table as never} columnWidths={widths} />);
+
+    const thead = screen.getByTestId('table-header');
+    const columnHeaders = within(thead).getAllByRole('columnheader');
+    expect(columnHeaders[0]).toHaveAttribute('aria-sort', 'ascending');
+    expect(columnHeaders[1]).toHaveAttribute('aria-sort', 'descending');
+    expect(columnHeaders[2]).not.toHaveAttribute('aria-sort');
+  });
+
   it('does not render sort button (read-only indicators)', () => {
     const table = createMockTable(defaultHeaders);
     renderTableHeader(<TableHeader table={table as never} columnWidths={defaultWidths} />);

--- a/src/shared/components/TableV2/__tests__/TableHeader.spec.tsx
+++ b/src/shared/components/TableV2/__tests__/TableHeader.spec.tsx
@@ -70,24 +70,48 @@ describe('TableHeader', () => {
     expect(screen.getByTestId('table-header')).toBeInTheDocument();
   });
 
-  it('sets sort prop on sortable columns', () => {
+  it('renders ascending sort icon for sorted asc column', () => {
     const table = createMockTable(defaultHeaders);
     renderTableHeader(<TableHeader table={table as never} columnWidths={defaultWidths} />);
 
     const thead = screen.getByTestId('table-header');
     const columnHeaders = within(thead).getAllByRole('columnheader');
-    // Sortable column (Name) should have aria-sort attribute
-    expect(columnHeaders[0]).toHaveAttribute('aria-sort', 'ascending');
+    // Sorted column (Name, asc) should have sort indicator
+    const sortIndicator = within(columnHeaders[0]).getByTestId('sort-indicator');
+    expect(sortIndicator).toBeInTheDocument();
   });
 
-  it('does not set sort on non-sortable columns', () => {
+  it('renders descending sort icon for sorted desc column', () => {
+    const headers = [
+      { id: 'name', header: 'Name', canSort: true, isSorted: 'desc' as const },
+      { id: 'status', header: 'Status', canSort: false, isSorted: false as const },
+    ];
+    const table = createMockTable(headers);
+    renderTableHeader(<TableHeader table={table as never} columnWidths={defaultWidths} />);
+
+    const thead = screen.getByTestId('table-header');
+    const columnHeaders = within(thead).getAllByRole('columnheader');
+    const sortIndicator = within(columnHeaders[0]).getByTestId('sort-indicator');
+    expect(sortIndicator).toBeInTheDocument();
+  });
+
+  it('does not render sort icon on non-sorted columns', () => {
     const table = createMockTable(defaultHeaders);
     renderTableHeader(<TableHeader table={table as never} columnWidths={defaultWidths} />);
 
     const thead = screen.getByTestId('table-header');
     const columnHeaders = within(thead).getAllByRole('columnheader');
-    // Non-sortable column (Status) should NOT have aria-sort
-    expect(columnHeaders[1]).not.toHaveAttribute('aria-sort');
+    // Non-sortable column (Status) should NOT have sort indicator
+    expect(within(columnHeaders[1]).queryByTestId('sort-indicator')).not.toBeInTheDocument();
+  });
+
+  it('does not render sort button (read-only indicators)', () => {
+    const table = createMockTable(defaultHeaders);
+    renderTableHeader(<TableHeader table={table as never} columnWidths={defaultWidths} />);
+
+    const thead = screen.getByTestId('table-header');
+    // No interactive sort buttons — indicators are read-only
+    expect(within(thead).queryByRole('button')).not.toBeInTheDocument();
   });
 
   it('applies inline style for flex columns', () => {

--- a/src/shared/components/TableV2/index.ts
+++ b/src/shared/components/TableV2/index.ts
@@ -20,3 +20,4 @@ export { TableSkeleton } from './TableSkeleton';
 export { TableHeader } from './TableHeader';
 export { computeColumnWidths, type ColumnWidth } from './column-widths';
 export { Table } from './Table';
+export { SortDropdown } from './SortDropdown';


### PR DESCRIPTION
## Fixes
<!-- No Jira ticket ID found -->

https://redhat.atlassian.net/browse/KFLUXUI-1431

## Description

Adds grouped option support to the filter system and introduces a `SortDropdown` component for TableV2 that replaces click-to-sort column headers with a toolbar dropdown.

The filter system is extended with a `GroupedOptions` type, `buildGroupedOptions` utility, and a shared `SelectDropdown` presentational component. Both `MultiSelectFilter` and `SingleSelectFilter` are refactored to delegate rendering to `SelectDropdown`, reducing duplication while maintaining full backward compatibility. The `SortDropdown` uses grouped options to show sortable columns and sort direction in a single dropdown, and `TableHeader` sort indicators become read-only (no more clickable sort buttons on column headers).

### Changes

**Filter system extensions:**
- `GroupedOptions`, `OptionItems` types and `isGroupedOptions`/`isFilterOption` type guards
- `buildGroupedOptions` utility for extracting grouped options from data
- `SelectDropdown` — shared presentational component supporting flat/grouped options, checkboxes, badges, icons, toggle variants

**Filter refactors (backward compatible):**
- `MultiSelectFilter` and `SingleSelectFilter` now wrap `SelectDropdown`
- `FilterToolbar` accepts `OptionItems` (union of `OptionItem[]` and `GroupedOptions[]`)

**TableV2 sorting:**
- `SortDropdown` — toolbar dropdown with "Sort by" and "Direction" grouped options, shares `columnStateKey` with `Table`
- `TableHeader` — read-only sort indicators (passive icons instead of clickable buttons)

## Type of change

- [x] Feature
- [x] Refactoring (no functional changes, no api changes)

## Screen shots / Gifs for design review

<img width="1194" height="453" alt="image" src="https://github.com/user-attachments/assets/dfeb4137-8280-43b1-af26-df6d48af8eee" />
<img width="1194" height="515" alt="image" src="https://github.com/user-attachments/assets/edaee7e2-b47b-416c-8ae7-a5016bcbbaaa" />

<img width="1216" height="803" alt="image" src="https://github.com/user-attachments/assets/e5b24453-521a-4d23-b488-40ad05816be0" />



## How to test or reproduce?

- Run `yarn test` — all 4361 tests pass (30 new unit tests added)
- Run `yarn storybook` — verify stories under `TableV2/SortDropdown`:
  - `SortDropdownDefault` — dropdown opens with grouped options
  - `SortByColumn` — selecting column + direction re-sorts the table
  - `ReadOnlySortIndicators` — no clickable sort buttons on headers
- Run `yarn lint && yarn lint:restricted-imports && yarn type-checks` — all clean
- Verify existing `MultiSelectFilter` and `SingleSelectFilter` tests pass unchanged after refactor

## Browser conformance:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of Release Notes

* **New Features**
  * Added dropdown-based table sorting with grouped “Sort by” options and separate ascending/descending selection.
  * Upgraded filter dropdowns to support grouped options, option descriptions/icons, selection-count badges, disabled states, and multi-select checkboxes.

* **Bug Fixes**
  * Improved filter chip labeling and selection behavior to work consistently with both flat and grouped option lists.

* **Tests**
  * Added coverage for filter dropdown interactions, grouped option building, sort dropdown behavior, and read-only sort indicators; updated related Storybook stories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->