### PR TITLE
fix(KFLUXSE-366): fall back to alternate Conforma log backend on failure

### DIFF
--- a/src/components/Conforma/ConformaResultsTab/__tests__/conforma-fetchers.spec.ts
+++ b/src/components/Conforma/ConformaResultsTab/__tests__/conforma-fetchers.spec.ts
@@ -190,14 +190,18 @@ describe('resolveConformaResultFromTaskRun', () => {
     expect(result).toEqual(mockConformaResult);
   });
 
-  it('throws when flag is ON and kubearchive fails — tekton-results is never called', async () => {
+  it('falls back to tekton-results when flag is ON and kubearchive fails', async () => {
     jest.mocked(commonFetchJSON).mockRejectedValue(new Error('kubearchive down'));
 
-    await expect(
-      resolveConformaResultFromTaskRun(NAMESPACE, createTaskRun('tr-1', 'pod-1'), true),
-    ).rejects.toThrow('kubearchive down');
+    const result = await resolveConformaResultFromTaskRun(
+      NAMESPACE,
+      createTaskRun('tr-1', 'pod-1'),
+      true,
+    );
 
-    expect(getTaskRunLog).not.toHaveBeenCalled();
+    expect(commonFetchJSON).toHaveBeenCalled();
+    expect(getTaskRunLog).toHaveBeenCalled();
+    expect(result).toEqual(mockConformaResult);
   });
 
   it('delegates to tekton-results when flag is OFF', async () => {
@@ -212,14 +216,56 @@ describe('resolveConformaResultFromTaskRun', () => {
     expect(result).toEqual(mockConformaResult);
   });
 
-  it('throws when flag is OFF and tekton-results fails — kubearchive is never called', async () => {
+  it('falls back to kubearchive when flag is OFF and tekton-results fails', async () => {
     jest.mocked(getTaskRunLog).mockRejectedValue(new Error('tekton-results down'));
+
+    const result = await resolveConformaResultFromTaskRun(
+      NAMESPACE,
+      createTaskRun('tr-1', 'pod-1'),
+      false,
+    );
+
+    expect(getTaskRunLog).toHaveBeenCalled();
+    expect(commonFetchJSON).toHaveBeenCalled();
+    expect(result).toEqual(mockConformaResult);
+  });
+
+  it('throws primary (kubearchive) error when flag is ON and both sources fail', async () => {
+    jest.mocked(commonFetchJSON).mockRejectedValue(new Error('kubearchive down'));
+    jest.mocked(getTaskRunLog).mockRejectedValue(new Error('tekton-results down'));
+
+    await expect(
+      resolveConformaResultFromTaskRun(NAMESPACE, createTaskRun('tr-1', 'pod-1'), true),
+    ).rejects.toThrow('kubearchive down');
+  });
+
+  it('throws primary (tekton-results) error when flag is OFF and both sources fail', async () => {
+    jest.mocked(getTaskRunLog).mockRejectedValue(new Error('tekton-results down'));
+    jest.mocked(commonFetchJSON).mockRejectedValue(new Error('kubearchive down'));
 
     await expect(
       resolveConformaResultFromTaskRun(NAMESPACE, createTaskRun('tr-1', 'pod-1'), false),
     ).rejects.toThrow('tekton-results down');
+  });
+
+  it('falls back to tekton-results when flag is ON and TaskRun has no podName', async () => {
+    const result = await resolveConformaResultFromTaskRun(
+      NAMESPACE,
+      createTaskRun('tr-1'),
+      true,
+    );
 
     expect(commonFetchJSON).not.toHaveBeenCalled();
+    expect(getTaskRunLog).toHaveBeenCalled();
+    expect(result).toEqual(mockConformaResult);
+  });
+
+  it('throws primary (tekton-results) error when flag is OFF, tekton fails, and TaskRun has no podName', async () => {
+    jest.mocked(getTaskRunLog).mockRejectedValue(new Error('tekton-results down'));
+
+    await expect(
+      resolveConformaResultFromTaskRun(NAMESPACE, createTaskRun('tr-1'), false),
+    ).rejects.toThrow('tekton-results down');
   });
 });
 

--- a/src/components/Conforma/ConformaResultsTab/conforma-fetchers.ts
+++ b/src/components/Conforma/ConformaResultsTab/conforma-fetchers.ts
@@ -89,10 +89,19 @@ export async function resolveConformaResultFromTaskRun(
   taskRun: TaskRunKind,
   isKubearchiveLogsEnabled: boolean,
 ): Promise<ConformaResult | undefined> {
-  if (isKubearchiveLogsEnabled) {
-    return fetchConformaLogFromKubearchive(namespace, taskRun);
+  const [primary, fallback] = isKubearchiveLogsEnabled
+    ? [fetchConformaLogFromKubearchive, fetchConformaLogFromTektonResults]
+    : [fetchConformaLogFromTektonResults, fetchConformaLogFromKubearchive];
+
+  try {
+    return await primary(namespace, taskRun);
+  } catch (primaryError) {
+    try {
+      return await fallback(namespace, taskRun);
+    } catch {
+      throw primaryError;
+    }
   }
-  return fetchConformaLogFromTektonResults(namespace, taskRun);
 }
 
 /**

--- a/src/components/Conforma/__tests__/useConformaResult.spec.tsx
+++ b/src/components/Conforma/__tests__/useConformaResult.spec.tsx
@@ -259,13 +259,25 @@ describe('useConformaResult', () => {
     expect(ecResult.findIndex((ec) => ec.name === 'devfile-sample-1jik')).toEqual(-1);
   });
 
-  it('should return handle api errors', async () => {
+  it('should fall back to kubearchive when tekton-results fails', async () => {
     mockGetTaskRunLogs.mockRejectedValue(new Error('Api error'));
 
     const { result, waitForNextUpdate } = renderHookWithQueryClient('dummy-abcd');
     await waitForNextUpdate();
     const [ecResult, loaded] = result.current;
     expect(mockGetTaskRunLogs).toHaveBeenCalled();
+    expect(mockCommmonFetchJSON).toHaveBeenCalled();
+    expect(loaded).toBe(true);
+    expect(ecResult).toBeDefined();
+  });
+
+  it('should return undefined when both tekton-results and kubearchive fail', async () => {
+    mockGetTaskRunLogs.mockRejectedValue(new Error('Api error'));
+    mockCommmonFetchJSON.mockRejectedValue(new Error('KubeArchive error'));
+
+    const { result, waitForNextUpdate } = renderHookWithQueryClient('dummy-abcd');
+    await waitForNextUpdate();
+    const [ecResult, loaded] = result.current;
     expect(loaded).toBe(true);
     expect(ecResult).toBeUndefined();
   });
@@ -342,15 +354,28 @@ describe('useConformaResult', () => {
     expect(ecResult[0].violations.length).toEqual(1);
   });
 
-  it('should show empty state when kubearchive fetch fails', async () => {
+  it('should fall back to tekton-results when kubearchive fetch fails', async () => {
     mockUseIsOnFeatureFlag.mockReturnValue(true);
     mockCommmonFetchJSON.mockRejectedValue(new Error('KubeArchive error'));
 
     const { result, waitForNextUpdate } = renderHookWithQueryClient('dummy-abcd');
     await waitForNextUpdate();
 
-    expect(mockCommmonFetchJSON).toHaveBeenCalledTimes(1);
-    expect(mockGetTaskRunLogs).not.toHaveBeenCalled();
+    expect(mockCommmonFetchJSON).toHaveBeenCalled();
+    expect(mockGetTaskRunLogs).toHaveBeenCalled();
+
+    const [ecResult, loaded] = result.current;
+    expect(loaded).toBe(true);
+    expect(ecResult).toBeDefined();
+  });
+
+  it('should return undefined when kubearchive is enabled and both sources fail', async () => {
+    mockUseIsOnFeatureFlag.mockReturnValue(true);
+    mockCommmonFetchJSON.mockRejectedValue(new Error('KubeArchive error'));
+    mockGetTaskRunLogs.mockRejectedValue(new Error('Tekton error'));
+
+    const { result, waitForNextUpdate } = renderHookWithQueryClient('dummy-abcd');
+    await waitForNextUpdate();
 
     const [ecResult, loaded] = result.current;
     expect(loaded).toBe(true);


### PR DESCRIPTION
When the kubearchive-logs flag picks one log source and it 404s or errors, try the other backend before treating the TaskRun as empty.

Assisted-by: Cursor


## Fixes 
https://redhat.atlassian.net/browse/KFLUXSE-366

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## How to test or reproduce?
tests & local cluster


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Conforma result loading by automatically falling back between Tekton Results and Kubearchive when the primary log source fails.
  * Preserved loading state while successfully retrieving results from the fallback source.
  * Improved error handling when both log sources fail or required task information is unavailable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->