### PR TITLE
chore(#1168): remove stale patternfly-v6 CI triggers

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches:
       - main
-      - patternfly-v6
   merge_group:
     types: [checks_requested]
   # Triggers the workflow on manual dispatch

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - main
-      - patternfly-v6
 
 # Cancel in-progress runs when new commits are pushed to main
 concurrency:


### PR DESCRIPTION
## Fixes

Fixes #1168

## Description

Removes the stale `patternfly-v6` branch trigger from the pull-request and post-merge workflows. The feature branch was merged into `main`, so retaining these entries leaves dead CI configuration that suggests the branch is still active.

## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review

Not applicable. This change only updates GitHub Actions branch filters.

## How to test or reproduce?

- Confirm `rg 'patternfly-v6' .github/workflows` returns no matches.
- Parse `.github/workflows/main.yaml` and `.github/workflows/post-merge.yaml` as YAML; both remain valid.
- Confirm the remaining `main` branch triggers are unchanged.

## Browser conformance:

Not applicable. There are no UI or browser-facing changes.

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow triggers to run only for pull requests and pushes targeting the `main` branch.
  * Removed workflow execution for the `patternfly-v6` branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->