### PR TITLE
chore(KFLUXSE-367): speed up Conforma results with bounded fetch and settling UI

### DIFF
--- a/src/components/Conforma/ConformaResultsTab/ConformaResultsTab.tsx
+++ b/src/components/Conforma/ConformaResultsTab/ConformaResultsTab.tsx
@@ -4,6 +4,7 @@ import {
   Alert,
   AlertVariant,
   Bullseye,
+  Flex,
   PageSection,
   Content,
   ContentVariants,
@@ -23,6 +24,7 @@ import {
 } from './conforma-grouping-utils';
 import { ConformaGroupedTable } from './ConformaGroupedTable';
 import { ConformaResultsToolbar } from './ConformaResultsToolbar';
+import { ConformaSettlingAnnouncement } from './ConformaSettlingAnnouncement';
 import { ConformaSummaryBar } from './ConformaSummaryBar';
 import { useApplicationConformaResults } from './useApplicationConformaResults';
 import { useConformaFilters } from './useConformaFilters';
@@ -41,6 +43,7 @@ const ConformaResultsTabContent: React.FC = () => {
     totalComponents,
     totalFailed,
     loaded,
+    settling,
     error,
     partialLogError,
     refresh,
@@ -133,7 +136,7 @@ const ConformaResultsTabContent: React.FC = () => {
     );
   }
 
-  const isEmpty = allResults.length === 0;
+  const isEmpty = allResults.length === 0 && !settling;
 
   return (
     <>
@@ -147,7 +150,11 @@ const ConformaResultsTabContent: React.FC = () => {
             validating them against a clearly defined policy.
           </Content>
         </Content>
-        <div className="conforma-results-tab__summary-wrapper">
+        <div
+          className="conforma-results-tab__summary-wrapper"
+          aria-busy={settling}
+          data-test="conforma-results-summary-wrapper"
+        >
           <ConformaSummaryBar
             totalComponents={totalComponents}
             totalFailed={totalFailed}
@@ -158,6 +165,11 @@ const ConformaResultsTabContent: React.FC = () => {
             totalWarningsRaw={rawCounts.totalWarnings}
             totalSuccessesRaw={rawCounts.totalSuccesses}
           />
+          {settling ? (
+            <Flex justifyContent={{ default: 'justifyContentCenter' }}>
+              <Spinner size="md" aria-label="Updating summary" />
+            </Flex>
+          ) : null}
         </div>
       </PageSection>
 
@@ -194,9 +206,13 @@ const ConformaResultsTabContent: React.FC = () => {
             </Content>
           </Bullseye>
         ) : groups.length === 0 ? (
-          <Bullseye>
-            <Content component={ContentVariants.p}>No results match the current filters.</Content>
-          </Bullseye>
+          settling ? null : (
+            <Bullseye>
+              <Content component={ContentVariants.p}>
+                No results match the current filters.
+              </Content>
+            </Bullseye>
+          )
         ) : (
           <ConformaGroupedTable
             groups={groups}
@@ -206,6 +222,8 @@ const ConformaResultsTabContent: React.FC = () => {
           />
         )}
       </PageSection>
+
+      <ConformaSettlingAnnouncement settling={settling} />
     </>
   );
 };

--- a/src/components/Conforma/ConformaResultsTab/ConformaSettlingAnnouncement.tsx
+++ b/src/components/Conforma/ConformaResultsTab/ConformaSettlingAnnouncement.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { Bullseye, Content, ContentVariants, Flex, Spinner } from '@patternfly/react-core';
+
+const SETTLING_STATUS_FINALIZING = 'Finalizing Conforma results.';
+const SETTLING_STATUS_COMPLETE = 'Conforma results finalized.';
+const SETTLING_COMPLETE_ANNOUNCEMENT_MS = 2000;
+
+type SettlingAnnouncement = 'idle' | 'finalizing' | 'complete';
+
+type ConformaSettlingAnnouncementProps = {
+  settling: boolean;
+};
+
+/**
+ * Stable live region that announces when Conforma results are finalizing and
+ * when that pass completes, then auto-clears the completion message.
+ */
+export const ConformaSettlingAnnouncement: React.FC<ConformaSettlingAnnouncementProps> = ({
+  settling,
+}) => {
+  const [settlingAnnouncement, setSettlingAnnouncement] =
+    React.useState<SettlingAnnouncement>('idle');
+
+  React.useEffect(() => {
+    if (settling) {
+      setSettlingAnnouncement('finalizing');
+      return;
+    }
+    setSettlingAnnouncement((current) => (current === 'finalizing' ? 'complete' : current));
+  }, [settling]);
+
+  React.useEffect(() => {
+    if (settlingAnnouncement !== 'complete') return;
+    const timer = setTimeout(
+      () => setSettlingAnnouncement('idle'),
+      SETTLING_COMPLETE_ANNOUNCEMENT_MS,
+    );
+    return () => clearTimeout(timer);
+  }, [settlingAnnouncement]);
+
+  return (
+    <div
+      aria-live="polite"
+      aria-atomic="true"
+      data-test="conforma-results-settling-live-region"
+      className="conforma-results-tab__settling-live-region"
+    >
+      {settlingAnnouncement === 'finalizing' ? (
+        <Bullseye className="pf-v6-u-mt-md">
+          <Flex
+            direction={{ default: 'column' }}
+            alignItems={{ default: 'alignItemsCenter' }}
+            gap={{ default: 'gapSm' }}
+          >
+            <Spinner size="lg" aria-hidden data-test="conforma-results-settling-spinner" />
+            <Content component={ContentVariants.p} data-test="conforma-results-settling-status">
+              {SETTLING_STATUS_FINALIZING}
+            </Content>
+          </Flex>
+        </Bullseye>
+      ) : settlingAnnouncement === 'complete' ? (
+        <Bullseye className="pf-v6-u-mt-md">
+          <Content component={ContentVariants.p} data-test="conforma-results-settled-status">
+            {SETTLING_STATUS_COMPLETE}
+          </Content>
+        </Bullseye>
+      ) : null}
+    </div>
+  );
+};

--- a/src/components/Conforma/ConformaResultsTab/__tests__/ConformaResultsTab.spec.tsx
+++ b/src/components/Conforma/ConformaResultsTab/__tests__/ConformaResultsTab.spec.tsx
@@ -19,6 +19,10 @@ jest.mock('react-router-dom', () => ({
 
 const mockUseApplicationConformaResults = useApplicationConformaResults as jest.Mock;
 
+const SETTLING_STATUS_FINALIZING = 'Finalizing Conforma results.';
+const SETTLING_STATUS_COMPLETE = 'Conforma results finalized.';
+const SETTLING_COMPLETE_ANNOUNCEMENT_MS = 2000;
+
 const createMockRow = (overrides: Partial<ConformaResultRow> = {}): ConformaResultRow => ({
   title: 'Test rule',
   description: 'A test rule description',
@@ -41,6 +45,7 @@ const emptyResults: ApplicationConformaResults = {
   totalComponents: 0,
   totalFailed: 0,
   loaded: true,
+  settling: false,
   error: undefined,
   refresh: noOpRefresh,
 };
@@ -81,6 +86,7 @@ const archDupeResults: ApplicationConformaResults = {
   totalComponents: 1,
   totalFailed: 1,
   loaded: true,
+  settling: false,
   error: undefined,
   refresh: noOpRefresh,
 };
@@ -127,6 +133,7 @@ const populatedResults: ApplicationConformaResults = {
   totalComponents: 2,
   totalFailed: 1,
   loaded: true,
+  settling: false,
   error: undefined,
   refresh: noOpRefresh,
 };
@@ -134,6 +141,10 @@ const populatedResults: ApplicationConformaResults = {
 describe('ConformaResultsTab', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it('shows a spinner when data is loading', () => {
@@ -311,6 +322,158 @@ describe('ConformaResultsTab', () => {
     expect(screen.getByText(/sha256:aaa/)).toBeInTheDocument();
     expect(screen.getByText(/sha256:bbb/)).toBeInTheDocument();
     expect(screen.getByText(/sha256:ccc/)).toBeInTheDocument();
+  });
+
+  it('shows an inline settling spinner and status when loaded but still settling', () => {
+    mockUseApplicationConformaResults.mockReturnValue({
+      ...populatedResults,
+      settling: true,
+    });
+
+    routerRenderer(<ConformaResultsTab />);
+
+    expect(screen.getByText(SETTLING_STATUS_FINALIZING)).toBeInTheDocument();
+    expect(screen.getByTestId('conforma-results-settling-spinner')).toBeInTheDocument();
+    expect(screen.getByTestId('conforma-results-settling-status')).toBeInTheDocument();
+
+    const liveRegion = screen.getByTestId('conforma-results-settling-live-region');
+    expect(liveRegion).toHaveAttribute('aria-live', 'polite');
+    expect(liveRegion).toHaveAttribute('aria-atomic', 'true');
+  });
+
+  it('does not show settling UI when settling is false and never started', () => {
+    mockUseApplicationConformaResults.mockReturnValue(populatedResults);
+
+    routerRenderer(<ConformaResultsTab />);
+
+    expect(screen.queryByText(SETTLING_STATUS_FINALIZING)).not.toBeInTheDocument();
+    expect(screen.queryByText(SETTLING_STATUS_COMPLETE)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('conforma-results-settling-spinner')).not.toBeInTheDocument();
+  });
+
+  it('shows a completion message in the live region when settling finishes', () => {
+    mockUseApplicationConformaResults.mockReturnValue({
+      ...populatedResults,
+      settling: true,
+    });
+
+    const { rerender } = routerRenderer(<ConformaResultsTab />);
+
+    expect(screen.getByText(SETTLING_STATUS_FINALIZING)).toBeInTheDocument();
+
+    mockUseApplicationConformaResults.mockReturnValue({
+      ...populatedResults,
+      settling: false,
+    });
+    rerender(<ConformaResultsTab />);
+
+    expect(screen.queryByText(SETTLING_STATUS_FINALIZING)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('conforma-results-settling-spinner')).not.toBeInTheDocument();
+    expect(screen.getByText(SETTLING_STATUS_COMPLETE)).toBeInTheDocument();
+    expect(screen.getByTestId('conforma-results-settled-status')).toBeInTheDocument();
+    expect(screen.getByTestId('conforma-results-settling-live-region')).toBeInTheDocument();
+  });
+
+  it('auto-clears the completion message after the announcement timeout', () => {
+    jest.useFakeTimers();
+    mockUseApplicationConformaResults.mockReturnValue({
+      ...populatedResults,
+      settling: true,
+    });
+
+    const { rerender } = routerRenderer(<ConformaResultsTab />);
+
+    mockUseApplicationConformaResults.mockReturnValue({
+      ...populatedResults,
+      settling: false,
+    });
+    rerender(<ConformaResultsTab />);
+
+    expect(screen.getByText(SETTLING_STATUS_COMPLETE)).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(SETTLING_COMPLETE_ANNOUNCEMENT_MS);
+    });
+
+    expect(screen.queryByText(SETTLING_STATUS_COMPLETE)).not.toBeInTheDocument();
+  });
+
+  it('does not let a stale auto-clear timer from a prior "complete" phase override a new settling cycle', () => {
+    jest.useFakeTimers();
+
+    // Step 1: settling starts -> announcement becomes 'finalizing'.
+    mockUseApplicationConformaResults.mockReturnValue({
+      ...populatedResults,
+      settling: true,
+    });
+    const { rerender } = routerRenderer(<ConformaResultsTab />);
+
+    expect(screen.getByText(SETTLING_STATUS_FINALIZING)).toBeInTheDocument();
+
+    // Step 2: settling finishes -> announcement becomes 'complete' and the
+    // 2-second auto-clear timer is scheduled.
+    mockUseApplicationConformaResults.mockReturnValue({
+      ...populatedResults,
+      settling: false,
+    });
+    rerender(<ConformaResultsTab />);
+
+    expect(screen.getByText(SETTLING_STATUS_COMPLETE)).toBeInTheDocument();
+
+    // Step 3: advance partway through the 2-second window (well before it fires).
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    // Step 4: a new refresh/fill-in cycle starts before the old timer fires.
+    mockUseApplicationConformaResults.mockReturnValue({
+      ...populatedResults,
+      settling: true,
+    });
+    rerender(<ConformaResultsTab />);
+
+    expect(screen.getByText(SETTLING_STATUS_FINALIZING)).toBeInTheDocument();
+    expect(screen.getByTestId('conforma-results-settling-spinner')).toBeInTheDocument();
+    expect(screen.queryByText(SETTLING_STATUS_COMPLETE)).not.toBeInTheDocument();
+
+    // Step 5: advance well past the moment the original (step 2) timer would
+    // have fired (500ms + 2000ms+ = well beyond the original 2000ms mark).
+    act(() => {
+      jest.advanceTimersByTime(SETTLING_COMPLETE_ANNOUNCEMENT_MS);
+    });
+
+    // Step 6: the stale timer must not have reverted the announcement to
+    // 'idle'. The UI should still correctly show the finalizing state.
+    expect(screen.getByText(SETTLING_STATUS_FINALIZING)).toBeInTheDocument();
+    expect(screen.getByTestId('conforma-results-settling-spinner')).toBeInTheDocument();
+    expect(screen.queryByText(SETTLING_STATUS_COMPLETE)).not.toBeInTheDocument();
+  });
+
+  it('does not show empty state when loaded and settling with empty results', () => {
+    mockUseApplicationConformaResults.mockReturnValue({
+      ...emptyResults,
+      settling: true,
+    });
+
+    routerRenderer(<ConformaResultsTab />);
+
+    expect(
+      screen.queryByText('No Conforma results available for this application.'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('No results match the current filters.')).not.toBeInTheDocument();
+    expect(screen.getByTestId('conforma-results-settling-spinner')).toBeInTheDocument();
+  });
+
+  it('sets aria-busy on summary wrapper while settling', () => {
+    mockUseApplicationConformaResults.mockReturnValue({
+      ...populatedResults,
+      settling: true,
+    });
+
+    routerRenderer(<ConformaResultsTab />);
+
+    const summaryWrapper = screen.getByTestId('conforma-results-summary-wrapper');
+    expect(summaryWrapper).toHaveAttribute('aria-busy', 'true');
   });
 
   it('shows "no results match" when filters exclude all results', () => {

--- a/src/components/Conforma/ConformaResultsTab/__tests__/conforma-fetchers.spec.ts
+++ b/src/components/Conforma/ConformaResultsTab/__tests__/conforma-fetchers.spec.ts
@@ -1,6 +1,7 @@
 import { extractConformaResultsFromTaskRunLogs } from '~/components/Conforma/utils';
-import { commonFetchJSON, getK8sResourceURL } from '~/k8s';
+import { commonFetchJSON, getK8sResourceURL, k8sListResource } from '~/k8s';
 import { KUBEARCHIVE_PATH_PREFIX } from '~/kubearchive/const';
+import { convertToKubearchiveQueryParams, withKubearchivePathPrefix } from '~/kubearchive/fetch-utils';
 import { PodModel } from '~/models/pod';
 import type { TaskRunKind } from '~/types';
 import {
@@ -9,21 +10,28 @@ import {
   type ConformaResult,
 } from '~/types/conforma';
 import { getPipelineRunFromTaskRunOwnerRef } from '~/utils/common-utils';
-import { getTaskRunLog } from '~/utils/tekton-results';
+import { getTaskRunLog, getTaskRuns } from '~/utils/tekton-results';
 import {
   fetchConformaLogFromKubearchive,
   fetchConformaLogFromTektonResults,
+  fetchLatestSecurityTaskRunForComponent,
   filterInvalidImageConformaRows,
   mapConformaResultData,
   resolveConformaResultFromTaskRun,
 } from '../conforma-fetchers';
+import { buildConformaSecurityTaskRunSelector } from '../conforma-taskrun-query';
 import '@testing-library/jest-dom';
 
 jest.mock('~/k8s', () => ({
   commonFetchJSON: jest.fn(),
   getK8sResourceURL: jest.fn(() => '/fake-url'),
+  k8sListResource: jest.fn(),
 }));
-jest.mock('~/utils/tekton-results', () => ({ getTaskRunLog: jest.fn() }));
+jest.mock('~/utils/tekton-results', () => ({ getTaskRunLog: jest.fn(), getTaskRuns: jest.fn() }));
+jest.mock('~/kubearchive/fetch-utils', () => ({
+  convertToKubearchiveQueryParams: jest.fn(),
+  withKubearchivePathPrefix: jest.fn((opts: unknown) => opts),
+}));
 jest.mock('~/components/Conforma/utils', () => ({
   extractConformaResultsFromTaskRunLogs: jest.fn(),
 }));
@@ -31,7 +39,7 @@ jest.mock('~/utils/common-utils', () => ({
   getPipelineRunFromTaskRunOwnerRef: jest.fn(),
 }));
 
-const createTaskRun = (name: string, podName?: string): TaskRunKind =>
+const createTaskRun = (name: string, podName?: string, creationTimestamp?: string): TaskRunKind =>
   ({
     apiVersion: 'tekton.dev/v1',
     kind: 'TaskRun',
@@ -40,6 +48,7 @@ const createTaskRun = (name: string, podName?: string): TaskRunKind =>
       namespace: 'test-ns',
       uid: `uid-${name}`,
       ownerReferences: [{ kind: 'PipelineRun', uid: 'pr-uid-1' }],
+      ...(creationTimestamp ? { creationTimestamp } : {}),
     },
     status: podName ? { podName } : {},
   }) as unknown as TaskRunKind;
@@ -68,6 +77,129 @@ const mockConformaResult: ConformaResult = {
 };
 
 const NAMESPACE = 'test-ns';
+
+describe('buildConformaSecurityTaskRunSelector', () => {
+  it('builds application-wide selector without component label', () => {
+    expect(buildConformaSecurityTaskRunSelector('test-app')).toEqual({
+      matchLabels: {
+        'appstudio.openshift.io/application': 'test-app',
+        'pipelines.appstudio.openshift.io/type': 'test',
+      },
+      matchExpressions: [
+        {
+          key: 'tekton.dev/pipelineTask',
+          operator: 'In',
+          values: ['verify', 'verify-conforma'],
+        },
+      ],
+    });
+  });
+
+  it('adds component label when componentName is provided', () => {
+    expect(buildConformaSecurityTaskRunSelector('test-app', 'comp-a')).toEqual(
+      expect.objectContaining({
+        matchLabels: expect.objectContaining({
+          'appstudio.openshift.io/application': 'test-app',
+          'appstudio.openshift.io/component': 'comp-a',
+        }),
+      }),
+    );
+  });
+});
+
+describe('fetchLatestSecurityTaskRunForComponent', () => {
+  const taskRun = createTaskRun('tr-1', 'pod-1');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(convertToKubearchiveQueryParams).mockReturnValue({
+      ns: NAMESPACE,
+      queryParams: { labelSelector: buildConformaSecurityTaskRunSelector('test-app', 'comp-a') },
+    });
+  });
+
+  it('fetches via Tekton Results when kubearchive taskruns flag is OFF', async () => {
+    jest.mocked(getTaskRuns).mockResolvedValue([[taskRun], { nextPageToken: null, records: [] }]);
+
+    const result = await fetchLatestSecurityTaskRunForComponent(
+      NAMESPACE,
+      'test-app',
+      'comp-a',
+      false,
+    );
+
+    expect(getTaskRuns).toHaveBeenCalledWith(
+      NAMESPACE,
+      expect.objectContaining({
+        selector: buildConformaSecurityTaskRunSelector('test-app', 'comp-a'),
+        limit: 1,
+      }),
+    );
+    expect(k8sListResource).not.toHaveBeenCalled();
+    expect(result).toBe(taskRun);
+  });
+
+  it('fetches via KubeArchive requesting limit: 1 (server orders by creationTimestamp desc) when kubearchive taskruns flag is ON', async () => {
+    jest.mocked(k8sListResource).mockResolvedValue({ items: [taskRun] } as never);
+
+    const result = await fetchLatestSecurityTaskRunForComponent(
+      NAMESPACE,
+      'test-app',
+      'comp-a',
+      true,
+    );
+
+    expect(convertToKubearchiveQueryParams).toHaveBeenCalledWith(
+      expect.objectContaining({
+        namespace: NAMESPACE,
+        selector: buildConformaSecurityTaskRunSelector('test-app', 'comp-a'),
+      }),
+    );
+    expect(withKubearchivePathPrefix).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryOptions: expect.objectContaining({
+          queryParams: expect.objectContaining({ limit: 1 }),
+        }),
+      }),
+    );
+    expect(k8sListResource).toHaveBeenCalled();
+    expect(getTaskRuns).not.toHaveBeenCalled();
+    expect(result).toBe(taskRun);
+  });
+
+  it('returns items[0] from KubeArchive without client-side re-sorting', async () => {
+    const serverFirst = createTaskRun('tr-1', 'pod-1', '2024-01-01T00:00:00Z');
+    const newerInTimeButSecondInArray = createTaskRun('tr-2', 'pod-2', '2024-03-01T00:00:00Z');
+    jest.mocked(k8sListResource).mockResolvedValue({
+      items: [serverFirst, newerInTimeButSecondInArray],
+    } as never);
+
+    const result = await fetchLatestSecurityTaskRunForComponent(
+      NAMESPACE,
+      'test-app',
+      'comp-a',
+      true,
+    );
+
+    expect(result).toBe(serverFirst);
+  });
+
+  it('returns null when no TaskRun is found', async () => {
+    jest.mocked(getTaskRuns).mockResolvedValue([[], { nextPageToken: null, records: [] }]);
+
+    await expect(
+      fetchLatestSecurityTaskRunForComponent(NAMESPACE, 'test-app', 'comp-a', false),
+    ).resolves.toBeNull();
+  });
+
+  it('returns null when KubeArchive returns no TaskRuns', async () => {
+    jest.mocked(k8sListResource).mockResolvedValue({ items: [] } as never);
+
+    await expect(
+      fetchLatestSecurityTaskRunForComponent(NAMESPACE, 'test-app', 'comp-a', true),
+    ).resolves.toBeNull();
+  });
+});
 
 describe('fetchConformaLogFromKubearchive', () => {
   beforeEach(() => {

--- a/src/components/Conforma/ConformaResultsTab/__tests__/useApplicationConformaResults.spec.ts
+++ b/src/components/Conforma/ConformaResultsTab/__tests__/useApplicationConformaResults.spec.ts
@@ -4,9 +4,12 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import { useIsOnFeatureFlag } from '~/feature-flags/hooks';
 import { useComponents } from '~/hooks/useComponents';
 import { useTaskRunsV2 } from '~/hooks/useTaskRunsV2';
+import { k8sListResource } from '~/k8s';
+import { convertToKubearchiveQueryParams } from '~/kubearchive/fetch-utils';
 import { useNamespace } from '~/shared/providers/Namespace';
 import type { ComponentKind, TaskRunKind } from '~/types';
 import { CONFORMA_RESULT_STATUS, type ConformaResult } from '~/types/conforma';
+import { getTaskRuns } from '~/utils/tekton-results';
 import { resolveConformaResultFromTaskRun } from '../conforma-fetchers';
 import { useApplicationConformaResults } from '../useApplicationConformaResults';
 import '@testing-library/jest-dom';
@@ -32,10 +35,27 @@ jest.mock('../conforma-fetchers', () => ({
   filterInvalidImageConformaRows:
     jest.requireActual('../conforma-fetchers').filterInvalidImageConformaRows,
   mapConformaResultData: jest.requireActual('../conforma-fetchers').mapConformaResultData,
+  fetchLatestSecurityTaskRunForComponent:
+    jest.requireActual('../conforma-fetchers').fetchLatestSecurityTaskRunForComponent,
 }));
 
 jest.mock('~/monitoring/logger', () => ({
   logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('~/utils/tekton-results', () => ({
+  getTaskRuns: jest.fn(),
+}));
+
+jest.mock('~/k8s', () => ({
+  ...jest.requireActual('~/k8s'),
+  k8sListResource: jest.fn(),
+}));
+
+jest.mock('~/kubearchive/fetch-utils', () => ({
+  ...jest.requireActual('~/kubearchive/fetch-utils'),
+  convertToKubearchiveQueryParams: jest.fn(),
+  withKubearchivePathPrefix: jest.fn((opts: unknown) => opts),
 }));
 
 const mockUseComponents = useComponents as jest.Mock;
@@ -43,6 +63,9 @@ const mockUseTaskRunsV2 = useTaskRunsV2 as jest.Mock;
 const mockUseNamespace = useNamespace as jest.Mock;
 const mockUseIsOnFeatureFlag = useIsOnFeatureFlag as jest.Mock;
 const mockResolveConforma = resolveConformaResultFromTaskRun as jest.Mock;
+const mockGetTaskRuns = getTaskRuns as jest.Mock;
+const mockK8sListResource = k8sListResource as jest.Mock;
+const mockConvertToKubearchiveQueryParams = convertToKubearchiveQueryParams as jest.Mock;
 
 const DEFAULT_WATCH_META = {
   dataUpdatedAt: 1000,
@@ -184,10 +207,17 @@ describe('useApplicationConformaResults', () => {
     });
 
     mockUseNamespace.mockReturnValue('test-ns');
-    mockUseIsOnFeatureFlag.mockReturnValue(false);
+    mockUseIsOnFeatureFlag.mockImplementation((flag: string) => {
+      if (flag === 'kubearchive-logs') return false;
+      if (flag === 'taskruns-kubearchive') return false;
+      return false;
+    });
     mockUseComponents.mockReturnValue([[], true, undefined]);
     mockUseTaskRunsV2.mockReturnValue(createTaskRunsV2Return());
     mockResolveConforma.mockResolvedValue(undefined);
+    mockGetTaskRuns.mockResolvedValue([[], { nextPageToken: null, records: [] }]);
+    mockK8sListResource.mockResolvedValue({ items: [] });
+    mockConvertToKubearchiveQueryParams.mockReturnValue({ ns: 'test-ns', queryParams: {} });
   });
 
   afterEach(() => {
@@ -207,6 +237,7 @@ describe('useApplicationConformaResults', () => {
       totalComponents: 0,
       totalFailed: 0,
       loaded: false,
+      settling: false,
       error: undefined,
       partialLogError: undefined,
       refresh: expect.objectContaining({
@@ -629,6 +660,37 @@ describe('useApplicationConformaResults', () => {
     expect(refetch).toHaveBeenCalled();
   });
 
+  it('refresh.onRefresh invalidates the conforma-fillin queries in addition to refetching TaskRuns', async () => {
+    const refetch = jest.fn();
+    setupTaskRunPipeline();
+    mockUseTaskRunsV2.mockReturnValue(
+      createTaskRunsV2Return(
+        [createSecurityTaskRun('tr-1', 'comp-a', 'pod-1')],
+        true,
+        undefined,
+        { ...DEFAULT_WATCH_META, refetch },
+      ),
+    );
+    mockResolveConforma.mockResolvedValue(mockConformaResult);
+
+    const invalidateQueriesSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useApplicationConformaResults('test-app'), {
+      wrapper: createWrapper(),
+    });
+
+    await flushEffects();
+
+    act(() => {
+      result.current.refresh.onRefresh();
+    });
+
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: ['conforma-fillin', 'test-ns'],
+    });
+    expect(refetch).toHaveBeenCalled();
+  });
+
   it('breaks timestamp ties by choosing the lexicographically greater TaskRun name', async () => {
     const components = [createComponent('comp-a')];
     const sameTimestamp = '2026-06-01T00:00:00Z';
@@ -866,5 +928,339 @@ describe('useApplicationConformaResults', () => {
     await flushEffects();
 
     expect(result.current.allResults[0].pipelineRunName).toBe('pr-1');
+  });
+
+  // --- New tests for batch limit and fill-in ---
+
+  it('passes correct batch limit (max(N*3, 10)) to useTaskRunsV2', () => {
+    const components = [
+      createComponent('comp-a'),
+      createComponent('comp-b'),
+      createComponent('comp-c'),
+      createComponent('comp-d'),
+      createComponent('comp-e'),
+    ];
+    mockUseComponents.mockReturnValue([components, true, undefined]);
+    mockUseTaskRunsV2.mockReturnValue(createTaskRunsV2Return([], true, undefined));
+
+    renderHook(() => useApplicationConformaResults('test-app'), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockUseTaskRunsV2).toHaveBeenCalledWith(
+      'test-ns',
+      expect.objectContaining({
+        limit: 15,
+      }),
+      expect.objectContaining({ staleTime: Infinity }),
+    );
+  });
+
+  it('uses minimum limit of 10 when N*3 < 10', () => {
+    const components = [createComponent('comp-a'), createComponent('comp-b')];
+    mockUseComponents.mockReturnValue([components, true, undefined]);
+    mockUseTaskRunsV2.mockReturnValue(createTaskRunsV2Return());
+
+    renderHook(() => useApplicationConformaResults('test-app'), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockUseTaskRunsV2).toHaveBeenCalledWith(
+      'test-ns',
+      expect.objectContaining({
+        limit: 10,
+      }),
+      expect.objectContaining({ staleTime: Infinity }),
+    );
+  });
+
+  it('applies the batch-limit floor of 10 while components are still loading', () => {
+    mockUseComponents.mockReturnValue([[], false, undefined]);
+    mockUseTaskRunsV2.mockReturnValue(createTaskRunsV2Return([], false));
+
+    renderHook(() => useApplicationConformaResults('test-app'), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockUseTaskRunsV2).toHaveBeenCalledWith(
+      'test-ns',
+      expect.objectContaining({
+        limit: 10,
+      }),
+      expect.objectContaining({ staleTime: Infinity }),
+    );
+  });
+
+  it('fill-in recovers a missing component via Tekton Results (kubearchive OFF)', async () => {
+    const components = [createComponent('comp-a'), createComponent('comp-b')];
+    const taskRuns = [createSecurityTaskRun('tr-1', 'comp-a', 'pod-1')];
+    mockUseComponents.mockReturnValue([components, true, undefined]);
+    mockUseTaskRunsV2.mockReturnValue(createTaskRunsV2Return(taskRuns));
+
+    const fillInTr = createSecurityTaskRun('tr-fillin', 'comp-b', 'pod-fillin', '2025-06-01T00:00:00Z', 'pr-fillin');
+    mockGetTaskRuns.mockResolvedValue([[fillInTr], { nextPageToken: null, records: [] }]);
+    mockResolveConforma.mockResolvedValue(mockConformaResult);
+
+    const { result } = renderHook(() => useApplicationConformaResults('test-app'), {
+      wrapper: createWrapper(),
+    });
+
+    await flushEffects();
+
+    expect(mockGetTaskRuns).toHaveBeenCalledWith(
+      'test-ns',
+      expect.objectContaining({
+        selector: expect.objectContaining({
+          matchLabels: expect.objectContaining({
+            'appstudio.openshift.io/component': 'comp-b',
+          }),
+        }),
+        limit: 1,
+      }),
+    );
+
+    const compB = result.current.componentStatuses.find((c) => c.componentName === 'comp-b');
+    expect(compB?.pipelineRunName).toBe('pr-fillin');
+  });
+
+  it('fill-in recovers a missing component via KubeArchive (kubearchive ON)', async () => {
+    mockUseIsOnFeatureFlag.mockImplementation((flag: string) => {
+      if (flag === 'taskruns-kubearchive') return true;
+      return false;
+    });
+
+    const components = [createComponent('comp-a'), createComponent('comp-b')];
+    const taskRuns = [createSecurityTaskRun('tr-1', 'comp-a', 'pod-1')];
+    mockUseComponents.mockReturnValue([components, true, undefined]);
+    mockUseTaskRunsV2.mockReturnValue(createTaskRunsV2Return(taskRuns));
+
+    const fillInTr = createSecurityTaskRun('tr-fillin', 'comp-b', 'pod-fillin', '2025-06-01T00:00:00Z', 'pr-fillin');
+    mockK8sListResource.mockResolvedValue({ items: [fillInTr] });
+    mockResolveConforma.mockResolvedValue(mockConformaResult);
+
+    const { result } = renderHook(() => useApplicationConformaResults('test-app'), {
+      wrapper: createWrapper(),
+    });
+
+    await flushEffects();
+
+    expect(mockK8sListResource).toHaveBeenCalled();
+    expect(mockGetTaskRuns).not.toHaveBeenCalled();
+
+    const compB = result.current.componentStatuses.find((c) => c.componentName === 'comp-b');
+    expect(compB?.pipelineRunName).toBe('pr-fillin');
+  });
+
+  it('selects the newest of two batch TaskRuns for the same component', async () => {
+    const components = [createComponent('comp-a')];
+    const olderTr = createSecurityTaskRun(
+      'tr-older',
+      'comp-a',
+      'pod-older',
+      '2025-01-01T00:00:00Z',
+      'pr-older',
+    );
+    const newerTr = createSecurityTaskRun(
+      'tr-newer',
+      'comp-a',
+      'pod-newer',
+      '2026-06-01T00:00:00Z',
+      'pr-newer',
+    );
+    mockUseComponents.mockReturnValue([components, true, undefined]);
+    mockUseTaskRunsV2.mockReturnValue(createTaskRunsV2Return([olderTr, newerTr]));
+    mockResolveConforma.mockResolvedValue(mockConformaResult);
+
+    const { result } = renderHook(() => useApplicationConformaResults('test-app'), {
+      wrapper: createWrapper(),
+    });
+
+    await flushEffects();
+
+    expect(mockGetTaskRuns).not.toHaveBeenCalled();
+    expect(mockK8sListResource).not.toHaveBeenCalled();
+    const compA = result.current.componentStatuses.find((c) => c.componentName === 'comp-a');
+    expect(compA?.pipelineRunName).toBe('pr-newer');
+  });
+
+  it('does not fire a fill-in query for a component already covered by the batch, so an older fill-in can never override it', async () => {
+    const components = [createComponent('comp-a'), createComponent('comp-b')];
+    const batchTr = createSecurityTaskRun(
+      'tr-batch',
+      'comp-a',
+      'pod-batch',
+      '2026-06-01T00:00:00Z',
+      'pr-batch',
+    );
+    mockUseComponents.mockReturnValue([components, true, undefined]);
+    mockUseTaskRunsV2.mockReturnValue(createTaskRunsV2Return([batchTr]));
+
+    const fillInTr = createSecurityTaskRun(
+      'tr-fillin',
+      'comp-b',
+      'pod-fillin',
+      '2025-01-01T00:00:00Z',
+      'pr-fillin',
+    );
+    mockGetTaskRuns.mockResolvedValue([[fillInTr], { nextPageToken: null, records: [] }]);
+    mockResolveConforma.mockResolvedValue(mockConformaResult);
+
+    const { result } = renderHook(() => useApplicationConformaResults('test-app'), {
+      wrapper: createWrapper(),
+    });
+
+    await flushEffects();
+
+    expect(mockGetTaskRuns).toHaveBeenCalledTimes(1);
+    expect(mockGetTaskRuns).toHaveBeenCalledWith(
+      'test-ns',
+      expect.objectContaining({
+        selector: expect.objectContaining({
+          matchLabels: expect.objectContaining({ 'appstudio.openshift.io/component': 'comp-b' }),
+        }),
+      }),
+    );
+
+    const compA = result.current.componentStatuses.find((c) => c.componentName === 'comp-a');
+    expect(compA?.pipelineRunName).toBe('pr-batch');
+  });
+
+  it('settling is true while fill-in queries are in-flight', async () => {
+    const components = [createComponent('comp-a'), createComponent('comp-b')];
+    const taskRuns = [createSecurityTaskRun('tr-1', 'comp-a', 'pod-1')];
+    mockUseComponents.mockReturnValue([components, true, undefined]);
+    mockUseTaskRunsV2.mockReturnValue(createTaskRunsV2Return(taskRuns));
+
+    let resolveFillIn: (v: [TaskRunKind[], unknown]) => void;
+    const pendingFillIn = new Promise<[TaskRunKind[], unknown]>((r) => {
+      resolveFillIn = r;
+    });
+    mockGetTaskRuns.mockReturnValue(pendingFillIn);
+    mockResolveConforma.mockResolvedValue(mockConformaResult);
+
+    const { result } = renderHook(() => useApplicationConformaResults('test-app'), {
+      wrapper: createWrapper(),
+    });
+
+    await flushEffects();
+
+    expect(result.current.loaded).toBe(true);
+    expect(result.current.settling).toBe(true);
+
+    const fillInTr = createSecurityTaskRun('tr-fillin', 'comp-b', 'pod-fillin');
+    await act(async () => {
+      resolveFillIn([[fillInTr], {}]);
+      await pendingFillIn;
+    });
+    await flushEffects();
+
+    expect(result.current.settling).toBe(false);
+  });
+
+  it('settling is true while fill-in and logs are both in-flight, false when both done', async () => {
+    const components = [createComponent('comp-a'), createComponent('comp-b')];
+    const taskRuns = [createSecurityTaskRun('tr-1', 'comp-a', 'pod-1')];
+    mockUseComponents.mockReturnValue([components, true, undefined]);
+    mockUseTaskRunsV2.mockReturnValue(createTaskRunsV2Return(taskRuns));
+
+    const fillInTr = createSecurityTaskRun('tr-fillin', 'comp-b', 'pod-fillin');
+    mockGetTaskRuns.mockResolvedValue([[fillInTr], { nextPageToken: null, records: [] }]);
+
+    let resolveLog: (v: ConformaResult) => void;
+    const pendingLog = new Promise<ConformaResult>((r) => {
+      resolveLog = r;
+    });
+    mockResolveConforma.mockReturnValue(pendingLog);
+
+    const { result } = renderHook(() => useApplicationConformaResults('test-app'), {
+      wrapper: createWrapper(),
+    });
+
+    await flushEffects();
+
+    expect(result.current.loaded).toBe(true);
+    expect(result.current.settling).toBe(true);
+
+    await act(async () => {
+      resolveLog(mockConformaResult);
+      await pendingLog;
+    });
+    await flushEffects();
+
+    expect(result.current.settling).toBe(false);
+  });
+
+  it('does not trigger fill-in when all components have TaskRuns in batch', async () => {
+    const components = [createComponent('comp-a'), createComponent('comp-b')];
+    const taskRuns = [
+      createSecurityTaskRun('tr-1', 'comp-a', 'pod-1'),
+      createSecurityTaskRun('tr-2', 'comp-b', 'pod-2'),
+    ];
+    mockUseComponents.mockReturnValue([components, true, undefined]);
+    mockUseTaskRunsV2.mockReturnValue(createTaskRunsV2Return(taskRuns));
+    mockResolveConforma.mockResolvedValue(mockConformaResult);
+
+    renderHook(() => useApplicationConformaResults('test-app'), {
+      wrapper: createWrapper(),
+    });
+
+    await flushEffects();
+
+    expect(mockGetTaskRuns).not.toHaveBeenCalled();
+    expect(mockK8sListResource).not.toHaveBeenCalled();
+  });
+
+  it('fill-in query rejection: settling becomes false, component stays unknown, no crash', async () => {
+    const { logger } = jest.requireMock('~/monitoring/logger');
+    const components = [createComponent('comp-a'), createComponent('comp-b')];
+    const taskRuns = [createSecurityTaskRun('tr-1', 'comp-a', 'pod-1')];
+    mockUseComponents.mockReturnValue([components, true, undefined]);
+    mockUseTaskRunsV2.mockReturnValue(createTaskRunsV2Return(taskRuns));
+    mockGetTaskRuns.mockRejectedValue(new Error('tekton-results unavailable'));
+    mockResolveConforma.mockResolvedValue(mockConformaResult);
+
+    const { result } = renderHook(() => useApplicationConformaResults('test-app'), {
+      wrapper: createWrapper(),
+    });
+
+    await flushEffects();
+
+    expect(result.current.settling).toBe(false);
+    const compB = result.current.componentStatuses.find((c) => c.componentName === 'comp-b');
+    expect(compB?.status).toBe('unknown');
+    expect(logger.warn).toHaveBeenCalledWith(
+      'useApplicationConformaResults: fill-in query failed',
+      expect.objectContaining({ message: expect.any(String) }),
+    );
+  });
+
+  it('KubeArchive fill-in requests limit: 1 (server orders by creationTimestamp desc)', async () => {
+    mockUseIsOnFeatureFlag.mockImplementation((flag: string) => {
+      if (flag === 'taskruns-kubearchive') return true;
+      return false;
+    });
+
+    const components = [createComponent('comp-a'), createComponent('comp-b')];
+    const taskRuns = [createSecurityTaskRun('tr-1', 'comp-a', 'pod-1')];
+    mockUseComponents.mockReturnValue([components, true, undefined]);
+    mockUseTaskRunsV2.mockReturnValue(createTaskRunsV2Return(taskRuns));
+
+    const fillInTr = createSecurityTaskRun('tr-fillin', 'comp-b', 'pod-fillin');
+    mockK8sListResource.mockResolvedValue({ items: [fillInTr] });
+    mockResolveConforma.mockResolvedValue(mockConformaResult);
+
+    renderHook(() => useApplicationConformaResults('test-app'), {
+      wrapper: createWrapper(),
+    });
+
+    await flushEffects();
+
+    expect(mockK8sListResource).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryOptions: expect.objectContaining({
+          queryParams: expect.objectContaining({ limit: 1 }),
+        }),
+      }),
+    );
   });
 });

--- a/src/components/Conforma/ConformaResultsTab/conforma-fetchers.ts
+++ b/src/components/Conforma/ConformaResultsTab/conforma-fetchers.ts
@@ -1,6 +1,8 @@
 import { extractConformaResultsFromTaskRunLogs } from '~/components/Conforma/utils';
-import { commonFetchJSON, getK8sResourceURL } from '~/k8s';
+import { commonFetchJSON, getK8sResourceURL, k8sListResource, K8sResourceListOptions } from '~/k8s';
 import { KUBEARCHIVE_PATH_PREFIX } from '~/kubearchive/const';
+import { convertToKubearchiveQueryParams, withKubearchivePathPrefix } from '~/kubearchive/fetch-utils';
+import { TaskRunGroupVersionKind, TaskRunModel } from '~/models';
 import { PodModel } from '~/models/pod';
 import type { TaskRunKind } from '~/types';
 import {
@@ -11,7 +13,45 @@ import {
   type ConformaRule,
 } from '~/types/conforma';
 import { getPipelineRunFromTaskRunOwnerRef } from '~/utils/common-utils';
-import { getTaskRunLog } from '~/utils/tekton-results';
+import { getTaskRunLog, getTaskRuns } from '~/utils/tekton-results';
+import { buildConformaSecurityTaskRunSelector } from './conforma-taskrun-query';
+
+export async function fetchLatestSecurityTaskRunForComponent(
+  namespace: string,
+  applicationName: string,
+  componentName: string,
+  isKubearchiveTaskRunsEnabled: boolean,
+): Promise<TaskRunKind | null> {
+  const selector = buildConformaSecurityTaskRunSelector(applicationName, componentName);
+
+  if (isKubearchiveTaskRunsEnabled) {
+    const k8sQueryOptions = convertToKubearchiveQueryParams({
+      groupVersionKind: TaskRunGroupVersionKind,
+      namespace,
+      isList: true,
+      selector,
+    });
+    // KubeArchive's list API always orders results by creationTimestamp desc
+    // (then id desc) server-side before applying `limit`, so items[0] is the
+    // newest match — same guarantee as Tekton Results' `create_time desc`.
+    const res = await k8sListResource<TaskRunKind>(
+      withKubearchivePathPrefix<K8sResourceListOptions>({
+        model: TaskRunModel,
+        queryOptions: {
+          ...(k8sQueryOptions || {}),
+          queryParams: {
+            ...(k8sQueryOptions?.queryParams || {}),
+            limit: 1,
+          },
+        },
+      }),
+    );
+    return res?.items?.[0] ?? null;
+  }
+
+  const [results] = await getTaskRuns(namespace, { selector, limit: 1 });
+  return results[0] ?? null;
+}
 
 const mapToConformaResultRow = (
   v: ConformaRule,

--- a/src/components/Conforma/ConformaResultsTab/conforma-taskrun-query.ts
+++ b/src/components/Conforma/ConformaResultsTab/conforma-taskrun-query.ts
@@ -2,7 +2,29 @@ import { PipelineRunLabel, PipelineRunType } from '~/consts/pipelinerun';
 import { CONFORMA_TASK, EC_TASK } from '~/consts/security';
 import { TaskRunGroupVersionKind } from '~/models/taskruns';
 import { TektonResourceLabel } from '~/types/coreTekton';
-import { WatchK8sResource } from '~/types/k8s';
+import type { Selector, WatchK8sResource } from '~/types/k8s';
+
+/**
+ * Builds the label selector for Conforma/EC security TaskRuns.
+ * Shared by both the K8s watch path and the on-demand fetcher path.
+ */
+export const buildConformaSecurityTaskRunSelector = (
+  applicationName: string,
+  componentName?: string,
+): Selector => ({
+  matchLabels: {
+    [PipelineRunLabel.APPLICATION]: applicationName,
+    ...(componentName ? { [PipelineRunLabel.COMPONENT]: componentName } : {}),
+    [PipelineRunLabel.PIPELINE_TYPE]: PipelineRunType.TEST,
+  },
+  matchExpressions: [
+    {
+      key: TektonResourceLabel.pipelineTask,
+      operator: 'In' as const,
+      values: [EC_TASK, CONFORMA_TASK],
+    },
+  ],
+});
 
 /**
  * Returns the WatchK8sResource descriptor for the Conforma security TaskRun
@@ -17,17 +39,5 @@ export const buildConformaSecurityTaskRunWatchOptions = (
   namespace,
   isList: true,
   watch: true,
-  selector: {
-    matchLabels: {
-      [PipelineRunLabel.APPLICATION]: applicationName,
-      [PipelineRunLabel.PIPELINE_TYPE]: PipelineRunType.TEST,
-    },
-    matchExpressions: [
-      {
-        key: TektonResourceLabel.pipelineTask,
-        operator: 'In',
-        values: [EC_TASK, CONFORMA_TASK],
-      },
-    ],
-  },
+  selector: buildConformaSecurityTaskRunSelector(applicationName),
 });

--- a/src/components/Conforma/ConformaResultsTab/useApplicationConformaResults.ts
+++ b/src/components/Conforma/ConformaResultsTab/useApplicationConformaResults.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useQueries, type UseQueryResult } from '@tanstack/react-query';
+import { useQueries, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
 import { PipelineRunLabel } from '~/consts/pipelinerun';
 import { useIsOnFeatureFlag } from '~/feature-flags/hooks';
 import { useComponents } from '~/hooks/useComponents';
@@ -16,11 +16,17 @@ import type {
 } from '~/types/conforma';
 import { TektonResourceLabel } from '~/types/coreTekton';
 import {
+  fetchLatestSecurityTaskRunForComponent,
   filterInvalidImageConformaRows,
   mapConformaResultData,
   resolveConformaResultFromTaskRun,
 } from './conforma-fetchers';
 import { buildConformaSecurityTaskRunWatchOptions } from './conforma-taskrun-query';
+
+/** Multiplier for per-component TaskRun headroom in the bounded batch (arch variants, retries). */
+const BATCH_LIMIT_PER_COMPONENT = 3;
+/** Minimum batch size so the first fetch stays bounded before components finish loading. */
+const BATCH_LIMIT_FLOOR = 10;
 
 const NO_OP_REFRESH: ConformaRefreshState = {
   lastFetchedAt: 0,
@@ -34,6 +40,7 @@ const EMPTY_RESULTS: ApplicationConformaResults = {
   totalComponents: 0,
   totalFailed: 0,
   loaded: false,
+  settling: false,
   error: undefined,
   partialLogError: undefined,
   refresh: NO_OP_REFRESH,
@@ -64,15 +71,38 @@ function statusFromCounts(
   return 'unknown';
 }
 
+function pickNewest(existing: TaskRunKind | undefined, candidate: TaskRunKind): TaskRunKind {
+  if (!existing) return candidate;
+  const candidateTs = candidate.metadata?.creationTimestamp ?? '';
+  const existingTs = existing.metadata?.creationTimestamp ?? '';
+  if (candidateTs !== existingTs) {
+    return candidateTs > existingTs ? candidate : existing;
+  }
+  const candidateName = candidate.metadata?.name ?? '';
+  const existingName = existing.metadata?.name ?? '';
+  return candidateName > existingName ? candidate : existing;
+}
+
 export const useApplicationConformaResults = (
   applicationName: string,
 ): ApplicationConformaResults => {
   const namespace = useNamespace();
   const isKubearchiveLogsEnabled = useIsOnFeatureFlag('kubearchive-logs');
+  const isKubearchiveTaskRunsEnabled = useIsOnFeatureFlag('taskruns-kubearchive');
 
   const [appComponents, componentsLoaded, componentsError] = useComponents(
     namespace,
     applicationName,
+  );
+
+  // Always apply a floor so useTaskRunsV2 never fires an unbounded list while components load.
+  const batchLimit = React.useMemo(
+    () =>
+      Math.max(
+        (componentsLoaded ? appComponents.length : 0) * BATCH_LIMIT_PER_COMPONENT,
+        BATCH_LIMIT_FLOOR,
+      ),
+    [appComponents.length, componentsLoaded],
   );
 
   // Conforma security TaskRun selector — passed to useTaskRunsV2 so list data
@@ -88,14 +118,16 @@ export const useApplicationConformaResults = (
   // Infinity staleTime: WS keeps data live; refresh button covers explicit refetch (vs global 30s).
   const [securityTaskRuns, taskRunsLoaded, taskRunsError, , , taskRunWatchMeta] = useTaskRunsV2(
     namespace,
-    watchOptions ? { selector: watchOptions.selector } : undefined,
+    watchOptions ? { selector: watchOptions.selector, limit: batchLimit } : undefined,
     { staleTime: Infinity },
   );
 
+  const queryClient = useQueryClient();
   const { refetch: refetchTaskRuns } = taskRunWatchMeta;
   const onRefresh = React.useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: ['conforma-fillin', namespace] });
     void refetchTaskRuns();
-  }, [refetchTaskRuns]);
+  }, [queryClient, namespace, refetchTaskRuns]);
 
   const refresh = React.useMemo(
     (): ConformaRefreshState => ({
@@ -114,25 +146,76 @@ export const useApplicationConformaResults = (
       const trName = tr.metadata?.name;
       if (!comp || !trName) continue;
 
-      const candidateTs = tr.metadata?.creationTimestamp ?? '';
-      const existing = newestByComp.get(comp);
-      const existingTs = existing?.metadata?.creationTimestamp ?? '';
-
-      if (
-        !existing ||
-        candidateTs.localeCompare(existingTs) > 0 ||
-        (candidateTs === existingTs && trName.localeCompare(existing.metadata?.name ?? '') > 0)
-      ) {
-        newestByComp.set(comp, tr);
-      }
+      newestByComp.set(comp, pickNewest(newestByComp.get(comp), tr));
     }
 
     return newestByComp;
   }, [securityTaskRuns]);
 
+  // --- Fill-in: fetch latest TaskRun for components missing from the batch ---
+  const missingComponents = React.useMemo(() => {
+    if (!taskRunsLoaded || !componentsLoaded) return [];
+    return appComponents
+      .map((c) => c.metadata?.name)
+      .filter((name): name is string => !!name && !latestPerComponent.has(name));
+  }, [appComponents, componentsLoaded, taskRunsLoaded, latestPerComponent]);
+
+  const { fillInTaskRuns, fillInSettled, fillInErrorKey } = useQueries({
+    queries: missingComponents.map((componentName) => ({
+      queryKey: [
+        'conforma-fillin',
+        namespace,
+        componentName,
+        applicationName,
+        isKubearchiveTaskRunsEnabled,
+      ] as const,
+      queryFn: () =>
+        fetchLatestSecurityTaskRunForComponent(
+          namespace,
+          applicationName,
+          componentName,
+          isKubearchiveTaskRunsEnabled,
+        ),
+      staleTime: Infinity,
+      enabled: !!namespace && missingComponents.length > 0,
+    })),
+    combine: (results) => {
+      const errors = results
+        .filter((q) => q.isError)
+        .map((q) => q.error)
+        .filter((error): error is Error => error != null);
+      return {
+        fillInTaskRuns: results.map((q) => q.data).filter((tr): tr is TaskRunKind => tr != null),
+        fillInSettled: results.every((q) => !q.isLoading),
+        // Stable key so the logging effect does not re-fire on every combine recompute.
+        fillInErrorKey: errors.map((e) => e.message).join('\0'),
+      };
+    },
+  });
+
+  React.useEffect(() => {
+    if (!fillInErrorKey) return;
+    for (const message of fillInErrorKey.split('\0')) {
+      logger.warn('useApplicationConformaResults: fill-in query failed', { message });
+    }
+  }, [fillInErrorKey]);
+
+  // Merge batch + fill-in into a single latest-per-component map
+  const mergedLatestPerComponent = React.useMemo((): Map<string, TaskRunKind> => {
+    if (fillInTaskRuns.length === 0) return latestPerComponent;
+
+    const merged = new Map(latestPerComponent);
+    for (const tr of fillInTaskRuns) {
+      const comp = tr.metadata?.labels?.[PipelineRunLabel.COMPONENT];
+      if (!comp) continue;
+      merged.set(comp, pickNewest(merged.get(comp), tr));
+    }
+    return merged;
+  }, [latestPerComponent, fillInTaskRuns]);
+
   const latestTaskRuns = React.useMemo(
-    () => Array.from(latestPerComponent.values()),
-    [latestPerComponent],
+    () => Array.from(mergedLatestPerComponent.values()),
+    [mergedLatestPerComponent],
   );
 
   const combineConformaLogResults = React.useCallback(
@@ -140,6 +223,7 @@ export const useApplicationConformaResults = (
       results: UseQueryResult<Awaited<ReturnType<typeof resolveConformaResultFromTaskRun>>>[],
     ) => ({
       logData: results.map((q) => q.data),
+      allSettled: results.every((q) => !q.isLoading),
       aggregatedLogError:
         results.length > 0 && results.some((q) => q.isError)
           ? results.find((q) => q.isError)?.error
@@ -148,7 +232,7 @@ export const useApplicationConformaResults = (
     [],
   );
 
-  const { logData, aggregatedLogError } = useQueries({
+  const { logData, allSettled: logsSettled, aggregatedLogError } = useQueries({
     queries: latestTaskRuns.map((tr) => ({
       queryKey: ['conforma-log', namespace, tr.metadata?.uid, isKubearchiveLogsEnabled] as const,
       queryFn: () => resolveConformaResultFromTaskRun(namespace, tr, isKubearchiveLogsEnabled),
@@ -159,6 +243,7 @@ export const useApplicationConformaResults = (
   });
 
   const loaded = Boolean(namespace?.length && componentsLoaded && taskRunsLoaded);
+  const settling = !fillInSettled || !logsSettled;
 
   const fatalError = componentsError ?? taskRunsError;
 
@@ -197,7 +282,7 @@ export const useApplicationConformaResults = (
       }
 
       const components = conformaByComponent.get(name);
-      const taskRun = latestPerComponent.get(name);
+      const taskRun = mergedLatestPerComponent.get(name);
       const pipelineRunName = taskRun?.metadata?.labels?.[TektonResourceLabel.pipelinerun];
 
       if (!components) {
@@ -227,17 +312,14 @@ export const useApplicationConformaResults = (
     const allResults: ConformaResultRow[] = [];
     for (const [realComponentName, components] of conformaByComponent.entries()) {
       const pipelineRunName =
-        latestPerComponent.get(realComponentName)?.metadata?.labels?.[
+        mergedLatestPerComponent.get(realComponentName)?.metadata?.labels?.[
           TektonResourceLabel.pipelinerun
         ];
       const rows = mapConformaResultData(components, pipelineRunName);
-      // The EC/Conforma report assigns its own per-image `name` to each
-      // components[] entry (see ComponentConformaResult), which is NOT the
-      // real K8s component name and can differ across architecture images
-      // of the same logical component. Overwrite it with the authoritative
-      // name so rows stay associated with the correct component regardless
-      // of how many arch-specific images were evaluated for it.
       rows.forEach((row) => {
+        // The EC/Conforma report assigns its own per-image `name` to each
+        // components[] entry, which is NOT the real K8s component name.
+        // Overwrite with the authoritative name so rows stay associated correctly.
         row.component = realComponentName;
       });
       allResults.push(...rows);
@@ -252,6 +334,7 @@ export const useApplicationConformaResults = (
       totalComponents,
       totalFailed,
       loaded,
+      settling,
       error: fatalError,
       partialLogError: aggregatedLogError,
       refresh,
@@ -260,9 +343,10 @@ export const useApplicationConformaResults = (
     aggregatedLogError,
     appComponents,
     fatalError,
-    latestPerComponent,
+    mergedLatestPerComponent,
     latestTaskRuns,
     loaded,
+    settling,
     logData,
     namespace?.length,
     refresh,

--- a/src/types/conforma.ts
+++ b/src/types/conforma.ts
@@ -103,6 +103,11 @@ export type ApplicationConformaResults = {
   totalComponents: number;
   totalFailed: number;
   loaded: boolean;
+  /**
+   * True while fill-in TaskRun queries or per-component log queries are still settling.
+   * The tab can render progressive results while this is true.
+   */
+  settling: boolean;
   /** Fatal errors that prevent the tab from loading (components or TaskRun list). */
   error: unknown;
   /** Non-fatal log fetch failures for one or more components; results may still be partial. */


### PR DESCRIPTION
Improve the loading time and relevancy of data on the conforma board by loading a capped latest-per-component TaskRun batch, fill in missing components, and show progressive loading so the tab reaches a useful board faster without dumping full history.

Assisted-by: Cursor


## Fixes 
https://redhat.atlassian.net/browse/KFLUXSE-367

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

<img width="1367" height="652" alt="image" src="https://github.com/user-attachments/assets/fbebfb44-8716-45c6-ac43-1ce8d95c8435" />


## Type of change
- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## How to test or reproduce?
tests & local cluster



## Browser conformance: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer progress feedback while Conforma results are being finalized, including accessible status announcements.
  * Summaries now indicate when results are still updating.
* **Bug Fixes**
  * Improved recovery when results are temporarily missing for individual components.
  * Prevented misleading empty-state messages from appearing while results are still loading.
  * Refined selection of the latest security results for each component.
* **Accessibility**
  * Added live status updates and busy-state indicators for assistive technology users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->