### PR TITLE
fix(KFLUXUI-1486): add registers.ts to sideEffects to prevent tree-shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,8 @@
   },
   "sideEffects": [
     "*.css",
-    "*.scss"
+    "*.scss",
+    "./src/registers.ts"
   ],
   "lint-staged": {
     "*.{ts,tsx,js,mjs,jsx}": [


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->

Fixes https://redhat.atlassian.net/browse/KFLUXUI-1486

Feature flag conditions not registering on staging (registers.ts tree-shaken from production builds).

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Webpack 5.108.0 ([changelog](https://github.com/webpack/webpack/releases/tag/v5.108.0)) introduced constant-inlining and dead-branch elimination for imported constants. This caused `registers.ts` to be silently dropped from production builds:

1. `registers.ts` exports `REGISTRATIONS_LOADED = true` (a primitive constant)
2. `main.tsx` uses it in `if (REGISTRATIONS_LOADED) { ... }`
3. Webpack inlines the constant, sees the branch is always taken, concludes the import is unused, and - since `registers.ts` isn't in the `sideEffects` array - drops the module
4. All `registerCondition()` calls never execute -> feature flags break

Fix: add `./src/registers.ts` to `sideEffects` in `package.json`.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

1. On `main` (without this fix): `yarn build`, then `npx serve dist`
2. Open DevTools → Sources → confirm `registers.ts` is missing
3. With this fix: rebuild and confirm `registers.ts` is present

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build settings to better preserve required styles and startup registrations during bundling, helping ensure the app loads correctly in optimized builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->