### PR TITLE
fix(KFLUXSE-368): search Conforma results by rule code with dots and underscores

### DIFF
--- a/src/components/Conforma/ConformaResultsTab/ConformaGroupedTable.tsx
+++ b/src/components/Conforma/ConformaResultsTab/ConformaGroupedTable.tsx
@@ -43,6 +43,7 @@ const DetailSubTable: React.FC<{ rows: ConformaResultRow[] }> = ({ rows }) => (
                 <Content component="p">
                   <strong>{row.title ?? '-'}</strong>
                 </Content>
+                {row.code && <Content component="small">{row.code}</Content>}
                 {row.description && <Content component="small">{row.description}</Content>}
               </Content>
             </Td>

--- a/src/components/Conforma/ConformaResultsTab/__tests__/ConformaGroupedTable.spec.tsx
+++ b/src/components/Conforma/ConformaResultsTab/__tests__/ConformaGroupedTable.spec.tsx
@@ -284,6 +284,29 @@ describe('ConformaGroupedTable', () => {
     expect(screen.getAllByText('-').length).toBeGreaterThanOrEqual(1);
   });
 
+  it('renders row code in the detail sub-table when present', () => {
+    const groupsWithCode: GroupedConformaRow[] = [
+      {
+        groupKey: 'Trusted task rule',
+        violations: 1,
+        warnings: 0,
+        successes: 0,
+        rows: [createRow({ code: 'trusted_task.trusted' })],
+      },
+    ];
+    const expandedGroups = new Set(['Trusted task rule']);
+
+    routerRenderer(
+      <ConformaGroupedTable
+        {...defaultProps}
+        groups={groupsWithCode}
+        expandedGroups={expandedGroups}
+      />,
+    );
+
+    expect(screen.getByText('trusted_task.trusted')).toBeInTheDocument();
+  });
+
   it('renders empty string msg instead of falling back to dash', () => {
     const groupsWithEmptyMsg: GroupedConformaRow[] = [
       {

--- a/src/components/Conforma/ConformaResultsTab/__tests__/conforma-grouping-utils.spec.ts
+++ b/src/components/Conforma/ConformaResultsTab/__tests__/conforma-grouping-utils.spec.ts
@@ -525,5 +525,24 @@ describe('conforma-grouping-utils', () => {
     it('returns empty array for empty input', () => {
       expect(filterResults([], 'test', [])).toHaveLength(0);
     });
+
+    it('filters by search text matching code even when title has no matching punctuation', () => {
+      const rows = [
+        mockRow({
+          code: 'trusted.task_trusted_rule',
+          title: 'Trusted Task Check',
+          component: 'build-service',
+        }),
+        ...sampleRows,
+      ];
+
+      const underscoreResults = filterResults(rows, 'trusted_', []);
+      expect(underscoreResults).toHaveLength(1);
+      expect(underscoreResults[0].code).toBe('trusted.task_trusted_rule');
+
+      const dotResults = filterResults(rows, 'trusted.', []);
+      expect(dotResults).toHaveLength(1);
+      expect(dotResults[0].code).toBe('trusted.task_trusted_rule');
+    });
   });
 });


### PR DESCRIPTION


## Fixes 
https://redhat.atlassian.net/browse/KFLUXSE-368


## Description
Include row.code in filterResults so searches match the displayed group label, and show code in detail rows so code-only matches are visible when grouped by component.

Assisted-by: Cursor


## Type of change
- [x] Bugfix


## Browser conformance: 
- [x] Chrome


<!-- ## Checklist: -->

<!-- 
- [x] Code follows the style guidelines
- [x] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [x] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Display rule code snippets in expanded Conforma result details when available.
  * Search Conforma results by rule code, in addition to title and component.

* **Bug Fixes**
  * Improved matching for rule codes containing underscores and periods.

* **Tests**
  * Added coverage for displaying and filtering results by rule code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->