### PR TITLE
fix(KFLUXUI-1491): fix Issues page test selectors

### DIFF
--- a/e2e-tests/support/pageObjects/pages-po.ts
+++ b/e2e-tests/support/pageObjects/pages-po.ts
@@ -120,9 +120,10 @@ export const namespacesPagePO = {
 };
 
 export const issuesPagePO = {
-  page: '[data-test="issues-data-test"]',
-  overviewTab: '[data-test="details__tabItem overview"]',
-  issuesTab: '[data-test="details__tabItem issues"]',
+  page: '[data-test="details"]',
+  pageDescription: 'Summary of issues in your Konflux content at any given point in time',
+  overviewTab: '[data-test="app-details__tabItem overview"]',
+  issuesTab: '[data-test="app-details__tabItem issues"]',
   serviceUnavailableState: '[data-test="service-unavailable-state"]',
   serviceUnavailableTitle: 'Service unavailable',
 };

--- a/e2e-tests/tests/basic-happy-path.spec.ts
+++ b/e2e-tests/tests/basic-happy-path.spec.ts
@@ -249,17 +249,16 @@ describe('Basic Happy Path', () => {
   describe('Check Issues page', () => {
     it('Navigate to Issues page from the sidebar', () => {
       Common.navigateTo(NavItem.issues);
+      Common.waitForLoad();
 
-      cy.get('body').then(($body) => {
-        if ($body.find(issuesPagePO.page).length) {
-          cy.get(issuesPagePO.page).should('exist');
-          cy.get(issuesPagePO.overviewTab).should('exist');
-          cy.get(issuesPagePO.issuesTab).should('exist');
-        } else {
-          cy.get(issuesPagePO.serviceUnavailableState).should('exist');
-          cy.contains(issuesPagePO.serviceUnavailableTitle).should('exist');
-        }
-      });
+      if (!Cypress.env('LOCAL_CLUSTER')) {
+        cy.get(issuesPagePO.page).contains(issuesPagePO.pageDescription).should('exist');
+        cy.get(issuesPagePO.overviewTab).should('exist');
+        cy.get(issuesPagePO.issuesTab).should('exist');
+      } else {
+        cy.get(issuesPagePO.serviceUnavailableState).should('exist');
+        cy.contains(issuesPagePO.serviceUnavailableTitle).should('exist');
+      }
     });
   });
 


### PR DESCRIPTION

## Fixes
https://issues.redhat.com/browse/KFLUXUI-1491

## Description
The Issues page e2e test was failing because the page object selectors didn't match the actual DOM:

- `issuesPagePO.page` used a `data-test` value that `DetailsPage` never renders - fixed to `[data-test="details"]`
- Tab selectors used wrong prefix (`details__tabItem` -> `app-details__tabItem`)
- Replaced `$body.find()` runtime DOM check with `Cypress.env('LOCAL_CLUSTER')` flag
- Added `pageDescription` field for Issues-page-specific assertion
- Added `Common.waitForLoad()` before assertions

## Type of change

- [x] Bugfix

## Screen shots / Gifs for design review
<!-- paste screenshot of passing e2e test here -->

The e2e test related to the "Issues" page is passing when running e2e locally:

<img width="1920" height="1009" alt="Screenshot 2026-07-10 at 12 29 50" src="https://github.com/user-attachments/assets/f33786a6-78f7-4221-ad7b-0948a74c836e" />


## How to test or reproduce?
- Run the e2e tests locally
- The "Check Issues page" test should pass

## Browser conformance:
- [x] Chrome