### PR TITLE
chore(KFLUXUI-1487): tighten renovate auto-merge rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,13 @@
   "packageRules": [
     {
       "description": "Automerge minor, patch, and digest updates for package versions",
-      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "matchUpdateTypes": ["patch", "digest"],
+      "matchPackageNames": [
+        "!/^react(-dom)?$/",
+        "!/^@patternfly\\/.*$/",
+        "!/^@tanstack\\/.*$/",
+        "!/^webpack$/"
+      ],
       "automerge": true
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,8 @@
   "minimumReleaseAge": "7 days",
   "packageRules": [
     {
-      "description": "Automerge patch and digest updates, excluding core dependencies",
-      "matchUpdateTypes": ["patch", "digest"],
+      "description": "Automerge minor, patch and digest updates, excluding core dependencies",
+      "matchUpdateTypes": ["minor", "patch", "digest"],
       "matchPackageNames": [
         "!/^react(-dom)?$/",
         "!/^@patternfly\\/.*$/",

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "minimumReleaseAge": "7 days",
   "packageRules": [
     {
-      "description": "Automerge minor, patch, and digest updates for package versions",
+      "description": "Automerge patch and digest updates, excluding core dependencies",
       "matchUpdateTypes": ["patch", "digest"],
       "matchPackageNames": [
         "!/^react(-dom)?$/",


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->

Fixes https://issues.redhat.com/browse/KFLUXUI-1487

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


Tightens renovate auto-merge rules to reduce risk of unreviewed breaking changes:

**1. Remove `minor` from `matchUpdateTypes`** - only `patch` and `digest` updates are auto-merged now.
**2. Exclude core dependencies -** `react`, `react-dom`, `@patternfly/*`, `@tanstack/*`, and `webpack` require human review even for patch updates, since patches in these packages can still introduce subtle breakage.

**Why not `matchConfidence`?**

Renovate supports a [`matchConfidence`](https://docs.renovatebot.com/configuration-options/#matchconfidence) option that gates auto-merge on Merge Confidence data (age, adoption, test compatibility). However, it requires a Mend.io API token and is only available to Mend-hosted or licensed Renovate instances - it's not usable with Mintmaker setup.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

- validated config with `npx --package renovate -- renovate-config-validator renovate.json`
- verify next Renovate run respects the new rules (patch/digest PRs for excluded packages should no longer auto-merge)

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update rules to refine what qualifies for automatic merging (now still limited to patch and digest, with improved wording).
  * Added additional filtering to prevent specific key dependency names and related package scopes from being matched for automatic merges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->