### PR TITLE
fix(KFLUXUI-1528): fix TableV2 invalid flex column width

### DIFF
--- a/src/shared/components/TableV2/TableHeader.tsx
+++ b/src/shared/components/TableV2/TableHeader.tsx
@@ -38,7 +38,7 @@ export const TableHeader = <TData,>({
             const widthProps: Partial<ThProps> = {};
 
             if (colWidth?.type === 'flex') {
-              widthProps.width = colWidth.widthPercent as ThProps['width'];
+              widthProps.style = { width: `${colWidth.widthPercent}%` };
             } else if (colWidth?.type === 'fixed') {
               widthProps.style = { width: colWidth.fixedWidth };
             }

--- a/src/shared/components/TableV2/__tests__/TableHeader.spec.tsx
+++ b/src/shared/components/TableV2/__tests__/TableHeader.spec.tsx
@@ -90,13 +90,13 @@ describe('TableHeader', () => {
     expect(columnHeaders[1]).not.toHaveAttribute('aria-sort');
   });
 
-  it('applies width class for flex columns', () => {
+  it('applies inline style for flex columns', () => {
     const table = createMockTable(defaultHeaders);
     renderTableHeader(<TableHeader table={table as never} columnWidths={defaultWidths} />);
 
     const thead = screen.getByTestId('table-header');
     const columnHeaders = within(thead).getAllByRole('columnheader');
-    expect(columnHeaders[0]).toHaveClass('pf-m-width-60');
+    expect(columnHeaders[0]).toHaveStyle({ width: '60%' });
   });
 
   it('applies inline style for fixed-width columns', () => {


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->

Fixes https://issues.redhat.com/browse/KFLUXUI-1528

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When using flex type, the computed width could have a value not supported by PF's `Th` width prop (e.g. 17%), which was silently ignored - leaving columns with no width constraint. This caused column overlap and flickering during browser resize.

Fix: use `style={{ width: x% }}` directly instead of PF's `width` prop, so any percentage value works. This is consistent with how fixed-width columns already apply their widths.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

https://github.com/user-attachments/assets/6685f5d2-f44f-4f66-867e-732b72e98d7c

AfteR:

https://github.com/user-attachments/assets/97c79e7d-864b-4b56-883e-1b3b7945ae98

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

- Navigate to Snapshots tab (Applications -> select an app -> Snapshots)
- Resize the browser window horizontally
- Verify columns (Name, Created at, Components, etc.) don't overlap or flicker during resize

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table column sizing for flexible-width columns, ensuring the configured percentage is applied correctly.
  * Preserved existing fixed-width and sorting behavior.

* **Tests**
  * Updated coverage to verify flexible columns use the correct inline width styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->