### PR TITLE
refactor(KFLUXUI-1464): replace DragDrop API with @patternfly/react-drag-drop

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@patternfly/react-charts": "7.4.5",
     "@patternfly/react-code-editor": "^6.5.1",
     "@patternfly/react-core": "6.5.1",
+    "@patternfly/react-drag-drop": "^6.5.1",
     "@patternfly/react-icons": "6.5.1",
     "@patternfly/react-log-viewer": "6.4.0",
     "@patternfly/react-styles": "6.5.1",

--- a/src/components/ColumnManagement/ColumnManagementModal.tsx
+++ b/src/components/ColumnManagement/ColumnManagementModal.tsx
@@ -5,19 +5,13 @@ import {
   Checkbox,
   DataList,
   DataListCell,
-  DataListControl,
-  DataListDragButton,
   DataListItem,
   DataListItemCells,
   DataListItemRow,
+  ModalBody,
   ModalVariant,
 } from '@patternfly/react-core';
-import {
-  DragDrop,
-  Draggable,
-  Droppable,
-  type DraggableItemPosition,
-} from '@patternfly/react-core/deprecated';
+import { DragDropSort, type DraggableObject } from '@patternfly/react-drag-drop';
 import { type ColumnState } from '~/shared/components/TableV2';
 import { type ComponentProps, createModalLauncher } from '../modal/createModalLauncher';
 
@@ -66,19 +60,13 @@ export const ColumnManagementModal: React.FC<ColumnManagementModalProps> = ({
   }, []);
 
   const handleDrop = useCallback(
-    (source: DraggableItemPosition, dest?: DraggableItemPosition): boolean => {
-      if (!dest) return false;
+    (_event: unknown, items: DraggableObject[]) => {
       setAllColumnsOrder((prev) => {
         const pinnedStartIds = prev.filter((id) => columnsById.get(id)?.pinned === 'start');
-        const unpinnedIds = prev.filter((id) => !columnsById.get(id)?.pinned);
         const pinnedEndIds = prev.filter((id) => columnsById.get(id)?.pinned === 'end');
-
-        const [moved] = unpinnedIds.splice(source.index, 1);
-        unpinnedIds.splice(dest.index, 0, moved);
-
-        return [...pinnedStartIds, ...unpinnedIds, ...pinnedEndIds];
+        const reorderedUnpinned = items.map((item) => String(item.id));
+        return [...pinnedStartIds, ...reorderedUnpinned, ...pinnedEndIds];
       });
-      return true;
     },
     [columnsById],
   );
@@ -107,7 +95,7 @@ export const ColumnManagementModal: React.FC<ColumnManagementModalProps> = ({
   const unpinned = allColumnsOrder.filter((id) => !columnsById.get(id)?.pinned);
   const pinnedEnd = allColumnsOrder.filter((id) => columnsById.get(id)?.pinned === 'end');
 
-  const renderColumnRow = (id: string, options: { isDraggable: boolean }) => {
+  const renderColumnRowContent = (id: string) => {
     const col = columnsById.get(id);
     if (!col) return null;
 
@@ -117,46 +105,45 @@ export const ColumnManagementModal: React.FC<ColumnManagementModalProps> = ({
     const isCheckboxDisabled = isNonHidable || isPinned;
 
     return (
-      <DataListItem key={id} data-test={`column-row-${id}`}>
-        <DataListItemRow>
-          <DataListControl>
-            <DataListDragButton
-              aria-label={`Reorder ${col.header}`}
-              isDisabled={!options.isDraggable}
-            />
-          </DataListControl>
-          <DataListItemCells
-            dataListCells={[
-              <DataListCell key="checkbox">
-                <Checkbox
-                  id={`col-checkbox-${id}`}
-                  label={col.header}
-                  isChecked={isChecked}
-                  isDisabled={isCheckboxDisabled}
-                  onChange={() => handleToggle(id)}
-                />
-              </DataListCell>,
-            ]}
-          />
-        </DataListItemRow>
-      </DataListItem>
+      <DataListItemRow>
+        <DataListItemCells
+          dataListCells={[
+            <DataListCell key="checkbox">
+              <Checkbox
+                id={`col-checkbox-${id}`}
+                label={col.header}
+                isChecked={isChecked}
+                isDisabled={isCheckboxDisabled}
+                onChange={() => handleToggle(id)}
+              />
+            </DataListCell>,
+          ]}
+        />
+      </DataListItemRow>
     );
   };
 
+  const pinnedRow = (id: string) => (
+    <DataListItem key={id} data-test={`column-row-${id}`}>
+      {renderColumnRowContent(id)}
+    </DataListItem>
+  );
+
+  const draggableItems: DraggableObject[] = unpinned.map((id) => ({
+    id,
+    content: renderColumnRowContent(id),
+  }));
+
   return (
-    <>
+    <ModalBody>
       <DataList aria-label="Column management" isCompact>
-        {pinnedStart.map((id) => renderColumnRow(id, { isDraggable: false }))}
-        <DragDrop onDrop={handleDrop}>
-          <Droppable>
-            {unpinned.map((id) => (
-              <Draggable key={id} hasNoWrapper>
-                {renderColumnRow(id, { isDraggable: true })}
-              </Draggable>
-            ))}
-          </Droppable>
-        </DragDrop>
-        {pinnedEnd.map((id) => renderColumnRow(id, { isDraggable: false }))}
+        {pinnedStart.map(pinnedRow)}
+      </DataList>
+      <DragDropSort items={draggableItems} onDrop={handleDrop} variant="DataList">
+        <DataList aria-label="Reorderable columns" isCompact />
+      </DragDropSort>
+      <DataList aria-label="Pinned end columns" isCompact>
+        {pinnedEnd.map(pinnedRow)}
       </DataList>
       <ActionGroup>
         <Button variant="link" onClick={handleReset}>
@@ -171,7 +158,7 @@ export const ColumnManagementModal: React.FC<ColumnManagementModalProps> = ({
           Cancel
         </Button>
       </ActionGroup>
-    </>
+    </ModalBody>
   );
 };
 

--- a/src/components/ColumnManagement/__tests__/ColumnManagementModal.spec.tsx
+++ b/src/components/ColumnManagement/__tests__/ColumnManagementModal.spec.tsx
@@ -87,16 +87,16 @@ describe('ColumnManagementModal', () => {
     expect(actionsCheckbox).toBeDisabled();
   });
 
-  it('should render drag buttons for each column', () => {
+  it('should render drag buttons for unpinned columns', () => {
     renderModal();
-    expect(screen.getAllByRole('button', { name: /reorder/i })).toHaveLength(columns.length);
+    const unpinnedCount = columns.filter((c) => !c.pinned).length;
+    expect(screen.getAllByRole('button', { name: /drag button/i })).toHaveLength(unpinnedCount);
   });
 
-  it('should disable drag button for pinned columns', () => {
+  it('should not render drag button for pinned columns', () => {
     renderModal();
     const actionsRow = screen.getByTestId('column-row-actions');
-    const dragButton = within(actionsRow).getByRole('button', { name: /reorder/i });
-    expect(dragButton).toBeDisabled();
+    expect(within(actionsRow).queryByRole('button', { name: /drag button/i })).toBeNull();
   });
 
   it('should reset to default column state when reset is clicked', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1867,6 +1867,68 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@dnd-kit/accessibility@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@dnd-kit/accessibility@npm:3.1.1"
+  dependencies:
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 10/961000456a36700a9cd13be51147a818bc100f7dfabb332b80438d02e06f3b556aa0ff46ddf13bdff3b70bc8f9b63dd5a392cc285597ab1f7026e672660c54b6
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/core@npm:^6.3.1":
+  version: 6.3.1
+  resolution: "@dnd-kit/core@npm:6.3.1"
+  dependencies:
+    "@dnd-kit/accessibility": "npm:^3.1.1"
+    "@dnd-kit/utilities": "npm:^3.2.2"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: 10/a5ae6fa8404765712aa80e308f58cb79bac9a306c274ec8272c405c2a59dd277d24b966348fe8ca6340bb3f0d75f90b8a021fa781edcf65255114d3cf2bef891
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/modifiers@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@dnd-kit/modifiers@npm:9.0.0"
+  dependencies:
+    "@dnd-kit/utilities": "npm:^3.2.2"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    "@dnd-kit/core": ^6.3.0
+    react: ">=16.8.0"
+  checksum: 10/2ae238a1b787029e95d92319d7e4a0e2ffba8fceed56c4b58dfee7ed6890df207bf89ce522d4126411051121954222bd8e1444fae321485b594ae518c7c4397d
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/sortable@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "@dnd-kit/sortable@npm:10.0.0"
+  dependencies:
+    "@dnd-kit/utilities": "npm:^3.2.2"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    "@dnd-kit/core": ^6.3.0
+    react: ">=16.8.0"
+  checksum: 10/bc61c25e76905204a53f91294b8116bf106fa27247eebca2c66478450b2051d7177115a384054e7e5639e6c4430083ade63056f79ee45f549da537cf05bc5288
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/utilities@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@dnd-kit/utilities@npm:3.2.2"
+  dependencies:
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 10/6cfe46a5fcdaced943982e7ae66b08b89235493e106eb5bc833737c25905e13375c6ecc3aa0c357d136cb21dae3966213dba063f19b7a60b1235a29a7b05ff84
+  languageName: node
+  linkType: hard
+
 "@dotenvx/dotenvx@npm:^1.7.0":
   version: 1.73.1
   resolution: "@dotenvx/dotenvx@npm:1.73.1"
@@ -3823,6 +3885,24 @@ __metadata:
     react: ^17 || ^18 || ^19
     react-dom: ^17 || ^18 || ^19
   checksum: 10/95178aebdab22bb0b79adf94e5779e29d18283a58b4ac22d9e53a1b9ec7359b7dc66c39f697f283e3d721db3744ba00d6d0491eba11acf491550cfb885ab2343
+  languageName: node
+  linkType: hard
+
+"@patternfly/react-drag-drop@npm:^6.5.1":
+  version: 6.5.1
+  resolution: "@patternfly/react-drag-drop@npm:6.5.1"
+  dependencies:
+    "@dnd-kit/core": "npm:^6.3.1"
+    "@dnd-kit/modifiers": "npm:^9.0.0"
+    "@dnd-kit/sortable": "npm:^10.0.0"
+    "@patternfly/react-core": "npm:^6.5.1"
+    "@patternfly/react-icons": "npm:^6.5.1"
+    "@patternfly/react-styles": "npm:^6.5.1"
+    resize-observer-polyfill: "npm:^1.5.1"
+  peerDependencies:
+    react: ^17 || ^18 || ^19
+    react-dom: ^17 || ^18 || ^19
+  checksum: 10/eeece389042a7d9017ed62cbd3c7cb6bfc650f845a5f266b383c509e9a1f053033a936d5d90a83d0c93e121eb782fb181706bd6b8edb10254dc1e4571e1ebdab
   languageName: node
   linkType: hard
 
@@ -13962,6 +14042,7 @@ __metadata:
     "@patternfly/react-charts": "npm:7.4.5"
     "@patternfly/react-code-editor": "npm:^6.5.1"
     "@patternfly/react-core": "npm:6.5.1"
+    "@patternfly/react-drag-drop": "npm:^6.5.1"
     "@patternfly/react-icons": "npm:6.5.1"
     "@patternfly/react-log-viewer": "npm:6.4.0"
     "@patternfly/react-styles": "npm:6.5.1"
@@ -17321,6 +17402,13 @@ __metadata:
   version: 1.0.0
   resolution: "requires-port@npm:1.0.0"
   checksum: 10/878880ee78ccdce372784f62f52a272048e2d0827c29ae31e7f99da18b62a2b9463ea03a75f277352f4697c100183debb0532371ad515a2d49d4bfe596dd4c20
+  languageName: node
+  linkType: hard
+
+"resize-observer-polyfill@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "resize-observer-polyfill@npm:1.5.1"
+  checksum: 10/e10ee50cd6cf558001de5c6fb03fee15debd011c2f694564b71f81742eef03fb30d6c2596d1d5bf946d9991cb692fcef529b7bd2e4057041377ecc9636c753ce
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Fixes
Fixes: https://issues.redhat.com/browse/KFLUXUI-1464

## Description

Migrates the `ColumnManagementModal` from the deprecated `DragDrop`/`Draggable`/`Droppable` components (`@patternfly/react-core/deprecated`) to `DragDropSort` from `@patternfly/react-drag-drop`.

In PF v6, the drag & drop logic was extracted into its own library. This component was introduced with the TableV2 system and still used the old API, which no longer exists in PF v6.

### Changes
- Replace `DragDrop`/`Draggable`/`Droppable` with `DragDropSort` using `variant="DataList"`
- Simplify `handleDrop` to use the reordered items array provided by `DragDropSort`
- Remove manual `DataListDragButton` (now managed by `DragDropSort`)
- Pinned columns rendered outside `DragDropSort` (no drag handle)
- Update tests to match new drag button behavior

## Type of change

- [x] Refactoring (no functional changes, no api changes)

## Screen shots / Gifs for design review

https://github.com/user-attachments/assets/9d75ce64-1eba-4807-9fe0-e58a7a9e08dc

## How to test or reproduce?

1. Navigate to the Snapshots page (which uses the TableV2 component)
2. Click the column management icon to open the "Manage columns" modal
3. Verify checkboxes toggle column visibility
4. Verify unpinned columns have drag handles and can be reordered
5. Verify pinned columns have no drag handles and disabled checkboxes
6. Click "Restore defaults" and verify it resets
7. Save and verify the column order persists

## Browser conformance:
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge