### PR TITLE
docs(KFLUXUI-1435): update guidelines for PatternFly v6 migration

### DIFF
--- a/docs/guidelines/layout-and-pages.md
+++ b/docs/guidelines/layout-and-pages.md
@@ -84,12 +84,12 @@ import DetailsPage from '~/components/DetailsPage/DetailsPage';
     },
   ]}
   tabs={[
-    { key: '', label: 'Overview', isFilled: true },         // index route
+    { key: '', label: 'Overview', isFilled: true }, // index route
     { key: 'pipelineruns', label: 'Pipeline runs', isFilled: true },
-    { key: 'activity', label: 'Activity', partial: true },  // matches /activity/*
+    { key: 'activity', label: 'Activity', partial: true }, // matches /activity/*
   ]}
   baseURL={baseURL}
-/>
+/>;
 ```
 
 **Action type for DetailsPage:**
@@ -99,11 +99,11 @@ type Action = {
   key: string;
   label: React.ReactNode;
   onClick?: () => void;
-  component?: React.ReactElement;         // For Link-based actions
+  component?: React.ReactElement; // For Link-based actions
   isDisabled?: boolean;
   disabledTooltip?: React.ReactNode;
-  type?: 'separator' | 'section-label';   // Structural items
-  hidden?: boolean;                       // Conditionally hide
+  type?: 'separator' | 'section-label'; // Structural items
+  hidden?: boolean; // Conditionally hide
 };
 ```
 
@@ -111,10 +111,10 @@ type Action = {
 
 ```ts
 type DetailsPageTabProps = {
-  key: string;      // Route path segment ('' for index)
-  label: string;    // Tab display text
-  isFilled?: boolean;   // Tab content fills remaining height
-  partial?: boolean;    // Match any path starting with key
+  key: string; // Route path segment ('' for index)
+  label: string; // Tab display text
+  isFilled?: boolean; // Tab content fills remaining height
+  partial?: boolean; // Match any path starting with key
   featureFlag?: string; // Show flag indicator badge
 };
 ```
@@ -162,6 +162,7 @@ FilterContextProvider filterParams={['name', 'status']}
 ```
 
 Key behaviors:
+
 - Filter state lives in URL via `useSearchParamBatch`.
 - `FilterContextProvider` declares which params are tracked.
 - Primary action button uses `ButtonWithAccessTooltip` for RBAC gating.
@@ -201,9 +202,7 @@ const MyFeatureOverviewTab: React.FC = () => (
           {/* More fields... */}
         </DescriptionList>
       </Flex>
-      <Flex flex={{ default: 'flex_3' }}>
-        {/* Second column */}
-      </Flex>
+      <Flex flex={{ default: 'flex_3' }}>{/* Second column */}</Flex>
     </Flex>
   </>
 );
@@ -228,6 +227,7 @@ MyFeatureView (Formik wrapper)
 ```
 
 The View-Form separation:
+
 - **View component** -- owns Formik context, initial values, validation schema, submit handler
 - **Form component** -- reads `useFormikContext()`, renders fields, passes `FormFooter` as layout footer
 
@@ -297,10 +297,18 @@ const MyConfirmModal: React.FC<{ obj: MyKind; modalProps: ModalProps }> = ({ obj
   <Stack hasGutter>
     <StackItem>Are you sure you want to process {obj.metadata.name}?</StackItem>
     <StackItem>
-      <Button variant="primary" onClick={() => { doAction(); modalProps.onClose(); }}>
+      <Button
+        variant="primary"
+        onClick={() => {
+          doAction();
+          modalProps.onClose();
+        }}
+      >
         Confirm
       </Button>
-      <Button variant="link" onClick={modalProps.onClose}>Cancel</Button>
+      <Button variant="link" onClick={modalProps.onClose}>
+        Cancel
+      </Button>
     </StackItem>
   </Stack>
 );
@@ -319,6 +327,8 @@ const handleAction = () => {
   showModal(myConfirmModalLauncher({ obj: myResource }));
 };
 ```
+
+For modals that need custom headers, descriptions, or footers, use `createRawModalLauncher` instead. See [patternfly-guidelines.md](./patternfly-guidelines.md#when-to-use-which) for the full modal API reference.
 
 ## Routing
 
@@ -374,9 +384,9 @@ Breadcrumbs are built as an array of `{ name: string, path: string }` objects or
 
 ```tsx
 const breadcrumbs = [
-  ...useApplicationBreadcrumbs(),  // "Applications" link + app name + switcher
+  ...useApplicationBreadcrumbs(), // "Applications" link + app name + switcher
   { path: MY_FEATURE_LIST_PATH.createPath({ workspaceName: namespace }), name: 'My Features' },
-  { path: '#', name: resource.metadata.name },  // Current page (non-navigable)
+  { path: '#', name: resource.metadata.name }, // Current page (non-navigable)
 ];
 ```
 
@@ -449,6 +459,7 @@ if (error) {
 ```
 
 `ErrorEmptyState` handles:
+
 - 403 -> "Access Denied" message
 - 404 -> Redirects to `NotFoundEmptyState`
 - Other errors -> Generic error with the message

--- a/docs/guidelines/patternfly-guidelines.md
+++ b/docs/guidelines/patternfly-guidelines.md
@@ -18,7 +18,7 @@ import { Flex, FlexItem } from '@patternfly/react-core';
 // Row with right-aligned element
 <Flex>
   <FlexItem>
-    <TextContent>{title}</TextContent>
+    <Content>{title}</Content>
   </FlexItem>
   <Flex align={{ default: 'alignRight' }}>
     <FlexItem>
@@ -56,9 +56,13 @@ import { Stack, StackItem } from '@patternfly/react-core';
   <StackItem>Section 1</StackItem>
   <StackItem>Section 2</StackItem>
   <StackItem>
-    {error && <Alert isInline variant="danger" title="Error">{error}</Alert>}
+    {error && (
+      <Alert isInline variant="danger" title="Error">
+        {error}
+      </Alert>
+    )}
   </StackItem>
-</Stack>
+</Stack>;
 ```
 
 ### Bullseye -- Centering
@@ -95,14 +99,14 @@ import { PageSection, PageSectionVariants } from '@patternfly/react-core';
 
 ### Layout Decision Guide
 
-| Need | Component |
-|---|---|
-| Horizontal row of items | `Flex` |
-| Right-aligned element in a row | `Flex` > `Flex align={{ default: 'alignRight' }}` |
-| Vertical list with spacing | `Stack hasGutter` |
-| Center a spinner/empty state | `Bullseye` |
-| Page content section | `PageSection variant={PageSectionVariants.light}` |
-| Two-column detail view | `Flex` with `flex={{ default: 'flex_3' }}` children |
+| Need                           | Component                                           |
+| ------------------------------ | --------------------------------------------------- |
+| Horizontal row of items        | `Flex`                                              |
+| Right-aligned element in a row | `Flex` > `Flex align={{ default: 'alignRight' }}`   |
+| Vertical list with spacing     | `Stack hasGutter`                                   |
+| Center a spinner/empty state   | `Bullseye`                                          |
+| Page content section           | `PageSection variant={PageSectionVariants.light}`   |
+| Two-column detail view         | `Flex` with `flex={{ default: 'flex_3' }}` children |
 
 **Not used in this codebase:** `Split`/`SplitItem`, `Gallery`. Prefer `Flex` for all horizontal layouts.
 
@@ -121,7 +125,7 @@ import AnalyticsButton from '~/components/AnalyticsButton/AnalyticsButton';
   onClick={handleCreate}
 >
   Create component
-</AnalyticsButton>
+</AnalyticsButton>;
 ```
 
 Raw `Button` is acceptable only in shared/utility components.
@@ -147,7 +151,7 @@ import { Tooltip } from '@patternfly/react-core';
   <AnalyticsButton variant="primary" isAriaDisabled>
     Create
   </AnalyticsButton>
-</Tooltip>
+</Tooltip>;
 ```
 
 `isAriaDisabled` keeps the button focusable for accessibility (tooltips don't work on elements with `disabled`).
@@ -164,7 +168,7 @@ import ButtonWithAccessTooltip from '~/components/ButtonWithAccessTooltip';
   analytics={{ link_name: 'create-resource' }}
 >
   Create
-</ButtonWithAccessTooltip>
+</ButtonWithAccessTooltip>;
 ```
 
 ## Alert
@@ -175,16 +179,18 @@ Always use `isInline` inside forms and modals:
 import { Alert, AlertVariant } from '@patternfly/react-core';
 
 // Error alert in a form/modal
-{error && (
-  <Alert isInline variant={AlertVariant.danger} title="An error occurred">
-    {error}
-  </Alert>
-)}
+{
+  error && (
+    <Alert isInline variant={AlertVariant.danger} title="An error occurred">
+      {error}
+    </Alert>
+  );
+}
 
 // Info alert for unsaved changes
 <Alert isInline variant="info" title="You made changes to this page.">
   Click Save to save changes or Reload to cancel changes.
-</Alert>
+</Alert>;
 ```
 
 ## Modal
@@ -209,20 +215,57 @@ const showModal = useModalLauncher();
 showModal(myModalLauncher({ prop1: value1 }));
 ```
 
+### When to Use Which
+
+| Scenario                                                                  | Use                                                                                       |
+| ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Simple modal where title, variant, and data-test are enough               | `createModalLauncher` — modal chrome (title, variant, close) is handled for you           |
+| Modal with custom header, description, footer, or composable API features | `createRawModalLauncher` — you control `ModalHeader`, `ModalBody`, `ModalFooter` directly |
+
+### Composable Modal with `createRawModalLauncher`
+
+For modals that need full control over layout (custom headers, descriptions, footers), use `createRawModalLauncher` with PF v6's composable `Modal`:
+
+```tsx
+import { Modal, ModalBody, ModalFooter, ModalHeader, ModalVariant } from '@patternfly/react-core';
+import { createRawModalLauncher, RawComponentProps } from '~/components/modal/createModalLauncher';
+
+const MyModal: React.FC<RawComponentProps> = ({ onClose, modalProps }) => {
+  const { isOpen, appendTo, ...rest } = modalProps || {};
+  return (
+    <Modal
+      {...rest}
+      isOpen={isOpen}
+      onClose={onClose}
+      appendTo={appendTo}
+      variant={ModalVariant.small}
+    >
+      <ModalHeader title="My Modal Title" description="Optional description text" />
+      <ModalBody>{/* modal content */}</ModalBody>
+      <ModalFooter>{/* action buttons */}</ModalFooter>
+    </Modal>
+  );
+};
+
+export const myModalLauncher = createRawModalLauncher(MyModal, { 'data-test': 'my-modal' });
+```
+
+> **Note:** Do not import `Modal` from `@patternfly/react-core/deprecated`. Use the composable `Modal` from `@patternfly/react-core`.
+
 ### Modal Variants
 
-| Variant | Width | Use For |
-|---|---|---|
-| `ModalVariant.small` | 560px | Confirmations, simple forms |
-| `ModalVariant.medium` | 768px | Standard forms |
-| `ModalVariant.large` | 992px | Complex content, tables |
+| Variant               | Width | Use For                     |
+| --------------------- | ----- | --------------------------- |
+| `ModalVariant.small`  | 560px | Confirmations, simple forms |
+| `ModalVariant.medium` | 768px | Standard forms              |
+| `ModalVariant.large`  | 992px | Complex content, tables     |
 
 ## Toolbar
 
 ```tsx
 import { Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
 
-<Toolbar usePageInsets clearAllFilters={onClearFilters}>
+<Toolbar className="pf-v6-u-py-md" clearAllFilters={onClearFilters}>
   <ToolbarContent>
     <ToolbarItem className="pf-v6-u-ml-0">
       <SearchInput
@@ -231,33 +274,35 @@ import { Toolbar, ToolbarContent, ToolbarItem } from '@patternfly/react-core';
         value={text}
       />
     </ToolbarItem>
-    <ToolbarItem alignSelf="center">
-      {children}
-    </ToolbarItem>
+    <ToolbarItem alignSelf="center">{children}</ToolbarItem>
   </ToolbarContent>
-</Toolbar>
+</Toolbar>;
 ```
 
-Always include `usePageInsets` prop. Use `clearAllFilters` callback for filter reset.
+Use `className="pf-v6-u-py-md"` for vertical spacing. Use `clearAllFilters` callback for filter reset.
 
 ## Empty States
 
 Use the three shared empty state wrappers. Never use raw PF `EmptyState` in feature components.
 
-| Component | Use For |
-|---|---|
-| `AppEmptyState` | Zero data (no resources exist) |
-| `FilteredEmptyState` | Filters yielded no results |
-| `ErrorEmptyState` | Error loading data |
+| Component            | Use For                        |
+| -------------------- | ------------------------------ |
+| `AppEmptyState`      | Zero data (no resources exist) |
+| `FilteredEmptyState` | Filters yielded no results     |
+| `ErrorEmptyState`    | Error loading data             |
 
 ```tsx
-import { AppEmptyState, FilteredEmptyState, ErrorEmptyState } from '~/shared/components/empty-state';
+import {
+  AppEmptyState,
+  FilteredEmptyState,
+  ErrorEmptyState,
+} from '~/shared/components/empty-state';
 
 // In table: EmptyMsg / NoDataEmptyMsg
 <Table
   EmptyMsg={FilteredEmptyState}
   NoDataEmptyMsg={() => <AppEmptyState emptyStateImg={MyImage} title="No resources yet" />}
-/>
+/>;
 
 // Direct usage
 if (error) return <ErrorEmptyState httpError={error} />;
@@ -270,13 +315,13 @@ All tabs are router-driven via `TabsLayout`. Never manage tab state with `useSta
 ```tsx
 // Define tabs as data
 const tabs: DetailsPageTabProps[] = [
-  { key: '', label: 'Overview', isFilled: true },         // index route
+  { key: '', label: 'Overview', isFilled: true }, // index route
   { key: 'pipelineruns', label: 'Pipeline runs' },
-  { key: 'activity', label: 'Activity', partial: true },  // matches /activity/*
+  { key: 'activity', label: 'Activity', partial: true }, // matches /activity/*
 ];
 
 // TabsLayout renders PF Tabs + <Outlet />
-<TabsLayout id="my-details" tabs={tabs} headTitle="My Resource" baseURL={baseURL} />
+<TabsLayout id="my-details" tabs={tabs} headTitle="My Resource" baseURL={baseURL} />;
 ```
 
 Always use `mountOnEnter` and `unmountOnExit` (set by default in `TabsLayout`).
@@ -292,7 +337,7 @@ import { Label, LabelGroup, Truncate } from '@patternfly/react-core';
       <Truncate content={item} />
     </Label>
   ))}
-</LabelGroup>
+</LabelGroup>;
 ```
 
 ## Tooltip / Popover
@@ -325,8 +370,10 @@ Used on detail page overview tabs for key-value display:
 
 ```tsx
 import {
-  DescriptionList, DescriptionListGroup,
-  DescriptionListTerm, DescriptionListDescription,
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
 } from '@patternfly/react-core';
 
 <DescriptionList columnModifier={{ default: '1Col' }}>
@@ -340,7 +387,7 @@ import {
       <Timestamp timestamp={resource.metadata.creationTimestamp} />
     </DescriptionListDescription>
   </DescriptionListGroup>
-</DescriptionList>
+</DescriptionList>;
 ```
 
 ## Design Tokens
@@ -351,31 +398,32 @@ Use PatternFly design tokens. Never hardcode pixel values.
 
 ```scss
 // Spacing scale
-gap: var(--pf-t--global--spacer--xs);    // 4px
-gap: var(--pf-t--global--spacer--sm);    // 8px
-gap: var(--pf-t--global--spacer--md);    // 16px
-gap: var(--pf-t--global--spacer--lg);    // 24px
-gap: var(--pf-t--global--spacer--xl);    // 32px
-gap: var(--pf-t--global--spacer--2xl);   // 48px
-gap: var(--pf-t--global--spacer--3xl);   // 64px
+gap: var(--pf-t--global--spacer--xs); // 4px
+gap: var(--pf-t--global--spacer--sm); // 8px
+gap: var(--pf-t--global--spacer--md); // 16px
+gap: var(--pf-t--global--spacer--lg); // 24px
+gap: var(--pf-t--global--spacer--xl); // 32px
+gap: var(--pf-t--global--spacer--2xl); // 48px
+gap: var(--pf-t--global--spacer--3xl); // 64px
 ```
 
 ### Color Tokens
 
 ```scss
 // Semantic colors
-color: var(--pf-t--global--color--status--danger--default);     // errors
-color: var(--pf-t--global--color--status--warning--default);    // warnings
-color: var(--pf-t--global--color--status--success--default);    // success
-color: var(--pf-t--global--color--status--info--default);       // info
-color: var(--pf-t--global--text--color--disabled);              // muted
-color: var(--pf-t--global--text--color--link--default);         // links
+color: var(--pf-t--global--color--status--danger--default); // errors
+color: var(--pf-t--global--color--status--warning--default); // warnings
+color: var(--pf-t--global--color--status--success--default); // success
+color: var(--pf-t--global--color--status--info--default); // info
+color: var(--pf-t--global--text--color--disabled); // muted
+color: var(--pf-t--global--text--color--link--default); // links
 
 // Background
 background-color: var(--pf-t--global--background--color--secondary--default);
 
 // Border
-border: var(--pf-t--global--border--width--regular) solid var(--pf-t--global--border--color--default);
+border: var(--pf-t--global--border--width--regular) solid
+  var(--pf-t--global--border--color--default);
 ```
 
 ### Typography Tokens
@@ -451,15 +499,35 @@ import { css } from '@patternfly/react-styles';
 }
 ```
 
+## PF v6 Migration Gotchas
+
+Behavioral changes in PatternFly v6 that can cause subtle bugs:
+
+| Change                                          | Impact                                                                                     | Fix                                                                                                          |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| Drawer padding uses direct-child CSS selectors  | Wrapper divs between `DrawerPanelContent` and `DrawerHead`/`DrawerPanelBody` break padding | Keep Drawer subcomponents as direct children                                                                 |
+| `MenuContent` applies `overflow:hidden`         | Components like `Tabs` that render outside their bounds get clipped                        | Place such components outside `MenuContent`                                                                  |
+| Modal accessible name includes all text content | Test assertions with exact `{ name: '...' }` may break                                     | Use regex: `{ name: /My Modal Title/ }`                                                                      |
+| `EmptyStateHeader`, `EmptyStateIcon` removed    | Import errors                                                                              | Use `EmptyState` props (`headingLevel`, `titleText`, `icon`) directly                                        |
+| `Text`/`TextContent` removed                    | Import errors                                                                              | Use `Content` with `ContentVariants`                                                                         |
+| `Chip`/`ChipGroup` deprecated                   | Moved to `@patternfly/react-core/deprecated`                                               | Use `Label`/`LabelGroup`                                                                                     |
+| `icon-button-group` toolbar variant removed     | Type error on `ToolbarGroup`                                                               | Use `action-group-plain` or remove the variant                                                               |
+| JS token imports renamed                        | `global_palette_*`, `global_danger_color_*` etc. no longer exist                           | Use `t_global_*` equivalents (e.g., `global_danger_color_100` → `t_global_icon_color_status_danger_default`) |
+| CSS class prefix `pf-v5-c-*` → `pf-v6-c-*`      | SCSS overrides and utility classes targeting `pf-v5-` break                                | Update to `pf-v6-c-*` and `pf-v6-u-*`                                                                        |
+| OUIA component type prefix `PF5/` → `PF6/`      | E2E selectors using `data-ouia-component-type="PF5/..."` break                             | Update to `PF6/` prefix                                                                                      |
+| `formik-pf` package removed                     | Import errors                                                                              | Use `~/shared/components/formik-base/`                                                                       |
+
 ## Deprecated PF APIs to Avoid
 
 These deprecated APIs exist in the codebase but should not be used in new code:
 
-| Deprecated | Use Instead |
-|---|---|
-| `Dropdown` from `@patternfly/react-core/deprecated` | `ActionMenu` from `~/shared/components/action-menu/` |
-| `Select` from `@patternfly/react-core/deprecated` | `BasicDropdown` from `~/shared/components/dropdown/` or PF5 `Select` |
-| `DropdownToggle` from `@patternfly/react-core/deprecated` | PF5 `MenuToggle` |
+| Deprecated                                                  | Use Instead                                                                                   |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `Dropdown` from `@patternfly/react-core/deprecated`         | `ActionMenu` from `~/shared/components/action-menu/`                                          |
+| `Select` from `@patternfly/react-core/deprecated`           | `BasicDropdown` from `~/shared/components/dropdown/` or PF5 `Select`                          |
+| `DropdownToggle` from `@patternfly/react-core/deprecated`   | PF5 `MenuToggle`                                                                              |
+| `Modal` from `@patternfly/react-core/deprecated`            | Composable `Modal` from `@patternfly/react-core` with `ModalHeader`/`ModalBody`/`ModalFooter` |
+| `Chip`/`ChipGroup` from `@patternfly/react-core/deprecated` | `Label`/`LabelGroup` from `@patternfly/react-core`                                            |
 
 ## Common Pitfalls — Composable Component DOM Semantics
 
@@ -509,15 +577,16 @@ In the composable `Select`, `SelectOption` requires an explicit `value` prop. If
 
 ## Component Wrapping Decision Guide
 
-| Need | Use |
-|---|---|
-| Button in feature component | `AnalyticsButton` |
-| Button with RBAC tooltip | `ButtonWithAccessTooltip` |
-| External link | `ExternalLink` from `~/shared/components/links/` |
-| Action menu / kebab | `ActionMenu` from `~/shared/components/action-menu/` |
-| Loading/error wrapper | `StatusBox` from `~/shared/components/status-box/` |
-| Modal | `createModalLauncher` + `useModalLauncher` |
-| Timestamp display | `Timestamp` from `~/shared/components/timestamp/` |
-| Text truncation | `Truncate` from `~/shared/components/truncate-text/` |
-| Overflow list with popover | `TruncatedLinkListWithPopover` |
-| Skeleton placeholder | `LoadingSkeleton` from `~/shared/components/skeleton/` |
+| Need                            | Use                                                    |
+| ------------------------------- | ------------------------------------------------------ |
+| Button in feature component     | `AnalyticsButton`                                      |
+| Button with RBAC tooltip        | `ButtonWithAccessTooltip`                              |
+| External link                   | `ExternalLink` from `~/shared/components/links/`       |
+| Action menu / kebab             | `ActionMenu` from `~/shared/components/action-menu/`   |
+| Loading/error wrapper           | `StatusBox` from `~/shared/components/status-box/`     |
+| Simple modal                    | `createModalLauncher` + `useModalLauncher`             |
+| Modal with custom header/footer | `createRawModalLauncher` + `useModalLauncher`          |
+| Timestamp display               | `Timestamp` from `~/shared/components/timestamp/`      |
+| Text truncation                 | `Truncate` from `~/shared/components/truncate-text/`   |
+| Overflow list with popover      | `TruncatedLinkListWithPopover`                         |
+| Skeleton placeholder            | `LoadingSkeleton` from `~/shared/components/skeleton/` |

--- a/docs/guidelines/patternfly-guidelines.md
+++ b/docs/guidelines/patternfly-guidelines.md
@@ -519,15 +519,7 @@ Behavioral changes in PatternFly v6 that can cause subtle bugs:
 
 ## Deprecated PF APIs to Avoid
 
-These deprecated APIs exist in the codebase but should not be used in new code:
-
-| Deprecated                                                  | Use Instead                                                                                   |
-| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `Dropdown` from `@patternfly/react-core/deprecated`         | `ActionMenu` from `~/shared/components/action-menu/`                                          |
-| `Select` from `@patternfly/react-core/deprecated`           | `BasicDropdown` from `~/shared/components/dropdown/` or PF5 `Select`                          |
-| `DropdownToggle` from `@patternfly/react-core/deprecated`   | PF5 `MenuToggle`                                                                              |
-| `Modal` from `@patternfly/react-core/deprecated`            | Composable `Modal` from `@patternfly/react-core` with `ModalHeader`/`ModalBody`/`ModalFooter` |
-| `Chip`/`ChipGroup` from `@patternfly/react-core/deprecated` | `Label`/`LabelGroup` from `@patternfly/react-core`                                            |
+PF v6 removed `@patternfly/react-core/deprecated` entirely. All components that previously lived there (Dropdown, Select, Modal, Chip/ChipGroup) have already been migrated to their composable equivalents. Do not re-introduce imports from `@patternfly/react-core/deprecated`.
 
 ## Common Pitfalls — Composable Component DOM Semantics
 

--- a/docs/guidelines/patternfly-guidelines.md
+++ b/docs/guidelines/patternfly-guidelines.md
@@ -499,24 +499,6 @@ import { css } from '@patternfly/react-styles';
 }
 ```
 
-## PF v6 Migration Gotchas
-
-Behavioral changes in PatternFly v6 that can cause subtle bugs:
-
-| Change                                          | Impact                                                                                     | Fix                                                                                                          |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| Drawer padding uses direct-child CSS selectors  | Wrapper divs between `DrawerPanelContent` and `DrawerHead`/`DrawerPanelBody` break padding | Keep Drawer subcomponents as direct children                                                                 |
-| `MenuContent` applies `overflow:hidden`         | Components like `Tabs` that render outside their bounds get clipped                        | Place such components outside `MenuContent`                                                                  |
-| Modal accessible name includes all text content | Test assertions with exact `{ name: '...' }` may break                                     | Use regex: `{ name: /My Modal Title/ }`                                                                      |
-| `EmptyStateHeader`, `EmptyStateIcon` removed    | Import errors                                                                              | Use `EmptyState` props (`headingLevel`, `titleText`, `icon`) directly                                        |
-| `Text`/`TextContent` removed                    | Import errors                                                                              | Use `Content` with `ContentVariants`                                                                         |
-| `Chip`/`ChipGroup` deprecated                   | Moved to `@patternfly/react-core/deprecated`                                               | Use `Label`/`LabelGroup`                                                                                     |
-| `icon-button-group` toolbar variant removed     | Type error on `ToolbarGroup`                                                               | Use `action-group-plain` or remove the variant                                                               |
-| JS token imports renamed                        | `global_palette_*`, `global_danger_color_*` etc. no longer exist                           | Use `t_global_*` equivalents (e.g., `global_danger_color_100` → `t_global_icon_color_status_danger_default`) |
-| CSS class prefix `pf-v5-c-*` → `pf-v6-c-*`      | SCSS overrides and utility classes targeting `pf-v5-` break                                | Update to `pf-v6-c-*` and `pf-v6-u-*`                                                                        |
-| OUIA component type prefix `PF5/` → `PF6/`      | E2E selectors using `data-ouia-component-type="PF5/..."` break                             | Update to `PF6/` prefix                                                                                      |
-| `formik-pf` package removed                     | Import errors                                                                              | Use `~/shared/components/formik-base/`                                                                       |
-
 ## Deprecated PF APIs to Avoid
 
 PF v6 removed `@patternfly/react-core/deprecated` entirely. All components that previously lived there (Dropdown, Select, Modal, Chip/ChipGroup) have already been migrated to their composable equivalents. Do not re-introduce imports from `@patternfly/react-core/deprecated`.

--- a/docs/guidelines/unit-testing.md
+++ b/docs/guidelines/unit-testing.md
@@ -4,11 +4,11 @@ This document covers testing patterns, utilities, and conventions for writing un
 
 ## Quick Reference
 
-| Task | Command |
-|---|---|
-| Run all tests | `yarn test` |
-| Run single file | `yarn test -- path/to/file.spec.tsx` |
-| Run with coverage | `yarn coverage` |
+| Task              | Command                              |
+| ----------------- | ------------------------------------ |
+| Run all tests     | `yarn test`                          |
+| Run single file   | `yarn test -- path/to/file.spec.tsx` |
+| Run with coverage | `yarn coverage`                      |
 
 ## Test File Conventions
 
@@ -30,13 +30,13 @@ This document covers testing patterns, utilities, and conventions for writing un
 
 Import from `~/unit-test-utils/`:
 
-| Utility | Use When |
-|---|---|
+| Utility                          | Use When                                                          |
+| -------------------------------- | ----------------------------------------------------------------- |
 | `renderWithQueryClientAndRouter` | Component needs BrowserRouter + QueryClientProvider (most common) |
-| `renderWithQueryClient` | Component needs only QueryClientProvider (no routing) |
-| `routerRenderer` | Component needs only BrowserRouter |
-| `formikRenderer` | Component uses Formik fields |
-| `namespaceRenderer` | Component uses `useNamespace()` via context |
+| `renderWithQueryClient`          | Component needs only QueryClientProvider (no routing)             |
+| `routerRenderer`                 | Component needs only BrowserRouter                                |
+| `formikRenderer`                 | Component uses Formik fields                                      |
+| `namespaceRenderer`              | Component uses `useNamespace()` via context                       |
 
 ```tsx
 import { renderWithQueryClientAndRouter } from '~/unit-test-utils';
@@ -400,8 +400,7 @@ screen.getByRole('button', { name: /Submit/i });
 expect(screen.queryByText('Error')).not.toBeInTheDocument();
 
 // PatternFly disabled buttons use aria-disabled, not disabled attribute
-expect(screen.getByRole('button', { name: /Delete/i }))
-  .toHaveAttribute('aria-disabled', 'true');
+expect(screen.getByRole('button', { name: /Delete/i })).toHaveAttribute('aria-disabled', 'true');
 
 // Waiting for loading to finish
 import { waitForLoadingToFinish } from '~/unit-test-utils';
@@ -451,16 +450,16 @@ beforeEach(() => {
 });
 ```
 
-### 5. Testing PF disabled state with wrong attribute
+### 5. Testing PF disabled state
 
-PatternFly uses `aria-disabled="true"` instead of the HTML `disabled` attribute:
+PF v6 changed how `isDisabled` works on native `<button>` elements — it now sets the HTML `disabled` attribute, not `aria-disabled`. Only `isAriaDisabled` sets `aria-disabled`.
 
 ```tsx
-// Wrong
-expect(button).toBeDisabled();
+// Button with isDisabled (native <button>) — use .toBeDisabled()
+expect(screen.getByRole('button', { name: /Delete/i })).toBeDisabled();
 
-// Correct for PF buttons with isAriaDisabled
-expect(button).toHaveAttribute('aria-disabled', 'true');
+// Button with isAriaDisabled — check aria-disabled
+expect(screen.getByRole('button', { name: /Create/i })).toHaveAttribute('aria-disabled', 'true');
 ```
 
 ### 6. Not using `act()` for state updates
@@ -497,6 +496,9 @@ export const mockMyFeature: MyFeatureKind = {
 
 export const mockMyFeatureList: MyFeatureKind[] = [
   mockMyFeature,
-  { ...mockMyFeature, metadata: { ...mockMyFeature.metadata, name: 'test-feature-2', uid: 'uid-2' } },
+  {
+    ...mockMyFeature,
+    metadata: { ...mockMyFeature.metadata, name: 'test-feature-2', uid: 'uid-2' },
+  },
 ];
 ```


### PR DESCRIPTION
## Fixes
Fixes: https://issues.redhat.com/browse/KFLUXUI-1435

## Description
Update developer guidelines to reflect PatternFly v6 API changes and migration patterns.

- **patternfly-guidelines.md** — update code examples to PF v6 APIs (e.g., `Content` instead of `TextContent`), document `createRawModalLauncher` for composable modals, add migration gotchas (JS token renames, CSS/OUIA prefix changes, `formik-pf` removal)
- **layout-and-pages.md** — add cross-reference to modal API docs, fix code formatting
- **unit-testing.md** — rewrite disabled button testing pitfall to cover PF v6 `isDisabled` vs `isAriaDisabled` behavior

## Type of change

- [x] Documentation content changes

## Screen shots / Gifs for design review
N/A — documentation only

## How to test or reproduce?
- Review the updated docs for accuracy against the PF v6 migration branch

## Browser conformance:
N/A — documentation only