### PR TITLE
fix(KFLUXUI-1455): fetch all TaskRun pages for Conforma Results

### DIFF
--- a/src/components/Conforma/ConformaResultsTab/__tests__/useApplicationConformaResults.spec.ts
+++ b/src/components/Conforma/ConformaResultsTab/__tests__/useApplicationConformaResults.spec.ts
@@ -771,4 +771,126 @@ describe('useApplicationConformaResults', () => {
 
     expect(result.current.componentStatuses[0].pipelineRunName).toBe('pr-1');
   });
+
+  describe('pagination', () => {
+    it('calls getNextPage and reports loaded=false while hasNextPage is true', async () => {
+      const components = [createComponent('comp-a')];
+      const taskRuns = [createSecurityTaskRun('tr-1', 'comp-a', 'pod-1')];
+      const getNextPage = jest.fn();
+
+      mockUseComponents.mockReturnValue([components, true, undefined]);
+      mockUseTaskRunsV2.mockReturnValue([
+        taskRuns,
+        true,
+        undefined,
+        getNextPage,
+        { hasNextPage: true, isFetchingNextPage: false },
+      ]);
+      mockResolveConforma.mockResolvedValue(mockConformaResult);
+
+      const { result } = renderHook(() => useApplicationConformaResults('test-app'), {
+        wrapper: createWrapper(),
+      });
+
+      await flushEffects();
+
+      expect(result.current.loaded).toBe(false);
+      expect(getNextPage).toHaveBeenCalled();
+    });
+
+    it('becomes loaded with all results once pagination completes', async () => {
+      const components = [createComponent('comp-a'), createComponent('comp-b')];
+      const page1TaskRuns = [createSecurityTaskRun('tr-1', 'comp-a', 'pod-1')];
+      const getNextPage = jest.fn();
+
+      mockUseComponents.mockReturnValue([components, true, undefined]);
+      mockUseTaskRunsV2.mockReturnValue([
+        page1TaskRuns,
+        true,
+        undefined,
+        getNextPage,
+        { hasNextPage: true, isFetchingNextPage: false },
+      ]);
+      mockResolveConforma.mockResolvedValue(mockConformaResult);
+
+      const { result, rerender } = renderHook(
+        () => useApplicationConformaResults('test-app'),
+        { wrapper: createWrapper() },
+      );
+
+      await flushEffects();
+      expect(result.current.loaded).toBe(false);
+
+      const allTaskRuns = [
+        createSecurityTaskRun('tr-1', 'comp-a', 'pod-1'),
+        createSecurityTaskRun('tr-2', 'comp-b', 'pod-2'),
+      ];
+      mockUseTaskRunsV2.mockReturnValue([
+        allTaskRuns,
+        true,
+        undefined,
+        getNextPage,
+        { hasNextPage: false, isFetchingNextPage: false },
+      ]);
+
+      rerender();
+      await flushEffects();
+
+      expect(result.current.loaded).toBe(true);
+      expect(result.current.allResults.length).toBeGreaterThan(0);
+      const resultComponents = result.current.allResults.map((r) => r.component);
+      expect(resultComponents).toContain('comp-a');
+      expect(resultComponents).toContain('comp-b');
+    });
+
+    it('reports loaded=true and surfaces error when pagination errors with hasNextPage still true', async () => {
+      const components = [createComponent('comp-a')];
+      const taskRuns = [createSecurityTaskRun('tr-1', 'comp-a', 'pod-1')];
+      const getNextPage = jest.fn();
+      const paginationError = new Error('pagination failed');
+
+      mockUseComponents.mockReturnValue([components, true, undefined]);
+      mockUseTaskRunsV2.mockReturnValue([
+        taskRuns,
+        true,
+        paginationError,
+        getNextPage,
+        { hasNextPage: true, isFetchingNextPage: false },
+      ]);
+
+      const { result } = renderHook(() => useApplicationConformaResults('test-app'), {
+        wrapper: createWrapper(),
+      });
+
+      await flushEffects();
+
+      expect(result.current.loaded).toBe(true);
+      expect(result.current.error).toBe(paginationError);
+      expect(getNextPage).not.toHaveBeenCalled();
+    });
+
+    it('does not call getNextPage while isFetchingNextPage is true', async () => {
+      const components = [createComponent('comp-a')];
+      const taskRuns = [createSecurityTaskRun('tr-1', 'comp-a', 'pod-1')];
+      const getNextPage = jest.fn();
+
+      mockUseComponents.mockReturnValue([components, true, undefined]);
+      mockUseTaskRunsV2.mockReturnValue([
+        taskRuns,
+        true,
+        undefined,
+        getNextPage,
+        { hasNextPage: true, isFetchingNextPage: true },
+      ]);
+
+      const { result } = renderHook(() => useApplicationConformaResults('test-app'), {
+        wrapper: createWrapper(),
+      });
+
+      await flushEffects();
+
+      expect(result.current.loaded).toBe(false);
+      expect(getNextPage).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/components/Conforma/ConformaResultsTab/useApplicationConformaResults.ts
+++ b/src/components/Conforma/ConformaResultsTab/useApplicationConformaResults.ts
@@ -83,12 +83,22 @@ export const useApplicationConformaResults = (
     [applicationName],
   );
 
-  const [securityTaskRuns, taskRunsLoaded, taskRunsError] = useTaskRunsV2(
-    namespace?.length ? namespace : null,
-    { selector },
-  );
+  const [securityTaskRuns, taskRunsLoaded, taskRunsError, getNextPage, nextPageProps] =
+    useTaskRunsV2(namespace?.length ? namespace : null, { selector });
+
+  React.useEffect(() => {
+    if (nextPageProps.hasNextPage && !nextPageProps.isFetchingNextPage && taskRunsLoaded && !taskRunsError) {
+      getNextPage();
+    }
+  }, [nextPageProps.hasNextPage, nextPageProps.isFetchingNextPage, taskRunsLoaded, getNextPage, taskRunsError]);
+
+  const taskRunsFullyLoaded =
+    taskRunsLoaded &&
+    !nextPageProps.isFetchingNextPage &&
+    (!nextPageProps.hasNextPage || !!taskRunsError);
 
   const latestPerComponent = React.useMemo((): Map<string, TaskRunKind> => {
+    if (!taskRunsFullyLoaded) return new Map();
     const newestByComp = new Map<string, TaskRunKind>();
 
     for (const tr of securityTaskRuns ?? []) {
@@ -110,7 +120,7 @@ export const useApplicationConformaResults = (
     }
 
     return newestByComp;
-  }, [securityTaskRuns]);
+  }, [securityTaskRuns, taskRunsFullyLoaded]);
 
   const latestTaskRuns = React.useMemo(
     () => Array.from(latestPerComponent.values()),
@@ -132,7 +142,7 @@ export const useApplicationConformaResults = (
     }),
   });
 
-  const loaded = Boolean(namespace?.length && componentsLoaded && taskRunsLoaded);
+  const loaded = Boolean(namespace?.length && componentsLoaded && taskRunsFullyLoaded);
   const settling = !allSettled;
 
   const aggregateError = componentsError ?? taskRunsError ?? aggregatedLogError;


### PR DESCRIPTION
Drain Tekton Results / KubeArchive pagination in
useApplicationConformaResults so apps with more TaskRuns than one page still get complete per-component Conforma data. Gate loaded state on full pagination (or error) to avoid partial results and infinite spinners.

Assisted-by: Cursor


## Fixes 
https://redhat.atlassian.net/browse/KFLUXUI-1455


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
tests 


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->