### PR TITLE
refactor(KFLUXUI-1525): use createRawModalLauncher for SavedViewDeleteModal

### DIFF
--- a/src/shared/components/SavedViews/SavedViewDeleteModal.tsx
+++ b/src/shared/components/SavedViews/SavedViewDeleteModal.tsx
@@ -1,46 +1,65 @@
 import * as React from 'react';
-import { Button, ButtonVariant, Content, ModalVariant } from '@patternfly/react-core';
-import { ComponentProps, createModalLauncher } from '~/shared/components/modal/createModalLauncher';
+import {
+  Button,
+  ButtonVariant,
+  Content,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+} from '@patternfly/react-core';
+import {
+  RawComponentProps,
+  createRawModalLauncher,
+} from '~/shared/components/modal/createModalLauncher';
 
-type SavedViewDeleteModalProps = ComponentProps & {
+type SavedViewDeleteModalProps = RawComponentProps & {
   viewLabel: string;
   onDelete: () => void;
 };
 
-export const SavedViewDeleteModal: React.FC<SavedViewDeleteModalProps> = ({
+export const SavedViewDeleteModal: React.FC<React.PropsWithChildren<SavedViewDeleteModalProps>> = ({
   onClose,
   viewLabel,
   onDelete,
+  modalProps,
 }) => {
+  const { isOpen, variant, title, ...rest } = modalProps || {};
+
   const handleDelete = () => {
     onDelete();
-    onClose();
+    onClose?.();
   };
 
   return (
-    <>
-      <Content>
+    <Modal {...rest} variant={variant} isOpen={isOpen} onClose={onClose}>
+      <ModalHeader title={title} />
+      <ModalBody>
         <Content>
           Are you sure you want to delete <strong>{viewLabel}</strong>? This action cannot be
           undone.
         </Content>
-      </Content>
-      <Button
-        variant={ButtonVariant.danger}
-        onClick={handleDelete}
-        data-test="saved-view-delete-confirm"
-      >
-        Delete
-      </Button>
-      <Button variant={ButtonVariant.link} onClick={() => onClose()}>
-        Cancel
-      </Button>
-    </>
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          variant={ButtonVariant.danger}
+          onClick={handleDelete}
+          data-test="saved-view-delete-confirm"
+        >
+          Delete
+        </Button>
+        <Button variant={ButtonVariant.link} onClick={() => onClose?.()}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
   );
 };
 
-export const createSavedViewDeleteModal = createModalLauncher(SavedViewDeleteModal, {
-  'data-test': 'saved-view-delete-modal',
-  title: 'Delete saved view',
-  variant: ModalVariant.small,
-});
+export const createSavedViewDeleteModal = (props: SavedViewDeleteModalProps) =>
+  createRawModalLauncher(SavedViewDeleteModal, {
+    'data-test': 'saved-view-delete-modal',
+    title: 'Delete saved view',
+    variant: ModalVariant.small,
+  })(props);

--- a/src/shared/components/SavedViews/__tests__/SavedViewDeleteModal.spec.tsx
+++ b/src/shared/components/SavedViews/__tests__/SavedViewDeleteModal.spec.tsx
@@ -4,6 +4,9 @@ import { SavedViewDeleteModal } from '../SavedViewDeleteModal';
 describe('SavedViewDeleteModal', () => {
   const mockOnClose = jest.fn();
   const mockOnDelete = jest.fn();
+  const modalProps = { isOpen: true } as React.ComponentProps<
+    typeof SavedViewDeleteModal
+  >['modalProps'];
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -11,7 +14,12 @@ describe('SavedViewDeleteModal', () => {
 
   it('renders view label in confirmation text', () => {
     render(
-      <SavedViewDeleteModal onClose={mockOnClose} onDelete={mockOnDelete} viewLabel="My View" />,
+      <SavedViewDeleteModal
+        onClose={mockOnClose}
+        onDelete={mockOnDelete}
+        viewLabel="My View"
+        modalProps={modalProps}
+      />,
     );
 
     expect(screen.getByText('My View')).toBeInTheDocument();
@@ -21,7 +29,12 @@ describe('SavedViewDeleteModal', () => {
 
   it('calls onDelete on Delete click', () => {
     render(
-      <SavedViewDeleteModal onClose={mockOnClose} onDelete={mockOnDelete} viewLabel="My View" />,
+      <SavedViewDeleteModal
+        onClose={mockOnClose}
+        onDelete={mockOnDelete}
+        viewLabel="My View"
+        modalProps={modalProps}
+      />,
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
@@ -32,7 +45,12 @@ describe('SavedViewDeleteModal', () => {
 
   it('closes without calling onDelete on Cancel', () => {
     render(
-      <SavedViewDeleteModal onClose={mockOnClose} onDelete={mockOnDelete} viewLabel="My View" />,
+      <SavedViewDeleteModal
+        onClose={mockOnClose}
+        onDelete={mockOnDelete}
+        viewLabel="My View"
+        modalProps={modalProps}
+      />,
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->

Fixes: https://issues.redhat.com/browse/KFLUXUI-KFLUXUI-1525

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Migrate `SavedViewDeleteModal` from `createModalLauncher` to `createRawModalLauncher` so the component controls its own `Modal` structure (`ModalHeader`, `ModalBody`, `ModalFooter`).

This fixes the missing spacing between body content and footer action buttons.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

| Before | After |
|--------|--------|
| <img width="657" height="242" alt="pf-vs-saved-view-delete-modal-broken-layout-ISSUE" src="https://github.com/user-attachments/assets/132e8678-e3b3-4d65-8fb5-ade1e7dd7a95" /> | <img width="659" height="263" alt="pf-vs-saved-view-delete-modal-broken-layout-FIX" src="https://github.com/user-attachments/assets/320cc954-4c1b-49e1-9dee-23a54a9351ca" /> | 


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

- Turn on "Cross-application Pipeline Runs page" feature flag
- Navigate to Pipeline Runs page (left nav item)
- Save a view
- On the left nav item, click the delete button on the saved view
- Verify the delete confirmation modal renders correctly with proper spacing between body text and footer buttons (Delete / Cancel)

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the saved view deletion dialog to use a standard modal layout with a header, body, footer, and configurable modal properties.
  * Improved modal controls so closing remains safe when no close handler is provided.

* **Bug Fixes**
  * Delete and Cancel actions now close the dialog consistently while preserving their expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->