### PR TITLE
fix(KFLUXUI-1507): handle grant access step in stage login flow

### DIFF
--- a/e2e-tests/support/pageObjects/login-po.ts
+++ b/e2e-tests/support/pageObjects/login-po.ts
@@ -3,6 +3,9 @@ export const stageLoginPO = {
   password: '#password',
   loginButton: '#submit',
   dex: `button[type="submit"]`,
+  approveButton: 'input[name="approve"]',
+  grantAccessClass: `.dex-btn-text`,
+  grantAccessText: 'Grant Access',
 };
 
 export const localKonfluxLoginPO = {

--- a/e2e-tests/utils/Login.ts
+++ b/e2e-tests/utils/Login.ts
@@ -76,14 +76,14 @@ export class Login {
     cy.get(stageLoginPO.username).type(username);
     cy.get(stageLoginPO.password).type(password, { log: false });
     cy.get(stageLoginPO.loginButton).click();
+
     // Click through OAuth consent page if it appears
-    cy.get(`${stageLoginPO.approveButton}, ${stageLoginPO.grantAccessClass}`, { timeout: 30000 })
-      .first()
-      .then(($el) => {
-        if ($el.is(stageLoginPO.approveButton)) {
-          cy.wrap($el).click();
-        }
-      });
+    cy.get('body', { timeout: 30000 }).then(($body) => {
+      if ($body.find(stageLoginPO.approveButton).length > 0) {
+        cy.get(stageLoginPO.approveButton).click();
+      }
+    });
+    // Grant Access is always required
     cy.contains(stageLoginPO.grantAccessClass, stageLoginPO.grantAccessText).click();
 
     // ----- Workaround -----

--- a/e2e-tests/utils/Login.ts
+++ b/e2e-tests/utils/Login.ts
@@ -76,15 +76,25 @@ export class Login {
     cy.get(stageLoginPO.username).type(username);
     cy.get(stageLoginPO.password).type(password, { log: false });
     cy.get(stageLoginPO.loginButton).click();
+    // Click through OAuth consent page if it appears
+    cy.get(`${stageLoginPO.approveButton}, ${stageLoginPO.grantAccessClass}`, { timeout: 30000 })
+      .first()
+      .then(($el) => {
+        if ($el.is(stageLoginPO.approveButton)) {
+          cy.wrap($el).click();
+        }
+      });
+    cy.contains(stageLoginPO.grantAccessClass, stageLoginPO.grantAccessText).click();
 
     // ----- Workaround -----
     // Sometimes page doesn't go to homepage but shows
     // "Something went wrong - Invalid token" message.
-    cy.contains('You have successfully logged into Red Hat Internal SSO', {
-      timeout: 10000,
-    }).should('be.visible');
-    cy.wait(2000);
-    cy.visit(Cypress.env('KONFLUX_BASE_URL'));
+    cy.get('body', { timeout: 10000 }).then(($body) => {
+      if ($body.text().includes('You have successfully logged into Red Hat Internal SSO')) {
+        cy.wait(2000);
+        cy.visit(Cypress.env('KONFLUX_BASE_URL'));
+      }
+    });
     // ----- end of workaround -----
 
     this.waitForApps();


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->

Fixes: https://issues.redhat.com/browse/KFLUXUI-1507

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Handle OAuth "Authorize Access" and Dex "Grant Access" consent pages that now appear during stage login. Both steps are conditional since they may be skipped depending on session state. Also makes the SSO redirect workaround non-blocking.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the end-to-end login page object with additional selectors for the “Grant Access” action.
  * Improved the login flow to conditionally handle an optional OAuth consent/approval step when present.
  * Extended the stage login flow to perform “Grant Access” before continuing with the existing workaround and navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->