### PR TITLE
feat(KONFLUX-14794): show PipelineTask description for idle PLR tasks

### DIFF
--- a/src/components/PipelineRun/PipelineRunDetailsView/sidepanels/TaskRunDetails.tsx
+++ b/src/components/PipelineRun/PipelineRunDetailsView/sidepanels/TaskRunDetails.tsx
@@ -29,6 +29,16 @@ const TaskDescriptionGroup: React.FC<{ content: string }> = ({ content }) => (
   </DescriptionListGroup>
 );
 
+const getTaskDescription = (
+  taskRun: TaskRunKind | undefined,
+  pipelineTaskDescription: string | undefined,
+): string => {
+  const taskSpecDescription = taskRun?.status?.taskSpec?.description?.trim();
+  const trimmedPipelineDescription = pipelineTaskDescription?.trim();
+
+  return taskSpecDescription || trimmedPipelineDescription || '-';
+};
+
 const TaskRunDetails: React.FC<React.PropsWithChildren<Props>> = ({
   taskRun,
   status,
@@ -36,6 +46,7 @@ const TaskRunDetails: React.FC<React.PropsWithChildren<Props>> = ({
 }) => {
   const results = isTaskV1Beta1(taskRun) ? taskRun?.status?.taskResults : taskRun?.status?.results;
   const specParams = taskRun?.spec?.params;
+  const taskDescription = getTaskDescription(taskRun, description);
   return (
     <>
       {status !== runStatus.Skipped ? (
@@ -57,16 +68,16 @@ const TaskRunDetails: React.FC<React.PropsWithChildren<Props>> = ({
             </DescriptionListGroup>
           </DescriptionList>
           <DescriptionList className="pf-v5-u-mt-lg">
-            <TaskDescriptionGroup content={taskRun?.status?.taskSpec?.description || '-'} />
+            <TaskDescriptionGroup content={taskDescription} />
             <ScanDescriptionListGroup taskRuns={[taskRun]} hideIfNotFound />
           </DescriptionList>
         </>
       ) : (
         <>
           <p>This task was skipped.</p>
-          {description?.trim() ? (
+          {taskDescription !== '-' ? (
             <DescriptionList className="pf-v5-u-mt-lg">
-              <TaskDescriptionGroup content={description} />
+              <TaskDescriptionGroup content={taskDescription} />
             </DescriptionList>
           ) : null}
         </>

--- a/src/components/PipelineRun/PipelineRunDetailsView/sidepanels/__tests__/TaskRunDetails.spec.tsx
+++ b/src/components/PipelineRun/PipelineRunDetailsView/sidepanels/__tests__/TaskRunDetails.spec.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { runStatus } from '~/consts/pipelinerun';
 import { TaskRunKind } from '../../../../../types';
@@ -55,6 +55,41 @@ describe('TaskRunDetails', () => {
     );
     expect(result.queryByText('Description')).toBeInTheDocument();
     expect(result.queryByText('test')).toBeInTheDocument();
+  });
+
+  it('should display pipeline task description for idle tasks without a TaskRun', () => {
+    const result = render(
+      <TaskRunDetails
+        status={runStatus.Idle}
+        description="Create an ephemeral OpenShift cluster on AWS HyperShift."
+      />,
+    );
+    expect(result.getByText('Description')).toBeInTheDocument();
+    expect(result.getByText('Create an ephemeral OpenShift cluster on AWS HyperShift.')).toBeInTheDocument();
+  });
+
+  it('should prefer TaskRun taskSpec description over pipeline task description', () => {
+    const result = render(
+      <TaskRunDetails
+        status={runStatus.Running}
+        description="Pipeline task description"
+        taskRun={
+          {
+            apiVersion: 'tekton.dev/v1',
+            status: { taskSpec: { description: 'Resolved task description' } },
+          } as TaskRunKind
+        }
+      />,
+    );
+    expect(result.getByText('Resolved task description')).toBeInTheDocument();
+    expect(result.queryByText('Pipeline task description')).not.toBeInTheDocument();
+  });
+
+  it('should display dash when idle task has no pipeline task description', () => {
+    const result = render(<TaskRunDetails status={runStatus.Idle} />);
+    const descriptionGroup = result.getByText('Description').closest('.pf-v5-c-description-list__group');
+    expect(descriptionGroup).not.toBeNull();
+    expect(within(descriptionGroup as HTMLElement).getByText('-')).toBeInTheDocument();
   });
 
   it('should display task results', () => {


### PR DESCRIPTION
## Fixes 
https://redhat.atlassian.net/browse/KONFLUX-14794

## Description
Follow-up to #1104: extend PipelineTask description display to **idle** tasks in the PLR Details side panel (tasks not yet run, no TaskRun). Adds `getTaskDescription` to prefer `taskSpec.description` when present, otherwise `PipelineTask.description`. Skipped tasks reuse the same helper for consistent trim/fallback.

## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 

<img width="2261" height="534" alt="image" src="https://github.com/user-attachments/assets/baa294b2-a019-44d2-a144-2eb5d8f6b714" />


## How to test or reproduce?

- [x] `yarn test -- src/components/PipelineRun/PipelineRunDetailsView/sidepanels/__tests__/TaskRunDetails.spec.tsx`
- [x] Open a running PLR with `PipelineTask.description` on not-yet-run tasks; select an idle task and confirm Description shows pipeline text

## Browser conformance: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task description display in pipeline run details by consistently choosing the most relevant available text.
  * Skipped/idle tasks now show a dash (`-`) when no description is available.
  * When both a task-specific and pipeline-level description exist, the task-specific description is used.

* **Tests**
  * Added/updated unit tests to verify description rendering across idle, skipped, and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->