### PR TITLE
fix(KFLUXUI-1511): remove redundant table wrapper in ConformaTable

### DIFF
--- a/src/components/Conforma/ConformaTable/ConformaTable.tsx
+++ b/src/components/Conforma/ConformaTable/ConformaTable.tsx
@@ -71,31 +71,29 @@ export const ConformaTable: React.FC<React.PropsWithChildren<ConformaTableProps>
   }, [activeSortDirection, activeSortIndex, crResult]);
 
   return sortedCRResult ? (
-    <div className="pf-v6-c-table pf-m-compact pf-m-grid-md">
-      <Table
-        virtualize
-        data={sortedCRResult}
-        aria-label="conforma-table"
-        Header={ConformaHeader}
-        ExpandedContent={(props) => {
-          const obj = props.obj as UIConformaData;
-          return <ConformaExpandedRowContent {...props} obj={obj} />;
-        }}
-        Row={(props) => {
-          const obj = props.obj as UIConformaData;
+    <Table
+      virtualize
+      data={sortedCRResult}
+      aria-label="conforma-table"
+      Header={ConformaHeader}
+      ExpandedContent={(props) => {
+        const obj = props.obj as UIConformaData;
+        return <ConformaExpandedRowContent {...props} obj={obj} />;
+      }}
+      Row={(props) => {
+        const obj = props.obj as UIConformaData;
 
-          return (
-            <WrappedConformaRow
-              {...props}
-              obj={obj}
-              customData={{ sortedConformaResult: sortedCRResult }}
-            />
-          );
-        }}
-        loaded
-        customData={{ sortedCRResult }}
-        expand
-      />
-    </div>
+        return (
+          <WrappedConformaRow
+            {...props}
+            obj={obj}
+            customData={{ sortedConformaResult: sortedCRResult }}
+          />
+        );
+      }}
+      loaded
+      customData={{ sortedCRResult }}
+      expand
+    />
   ) : null;
 };


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->

Fixes https://issues.redhat.com/browse/KFLUXUI-1511

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The `ConformaTable` had a redundant `<div className="pf-v6-c-table pf-m-compact pf-m-grid-md">` wrapping the shared `Table` component. This was unnecessary because `VirtualBody` already applies `pf-v6-c-table` and `pf-m-compact` internally.

The `pf-m-grid-md` modifier, when combined with expandable rows (`pf-m-expandable`), causes PF v6 to explicitly zero out row border widths - removing the dividers between rows.

Removing the redundant wrapper fixes the missing dividers and eliminates the double `pf-v6-c-table` nesting.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

| Before | After |
|--------|--------|
| <img width="1920" height="1015" alt="pf-v6-security-tab-rows-missing-border-ISSUE" src="https://github.com/user-attachments/assets/e5681ddb-fc88-41c9-aa89-159ff8f447cd" /> | <img width="1919" height="1013" alt="pf-v6-security-tab-rows-missing-border-FIX" src="https://github.com/user-attachments/assets/992e4326-e525-4761-bff8-a053d016aea7" /> |

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

1. Open the Security tab
2. Verify that table rows have visible dividers between them
3. Expand a row and verify the layout still looks correct

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table rendering by removing an unnecessary wrapper while preserving virtualization, accessibility labels, expandable rows, and existing table behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->