### PR TITLE
refactor(KFLUXUI-1512): wrap content with ModalBody

### DIFF
--- a/src/components/UserAccess/UserAccessChangeRoleModal.tsx
+++ b/src/components/UserAccess/UserAccessChangeRoleModal.tsx
@@ -16,6 +16,7 @@ import {
   SelectOption,
   Spinner,
   Content,
+  ModalBody,
 } from '@patternfly/react-core';
 import textStyles from '@patternfly/react-styles/css/utilities/Text/text.mjs';
 import { useRoleMap } from '~/hooks/useRole';
@@ -202,109 +203,111 @@ export const UserAccessChangeRoleModal: React.FC<UserAccessChangeRoleModalProps>
       onClose={handleClose}
       appendTo={() => document.querySelector('#hacDev-modal-container') ?? document.body}
     >
-      <Flex direction={{ default: 'column' }} gap={{ default: 'gapMd' }}>
-        <FlexItem>
-          <Content>
-            Change role for {selectedCount} user{selectedCount !== 1 ? 's' : ''} (highest role
-            displayed)
-          </Content>
-        </FlexItem>
-        {hasUnrankedRoles ? (
+      <ModalBody>
+        <Flex direction={{ default: 'column' }} gap={{ default: 'gapMd' }}>
           <FlexItem>
-            <Alert variant={AlertVariant.danger} title="Unsupported roles" isInline>
-              Cannot evaluate role changes for: {unrankedRoleRefs.join(', ')}. These role bindings
-              reference roles that are not listed in the cluster Konflux configuration, or the
-              configuration order is invalid. Update konflux-public-info or remove affected users
-              before continuing.
+            <Content>
+              Change role for {selectedCount} user{selectedCount !== 1 ? 's' : ''} (highest role
+              displayed)
+            </Content>
+          </FlexItem>
+          {hasUnrankedRoles ? (
+            <FlexItem>
+              <Alert variant={AlertVariant.danger} title="Unsupported roles" isInline>
+                Cannot evaluate role changes for: {unrankedRoleRefs.join(', ')}. These role bindings
+                reference roles that are not listed in the cluster Konflux configuration, or the
+                configuration order is invalid. Update konflux-public-info or remove affected users
+                before continuing.
+              </Alert>
+            </FlexItem>
+          ) : null}
+          <FlexItem>
+            <Alert variant={AlertVariant.warning} title="Role change information" isInline>
+              When changing access, the user will be removed from all role bindings in the current
+              namespace and then added to the new role binding in the namespace. If any selected
+              role binding contains multiple users, the role binding will be split and the users not
+              selected will be added to the new role binding with the same role.
             </Alert>
           </FlexItem>
-        ) : null}
-        <FlexItem>
-          <Alert variant={AlertVariant.warning} title="Role change information" isInline>
-            When changing access, the user will be removed from all role bindings in the current
-            namespace and then added to the new role binding in the namespace. If any selected role
-            binding contains multiple users, the role binding will be split and the users not
-            selected will be added to the new role binding with the same role.
-          </Alert>
-        </FlexItem>
-        <FlexItem>
-          <List className="user-access-change-role-modal__user-list">
-            {[...selectedRowKeys].map((rowKey) => {
-              const { username, subjectKind } = splitRowKey(rowKey);
+          <FlexItem>
+            <List className="user-access-change-role-modal__user-list">
+              {[...selectedRowKeys].map((rowKey) => {
+                const { username, subjectKind } = splitRowKey(rowKey);
 
-              return (
-                <ListItem key={rowKey}>
-                  <span className={textStyles.fontWeightBold}>
-                    {username} ({subjectKind})
-                  </span>
-                  : {getUserHighestRole(username)}
-                </ListItem>
-              );
-            })}
-          </List>
-        </FlexItem>
+                return (
+                  <ListItem key={rowKey}>
+                    <span className={textStyles.fontWeightBold}>
+                      {username} ({subjectKind})
+                    </span>
+                    : {getUserHighestRole(username)}
+                  </ListItem>
+                );
+              })}
+            </List>
+          </FlexItem>
 
-        <FlexItem>
-          <Flex direction={{ default: 'column' }}>
-            <FlexItem className="user-access-change-role-modal__role-label">
-              <Content data-test="user-access-change-role-label">New role*</Content>
-            </FlexItem>
-            <FlexItem>
-              {roleMapLoaded && roleMap ? (
-                <Select
-                  toggle={(toggleRef) => (
-                    <MenuToggle
-                      ref={toggleRef}
-                      data-test="user-access-change-role-select"
-                      isExpanded={isRoleSelectOpen}
-                      onClick={() => setRoleSelectOpen(!isRoleSelectOpen)}
-                      isDisabled={roleSelectOptions.length === 0 || isSaving}
-                      isFullWidth
-                    >
-                      {modalSelectedRoleRef
-                        ? (roleMap.roleMap[modalSelectedRoleRef] ?? modalSelectedRoleRef)
-                        : 'Select a role'}
-                    </MenuToggle>
-                  )}
-                  onSelect={(_, val) => {
-                    if (typeof val === 'string') {
-                      setModalSelectedRoleRef(val);
-                    }
-                    setRoleSelectOpen(false);
-                    setSaveError(null);
-                  }}
-                  selected={modalSelectedRoleRef}
-                  isOpen={isRoleSelectOpen}
-                  onOpenChange={setRoleSelectOpen}
-                >
-                  <SelectList>
-                    {roleSelectOptions.map(([refName, displayName]) => (
-                      <SelectOption key={refName} value={refName}>
-                        {displayName}
-                      </SelectOption>
-                    ))}
-                  </SelectList>
-                </Select>
-              ) : (
-                <Spinner size="sm" />
-              )}
-            </FlexItem>
-
-            {saveError ? (
-              <FlexItem>
-                <Alert
-                  variant={AlertVariant.danger}
-                  title="Unable to change roles"
-                  isInline
-                  data-test="user-access-change-role-save-error"
-                >
-                  {saveError}
-                </Alert>
+          <FlexItem>
+            <Flex direction={{ default: 'column' }}>
+              <FlexItem className="user-access-change-role-modal__role-label">
+                <Content data-test="user-access-change-role-label">New role*</Content>
               </FlexItem>
-            ) : null}
-          </Flex>
-        </FlexItem>
-      </Flex>
+              <FlexItem>
+                {roleMapLoaded && roleMap ? (
+                  <Select
+                    toggle={(toggleRef) => (
+                      <MenuToggle
+                        ref={toggleRef}
+                        data-test="user-access-change-role-select"
+                        isExpanded={isRoleSelectOpen}
+                        onClick={() => setRoleSelectOpen(!isRoleSelectOpen)}
+                        isDisabled={roleSelectOptions.length === 0 || isSaving}
+                        isFullWidth
+                      >
+                        {modalSelectedRoleRef
+                          ? (roleMap.roleMap[modalSelectedRoleRef] ?? modalSelectedRoleRef)
+                          : 'Select a role'}
+                      </MenuToggle>
+                    )}
+                    onSelect={(_, val) => {
+                      if (typeof val === 'string') {
+                        setModalSelectedRoleRef(val);
+                      }
+                      setRoleSelectOpen(false);
+                      setSaveError(null);
+                    }}
+                    selected={modalSelectedRoleRef}
+                    isOpen={isRoleSelectOpen}
+                    onOpenChange={setRoleSelectOpen}
+                  >
+                    <SelectList>
+                      {roleSelectOptions.map(([refName, displayName]) => (
+                        <SelectOption key={refName} value={refName}>
+                          {displayName}
+                        </SelectOption>
+                      ))}
+                    </SelectList>
+                  </Select>
+                ) : (
+                  <Spinner size="sm" />
+                )}
+              </FlexItem>
+
+              {saveError ? (
+                <FlexItem>
+                  <Alert
+                    variant={AlertVariant.danger}
+                    title="Unable to change roles"
+                    isInline
+                    data-test="user-access-change-role-save-error"
+                  >
+                    {saveError}
+                  </Alert>
+                </FlexItem>
+              ) : null}
+            </Flex>
+          </FlexItem>
+        </Flex>
+      </ModalBody>
       <ModalFooter>
         {isSaving ? (
           <Button key="save" variant="primary" isDisabled isLoading>

--- a/src/components/UserAccess/UserAccessChangeRoleModal.tsx
+++ b/src/components/UserAccess/UserAccessChangeRoleModal.tsx
@@ -204,11 +204,11 @@ export const UserAccessChangeRoleModal: React.FC<UserAccessChangeRoleModalProps>
       onClose={handleClose}
       appendTo={() => document.querySelector('#hacDev-modal-container') ?? document.body}
     >
-      <ModalBody>
-        <ModalHeader
-          title={`Change role for ${selectedCount} user${selectedCount !== 1 ? 's' : ''} (highest role
+      <ModalHeader
+        title={`Change role for ${selectedCount} user${selectedCount !== 1 ? 's' : ''} (highest role
               displayed)`}
-        />
+      />
+      <ModalBody>
         <Flex direction={{ default: 'column' }} gap={{ default: 'gapMd' }}>
           {hasUnrankedRoles ? (
             <FlexItem>

--- a/src/components/UserAccess/UserAccessChangeRoleModal.tsx
+++ b/src/components/UserAccess/UserAccessChangeRoleModal.tsx
@@ -17,6 +17,7 @@ import {
   Spinner,
   Content,
   ModalBody,
+  ModalHeader,
 } from '@patternfly/react-core';
 import textStyles from '@patternfly/react-styles/css/utilities/Text/text.mjs';
 import { useRoleMap } from '~/hooks/useRole';
@@ -204,13 +205,11 @@ export const UserAccessChangeRoleModal: React.FC<UserAccessChangeRoleModalProps>
       appendTo={() => document.querySelector('#hacDev-modal-container') ?? document.body}
     >
       <ModalBody>
+        <ModalHeader
+          title={`Change role for ${selectedCount} user${selectedCount !== 1 ? 's' : ''} (highest role
+              displayed)`}
+        />
         <Flex direction={{ default: 'column' }} gap={{ default: 'gapMd' }}>
-          <FlexItem>
-            <Content>
-              Change role for {selectedCount} user{selectedCount !== 1 ? 's' : ''} (highest role
-              displayed)
-            </Content>
-          </FlexItem>
           {hasUnrankedRoles ? (
             <FlexItem>
               <Alert variant={AlertVariant.danger} title="Unsupported roles" isInline>


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->

Fixes https://issues.redhat.com/browse/KFLUXUI-1512

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The User Access change role modal had broken layout because part of its content was not wrapped inside `ModalBody`. This caused the modal body and footer to render without proper spacing and structure.

Wrapped the content in `ModalBody` to match the composable Modal pattern used elsewhere.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

| Header | Header |
|--------|--------|
| <img width="1920" height="1015" alt="pf-v6-user-access-change-role-modal-layout-broken-ISSUE" src="https://github.com/user-attachments/assets/c84b988f-3aea-4f0d-bd68-653a96706b65" /> | <img width="1920" height="1014" alt="pf-v6-user-access-change-role-modal-layout-broken-FIX" src="https://github.com/user-attachments/assets/c8abd338-204f-4d41-9cf0-939b63fd386c" /> | 


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

1. Navigate to User Access page
2. Select one/multiple users and click the `Change access` button
3. Verify the modal has proper spacing between body content and footer buttons

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the Change Role modal layout by restructuring the main content area to use PatternFly’s `ModalBody`.
  * Moved the dynamic “change role for … (highest role displayed)” text into the modal header, while keeping the same alerts, user selection display, controls, and save/cancel behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->