### PR TITLE
fix(KONFLUX-14943): auto-fetch all TaskRun pages for PipelineRun details

### DIFF
--- a/src/hooks/__tests__/useTaskRunsV2.spec.ts
+++ b/src/hooks/__tests__/useTaskRunsV2.spec.ts
@@ -882,6 +882,66 @@ describe('useTaskRunsV2', () => {
       const callArgs = useK8sWatchResourceMock.mock.calls[0][0];
       expect(callArgs.selector.matchLabels).not.toHaveProperty('tekton.dev/pipelineTask');
     });
+
+    it('should fetch all TaskRun pages before reporting loaded', async () => {
+      const mockGetNextPage = jest.fn();
+      const oldestTaskRun: TaskRunKind = {
+        ...mockTaskRun2,
+        metadata: {
+          ...mockTaskRun2.metadata,
+          name: 'parse-pipeline-tests-tr',
+          labels: { 'tekton.dev/pipelineTask': 'parse-pipeline-tests' },
+        },
+        status: {
+          conditions: [{ type: 'Succeeded', status: 'True', reason: 'Succeeded' }],
+        },
+      };
+
+      useK8sWatchResourceMock.mockReturnValue({
+        data: [],
+        isLoading: false,
+        error: null,
+      });
+
+      mockUseTRTaskRuns.mockReturnValue([
+        [mockTaskRun1, mockTaskRun3],
+        true,
+        null,
+        mockGetNextPage,
+        { hasNextPage: true, isFetchingNextPage: false },
+      ]);
+
+      const { result, rerender } = renderHook(
+        () => useTaskRunsForPipelineRuns('test-ns', 'test-pipelinerun', undefined, false),
+        {
+          wrapper: ({ children }) =>
+            React.createElement(QueryClientProvider, { client: queryClient }, children),
+        },
+      );
+
+      await waitFor(() => {
+        expect(mockGetNextPage).toHaveBeenCalled();
+      });
+
+      expect(result.current[1]).toBe(false);
+
+      mockUseTRTaskRuns.mockReturnValue([
+        [mockTaskRun1, mockTaskRun3, oldestTaskRun],
+        true,
+        null,
+        mockGetNextPage,
+        { hasNextPage: false, isFetchingNextPage: false },
+      ]);
+
+      rerender();
+
+      await waitFor(() => {
+        expect(result.current[1]).toBe(true);
+      });
+
+      expect(result.current[0]).toHaveLength(3);
+      expect(result.current[0].map((tr) => tr.metadata.name)).toContain('parse-pipeline-tests-tr');
+    });
   });
 });
 

--- a/src/hooks/useTaskRunsV2.ts
+++ b/src/hooks/useTaskRunsV2.ts
@@ -224,7 +224,8 @@ export const useTaskRunsV2 = (
  * @param pipelineRunName - Name of the pipeline run to fetch TaskRuns for
  * @param taskName - Optional specific task name to filter by
  * @param watch - Whether to watch for real-time updates (default: true). Set to false for completed pipeline runs.
- * @returns Tuple of [taskRuns, loaded, error] sorted by completion time
+ * @returns Tuple of [taskRuns, allPagesLoaded, error, getNextPage, nextPageProps] sorted by completion time.
+ * `allPagesLoaded` is false while additional Tekton Results / KubeArchive pages are still loading.
  */
 export const useTaskRunsForPipelineRuns = (
   namespace: string | null,
@@ -254,9 +255,24 @@ export const useTaskRunsForPipelineRuns = (
     },
   );
 
+  React.useEffect(() => {
+    if (nextPageProps.hasNextPage && !nextPageProps.isFetchingNextPage && loaded && !error) {
+      getNextPage?.();
+    }
+  }, [
+    nextPageProps.hasNextPage,
+    nextPageProps.isFetchingNextPage,
+    loaded,
+    getNextPage,
+    error,
+  ]);
+
+  const allPagesLoaded =
+    loaded && !error && !nextPageProps.isFetchingNextPage && !nextPageProps.hasNextPage;
+
   const sortedTaskRuns = React.useMemo(() => sortTaskRunsByTime(taskRuns), [taskRuns]);
 
-  return [sortedTaskRuns, loaded, error, getNextPage, nextPageProps];
+  return [sortedTaskRuns, allPagesLoaded, error, getNextPage, nextPageProps];
 };
 
 export const useTaskRunV2 = (


### PR DESCRIPTION
## Fixes
Fixes: https://redhat.atlassian.net/browse/KONFLUX-14943

## Description
PipelineRun details can mark the first pipeline task as Idle with empty Details/Results/Logs on completed runs that have more than 30 TaskRuns (e.g. olminstall smoke+bvt). TaskRuns are loaded from Tekton Results / KubeArchive with page_size=30, newest first, so the oldest task falls off page 1 and the UI treats it as missing.

This change auto-fetches remaining TaskRun pages in `useTaskRunsForPipelineRuns` (same pattern as `useScanResults`) and reports `allPagesLoaded=false` until every page is loaded.

## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review

### Before the fix - Task content and log are empty:
<img width="1113" height="660" alt="image" src="https://github.com/user-attachments/assets/0ad57158-9e77-4d78-b749-87786fb7be4e" />

---

<img width="1161" height="420" alt="image" src="https://github.com/user-attachments/assets/a385d450-79f4-48cc-9fdf-8cb69135fedb" />


### After the fix - Task content and log are shown:
<img width="1301" height="675" alt="image" src="https://github.com/user-attachments/assets/d5cc167b-0441-47f4-add0-e2815020c819" />

---

<img width="1525" height="427" alt="image" src="https://github.com/user-attachments/assets/62e41b98-e4ec-4269-882c-db2bda79df42" />


## How to test or reproduce?
- Open a completed PipelineRun with 31+ TaskRuns (e.g. olminstall smoke+bvt on stone-prod-p02).
- Confirm the first task (e.g. `parse-pipeline-tests`) shows Succeeded, not Idle, with Details/Results/Logs populated.
- Run `yarn test -- src/hooks/__tests__/useTaskRunsV2.spec.ts` — includes multi-page fetch test.

## Browser conformance:
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task run pagination so all available pages are fetched automatically.
  * Task run results now remain in a loading state until every page has finished loading.
  * Ensured results include task runs from additional pages once pagination is complete.

* **Tests**
  * Added coverage verifying multi-page task run loading and completion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->