### PR TITLE
feat(KFLUXSE-344): add Component multi-select filter to Conforma results

### DIFF
--- a/src/components/Conforma/ConformaResultsTab/ConformaResultsTab.tsx
+++ b/src/components/Conforma/ConformaResultsTab/ConformaResultsTab.tsx
@@ -46,7 +46,11 @@ const ConformaResultsTabContent: React.FC = () => {
     refresh,
   } = useApplicationConformaResults(applicationName);
 
-  const { name: nameFilter, status: statusFilter } = useConformaFilters();
+  const {
+    name: nameFilter,
+    status: statusFilter,
+    component: componentFilter,
+  } = useConformaFilters();
 
   const [groupBy, setGroupBy] = React.useState<GroupByMode>('rule');
   const [expandedGroups, setExpandedGroups] = React.useState<Set<string>>(new Set());
@@ -70,8 +74,8 @@ const ConformaResultsTabContent: React.FC = () => {
   const rawCounts = React.useMemo(() => countResultsByStatus(allResults), [allResults]);
 
   const filteredResults = React.useMemo(
-    () => filterResults(displayResults, nameFilter, statusFilter),
-    [displayResults, nameFilter, statusFilter],
+    () => filterResults(displayResults, nameFilter, statusFilter, componentFilter),
+    [displayResults, nameFilter, statusFilter, componentFilter],
   );
 
   const allComponentNames = React.useMemo(
@@ -79,12 +83,20 @@ const ConformaResultsTabContent: React.FC = () => {
     [componentStatuses],
   );
 
+  const visibleComponentNames = React.useMemo(
+    () =>
+      componentFilter.length > 0
+        ? allComponentNames.filter((name) => componentFilter.includes(name))
+        : allComponentNames,
+    [allComponentNames, componentFilter],
+  );
+
   const groups = React.useMemo(
     () =>
       groupBy === 'rule'
         ? groupByRule(filteredResults)
-        : groupByComponent(filteredResults, allComponentNames),
-    [groupBy, filteredResults, allComponentNames],
+        : groupByComponent(filteredResults, visibleComponentNames),
+    [groupBy, filteredResults, visibleComponentNames],
   );
 
   const handleToggleGroup = React.useCallback((groupKey: string) => {
@@ -204,7 +216,7 @@ const ConformaResultsTabContent: React.FC = () => {
  * same pattern used by CommitsListViewV2 and PipelineRunsListViewV2.
  */
 export const ConformaResultsTab: React.FC = () => (
-  <FilterContextProvider filterParams={['name', 'status']}>
+  <FilterContextProvider filterParams={['name', 'status', 'component']}>
     <ConformaResultsTabContent />
   </FilterContextProvider>
 );

--- a/src/components/Conforma/ConformaResultsTab/ConformaResultsToolbar.tsx
+++ b/src/components/Conforma/ConformaResultsTab/ConformaResultsToolbar.tsx
@@ -62,9 +62,14 @@ export const ConformaResultsToolbar: React.FC<ConformaResultsToolbarProps> = ({
 }) => {
   const { setFilters, onClearFilters } = React.useContext(FilterContext);
   const filters = useConformaFilters();
-  const { name: nameFilter, status: statusFilter } = filters;
+  const { name: nameFilter, status: statusFilter, component: componentFilter } = filters;
 
   const [isGroupByOpen, setIsGroupByOpen] = React.useState(false);
+
+  const componentFilterObj = React.useMemo(
+    () => createFilterObj(allResults, (r) => r.component),
+    [allResults],
+  );
 
   const statusFilterObj = React.useMemo(
     () => createFilterObj(allResults, (r) => r.status, statuses),
@@ -79,6 +84,16 @@ export const ConformaResultsToolbar: React.FC<ConformaResultsToolbarProps> = ({
       onClearFilters={onClearFilters}
       dataTest="conforma-results-toolbar"
     >
+      <MultiSelect
+        label="Component"
+        filterKey="component"
+        values={componentFilter}
+        setValues={(component) => setFilters({ ...filters, component })}
+        options={componentFilterObj}
+        hasInlineFilter
+        inlineFilterPlaceholderText="Filter components"
+        inlineFilterThreshold={10}
+      />
       <MultiSelect
         label="Status"
         filterKey="status"

--- a/src/components/Conforma/ConformaResultsTab/__tests__/ConformaResultsToolbar.spec.tsx
+++ b/src/components/Conforma/ConformaResultsTab/__tests__/ConformaResultsToolbar.spec.tsx
@@ -20,10 +20,10 @@ const mockRow = (overrides: Partial<ConformaResultRow> = {}): ConformaResultRow 
 });
 
 const allResults: ConformaResultRow[] = [
-  mockRow({ status: CONFORMA_RESULT_STATUS.violations }),
-  mockRow({ status: CONFORMA_RESULT_STATUS.violations }),
-  mockRow({ status: CONFORMA_RESULT_STATUS.warnings }),
-  mockRow({ status: CONFORMA_RESULT_STATUS.successes }),
+  mockRow({ status: CONFORMA_RESULT_STATUS.violations, component: 'api-gateway' }),
+  mockRow({ status: CONFORMA_RESULT_STATUS.violations, component: 'auth-service' }),
+  mockRow({ status: CONFORMA_RESULT_STATUS.warnings, component: 'api-gateway' }),
+  mockRow({ status: CONFORMA_RESULT_STATUS.successes, component: 'auth-service' }),
 ];
 
 const makeRefresh = (overrides: Partial<ConformaRefreshState> = {}): ConformaRefreshState => ({
@@ -52,7 +52,7 @@ describe('ConformaResultsToolbar', () => {
 
   const renderToolbar = (props: Partial<typeof defaultProps> = {}) => {
     routerRenderer(
-      <FilterContextProvider filterParams={['name', 'status']}>
+      <FilterContextProvider filterParams={['name', 'status', 'component']}>
         <ConformaResultsToolbar {...defaultProps} {...props} />
       </FilterContextProvider>,
     );
@@ -150,7 +150,7 @@ describe('ConformaResultsToolbar', () => {
     renderToolbar();
 
     fireEvent.click(screen.getByTestId('conforma-group-by-select'));
-    fireEvent.click(screen.getByText('Component'));
+    fireEvent.click(screen.getByRole('option', { name: 'Component' }));
 
     expect(onGroupByChange).toHaveBeenCalledWith('component');
   });
@@ -218,5 +218,30 @@ describe('ConformaResultsToolbar', () => {
     renderToolbar({ refresh: makeRefresh({ lastFetchedAt: 0 }) });
 
     expect(screen.queryByTestId('conforma-last-checked')).not.toBeInTheDocument();
+  });
+
+  it('renders Component filter toggle button', () => {
+    renderToolbar();
+
+    expect(screen.getByRole('button', { name: /component filter menu/i })).toBeInTheDocument();
+  });
+
+  it('opens Component menu and shows distinct component names from allResults', () => {
+    renderToolbar();
+
+    fireEvent.click(screen.getByRole('button', { name: /component filter menu/i }));
+
+    expect(screen.getByText('api-gateway')).toBeInTheDocument();
+    expect(screen.getByText('auth-service')).toBeInTheDocument();
+  });
+
+  it('shows badge count on Component toggle after selecting an option', () => {
+    renderToolbar();
+
+    const toggle = screen.getByRole('button', { name: /component filter menu/i });
+    fireEvent.click(toggle);
+    fireEvent.click(screen.getByText('api-gateway'));
+
+    expect(toggle).toHaveTextContent('1');
   });
 });

--- a/src/components/Conforma/ConformaResultsTab/__tests__/conforma-grouping-utils.spec.ts
+++ b/src/components/Conforma/ConformaResultsTab/__tests__/conforma-grouping-utils.spec.ts
@@ -544,5 +544,35 @@ describe('conforma-grouping-utils', () => {
       expect(dotResults).toHaveLength(1);
       expect(dotResults[0].code).toBe('trusted.task_trusted_rule');
     });
+
+    it('filters by a single component', () => {
+      const results = filterResults(sampleRows, '', [], ['auth-service']);
+      expect(results).toHaveLength(1);
+      expect(results[0].component).toBe('auth-service');
+    });
+
+    it('filters by multiple components', () => {
+      const results = filterResults(sampleRows, '', [], ['api-gateway', 'auth-service']);
+      expect(results).toHaveLength(3);
+    });
+
+    it('returns all rows when componentFilters is empty', () => {
+      expect(filterResults(sampleRows, '', [], [])).toHaveLength(3);
+    });
+
+    it('composes with text search and status filters', () => {
+      const results = filterResults(
+        sampleRows,
+        'CVE',
+        [CONFORMA_RESULT_STATUS.violations],
+        ['api-gateway'],
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].title).toBe('Missing CVE scan');
+    });
+
+    it('returns empty when filtering by a nonexistent component', () => {
+      expect(filterResults(sampleRows, '', [], ['nonexistent'])).toHaveLength(0);
+    });
   });
 });

--- a/src/components/Conforma/ConformaResultsTab/conforma-grouping-utils.ts
+++ b/src/components/Conforma/ConformaResultsTab/conforma-grouping-utils.ts
@@ -89,6 +89,7 @@ export const filterResults = (
   results: ConformaResultRow[],
   searchText: string,
   statusFilters: string[],
+  componentFilters: string[] = [],
 ): ConformaResultRow[] =>
   results.filter((row) => {
     if (
@@ -101,6 +102,10 @@ export const filterResults = (
     }
 
     if (statusFilters.length > 0 && !statusFilters.includes(row.status)) {
+      return false;
+    }
+
+    if (componentFilters.length > 0 && !componentFilters.includes(row.component)) {
       return false;
     }
 

--- a/src/components/Conforma/ConformaResultsTab/useConformaFilters.ts
+++ b/src/components/Conforma/ConformaResultsTab/useConformaFilters.ts
@@ -5,6 +5,7 @@ import { useDeepCompareMemoize } from '~/shared';
 export type ConformaFilters = {
   name: string;
   status: string[];
+  component: string[];
 };
 
 export const useConformaFilters = (): ConformaFilters => {
@@ -12,5 +13,6 @@ export const useConformaFilters = (): ConformaFilters => {
   return useDeepCompareMemoize({
     name: filters.name ? (filters.name as string) : '',
     status: filters.status ? (filters.status as string[]) : [],
+    component: filters.component ? (filters.component as string[]) : [],
   });
 };


### PR DESCRIPTION
## Fixes 
https://redhat.atlassian.net/browse/KFLUXSE-344

## Description
URL-synced component filter composes with name/status search and hides unselected groups in group-by-component mode.

Assisted-by: Cursor


## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):



## How to test or reproduce?
unit tests & local cluster


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added component-based filtering for Conforma results alongside name and status filters.
  * Added a component multi-select control with available component options and selected-item counts.
  * Component filters now persist in the URL for navigation and bookmarks.
  * Grouped results update to reflect the selected components.

* **Bug Fixes**
  * Improved filtering behavior when combining component, name, and status criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->