### PR TITLE
refactor(KFLUXUI-1523): fix nav item height for feature flag indicators

### DIFF
--- a/src/AppRoot/AppSideBar.tsx
+++ b/src/AppRoot/AppSideBar.tsx
@@ -63,7 +63,12 @@ export const AppSideBar: React.FC<{ isOpen: boolean }> = ({ isOpen }) => {
                     namespace ? COMPONENTS_PATH.createPath({ workspaceName: namespace }) : undefined
                   }
                 >
-                  Components <FeatureFlagIndicator flags={['components-page']} />
+                  Components{' '}
+                  <FeatureFlagIndicator
+                    flags={['components-page']}
+                    hasNoPadding
+                    popOverTriggerAction="hover"
+                  />
                 </Link>
               </NavItem>
             </IfFeature>
@@ -115,7 +120,12 @@ export const AppSideBar: React.FC<{ isOpen: boolean }> = ({ isOpen }) => {
                       : undefined
                   }
                 >
-                  Pipeline Runs <FeatureFlagIndicator flags={['pipeline-runs-page']} />
+                  Pipeline Runs{' '}
+                  <FeatureFlagIndicator
+                    flags={['pipeline-runs-page']}
+                    hasNoPadding
+                    popOverTriggerAction="hover"
+                  />
                 </Link>
               </NavItem>
             </IfFeature>

--- a/src/feature-flags/FeatureFlagIndicator.tsx
+++ b/src/feature-flags/FeatureFlagIndicator.tsx
@@ -9,6 +9,7 @@ import {
   FlexItem,
   List,
   ListItem,
+  PopoverProps,
 } from '@patternfly/react-core';
 import { FlaskIcon } from '@patternfly/react-icons/dist/esm/icons/flask-icon';
 import { FLAGS, FLAGS_STATUS, type FlagKey } from './flags';
@@ -18,6 +19,8 @@ type FeatureFlagIndicatorProps = {
   flags: FlagKey[];
   fullLabel?: boolean;
   'data-test'?: string;
+  hasNoPadding?: boolean;
+  popOverTriggerAction?: PopoverProps['triggerAction'];
 };
 
 const warningColor = 'var(--pf-t--global--color--status--warning--default)';
@@ -27,6 +30,8 @@ export const FeatureFlagIndicator: React.FC<FeatureFlagIndicatorProps> = ({
   flags,
   fullLabel = false,
   'data-test': dataTest,
+  hasNoPadding = false,
+  popOverTriggerAction = 'click',
 }) => {
   const [allFlags] = useFeatureFlags();
   const activeFlags = flags.filter((f) => allFlags[f]);
@@ -67,6 +72,7 @@ export const FeatureFlagIndicator: React.FC<FeatureFlagIndicatorProps> = ({
       variant="plain"
       aria-label="Feature flag information"
       data-test={dataTest ?? `ff-indicator-${flags.join('-')}`}
+      hasNoPadding={hasNoPadding}
     >
       <Label icon={<FlaskIcon style={iconStyle} />} color={labelColor}>
         {statusText}
@@ -78,13 +84,19 @@ export const FeatureFlagIndicator: React.FC<FeatureFlagIndicatorProps> = ({
       variant="plain"
       aria-label="Feature flag information"
       data-test={dataTest ?? `ff-indicator-${flags.join('-')}`}
+      hasNoPadding={hasNoPadding}
     >
       <FlaskIcon style={iconStyle} />
     </Button>
   );
 
   return (
-    <Popover position="right" headerContent={header} bodyContent={body}>
+    <Popover
+      position="right"
+      headerContent={header}
+      bodyContent={body}
+      triggerAction={popOverTriggerAction}
+    >
       {trigger}
     </Popover>
   );


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->

Fixes https://issues.redhat.com/browse/KFLUXUI-1523

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Nav items that include a feature flag indicator badge had more height than other nav items, causing misalignment in the sidebar navigation.

The extra height came from the default Button padding on the `FeatureFlagIndicator` component. Added `hasNoPadding` and `popoverTriggerAction` props to `FeatureFlagIndicator` to allow callers to control these behaviors, then used them in `AppSideBar` to:
- remove the extra padding so nav items have consistent height
- change the popover trigger from click to hover for better UX in the sidebar context

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

| Before | After |
|--------|--------|
| <img width="293" height="436" alt="pf-v6-nav-item-different-hight-when-it-has-ff-indicator-ISSUE" src="https://github.com/user-attachments/assets/76b2575c-1e06-40f0-bbe9-f303ed6c6be1" /> | <img width="291" height="366" alt="pf-v6-nav-item-different-hight-when-it-has-ff-indicator-FIX" src="https://github.com/user-attachments/assets/62f02ce2-1663-41ac-874a-4a6e2fac1a5c" /> | 




## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

1. Enable a feature flag (e.g., `components-page`) so the indicator badge appears in the sidebar
2. Verify the nav item with the badge has the same height as other nav items
3. Hover over the badge to see the popover (should not require a click)

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated feature flag indicators in the sidebar for clearer, more consistent presentation.
  * Indicators can now display without extra padding and reveal details on hover where applicable.
  * Improved flexibility for how feature flag information is opened across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->