### PR TITLE
feat(KFLUXSE-345): conforma board to link pipelineruns

### DIFF
--- a/src/components/Conforma/ConformaResultsTab/ConformaGroupedTable.tsx
+++ b/src/components/Conforma/ConformaResultsTab/ConformaGroupedTable.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
+import { Link, useParams } from 'react-router-dom';
 import { Content, Tooltip, Truncate as PfTruncate } from '@patternfly/react-core';
 import { ExpandableRowContent, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { PIPELINE_RUNS_SECURITY_PATH } from '@routes/paths';
 import { getRuleStatus } from '~/components/Conforma/utils';
 import { Truncate } from '~/shared/components/truncate-text/Truncate';
+import { useNamespace } from '~/shared/providers/Namespace';
 import type { ConformaResultRow } from '~/types/conforma';
 import type { GroupByMode, GroupedConformaRow } from './conforma-grouping-utils';
 import { getCommonImageName } from './conforma-grouping-utils';
@@ -17,86 +20,111 @@ type ConformaGroupedTableProps = {
   onToggleGroup: (groupKey: string) => void;
 };
 
-const DetailSubTable: React.FC<{ rows: ConformaResultRow[] }> = ({ rows }) => (
-  <Table
-    aria-label="Conforma detail rows"
-    variant="compact"
-    borders={false}
-    className="conforma-results-tab__detail-table"
-  >
-    <Thead>
-      <Tr>
-        <Th width={20}>Rule</Th>
-        <Th width={15}>Component</Th>
-        <Th width={25}>Image</Th>
-        <Th width={10}>Status</Th>
-        <Th width={30}>Message</Th>
-      </Tr>
-    </Thead>
-    <Tbody>
-      {rows.map((row, idx) => {
-        const commonName = row.images.length > 1 ? getCommonImageName(row.images) : undefined;
-        return (
-          <Tr key={`${row.component}-${row.title}-${idx}`}>
-            <Td dataLabel="Rule">
-              <Content>
-                <Content component="p">
-                  <strong>{row.title ?? '-'}</strong>
+const DetailSubTable: React.FC<{ rows: ConformaResultRow[] }> = ({ rows }) => {
+  const namespace = useNamespace();
+  const { applicationName } = useParams();
+  return (
+    <Table
+      aria-label="Conforma detail rows"
+      variant="compact"
+      borders={false}
+      className="conforma-results-tab__detail-table"
+    >
+      <Thead>
+        <Tr>
+          <Th width={20}>Rule</Th>
+          <Th width={10}>Component</Th>
+          <Th width={25}>Image</Th>
+          <Th width={10}>Status</Th>
+          <Th width={20}>Message</Th>
+          <Th width={20}>Pipeline run</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {rows.map((row, idx) => {
+          const commonName = row.images.length > 1 ? getCommonImageName(row.images) : undefined;
+          return (
+            <Tr key={`${row.component}-${row.title}-${idx}`}>
+              <Td dataLabel="Rule">
+                <Content>
+                  <Content component="p">
+                    <strong>{row.title ?? '-'}</strong>
+                  </Content>
+                  {row.code && <Content component="small">{row.code}</Content>}
+                  {row.description && <Content component="small">{row.description}</Content>}
                 </Content>
-                {row.code && <Content component="small">{row.code}</Content>}
-                {row.description && <Content component="small">{row.description}</Content>}
-              </Content>
-            </Td>
-            <Td dataLabel="Component">{row.component}</Td>
-            <Td dataLabel="Image">
-              {row.images.length > 1 ? (
-                <Tooltip
-                  content={
-                    <ul>
-                      {row.images.map((img) => (
-                        <li key={img}>{img}</li>
-                      ))}
-                    </ul>
-                  }
-                >
-                  <Content>
-                    {commonName ? (
-                      <>
-                        <Content component="p">
-                          <PfTruncate content={commonName} />
-                        </Content>
-                        <Content component="small">{row.images.length} arch variants</Content>
-                      </>
+              </Td>
+              <Td dataLabel="Component">{row.component}</Td>
+              <Td dataLabel="Image">
+                {row.images.length > 1 ? (
+                  <Tooltip
+                    content={
+                      <ul>
+                        {row.images.map((img) => (
+                          <li key={img}>{img}</li>
+                        ))}
+                      </ul>
+                    }
+                  >
+                    <Content>
+                      {commonName ? (
+                        <>
+                          <Content component="p">
+                            <PfTruncate content={commonName} />
+                          </Content>
+                          <Content component="small">{row.images.length} arch variants</Content>
+                        </>
+                      ) : (
+                        <Content component="p">Affects {row.images.length} images</Content>
+                      )}
+                    </Content>
+                  </Tooltip>
+                ) : row.images.length === 1 ? (
+                  <PfTruncate content={row.images[0]} />
+                ) : (
+                  '-'
+                )}
+              </Td>
+              <Td dataLabel="Status">{getRuleStatus(row.status)}</Td>
+              <Td dataLabel="Message">
+                <Content>
+                  <Content component="p">
+                    {row.msg != null ? (
+                      <Truncate
+                        content={row.msg}
+                        expandInline
+                        data-test="conforma-violation-msg"
+                      />
                     ) : (
-                      <Content component="p">Affects {row.images.length} images</Content>
+                      '-'
                     )}
                   </Content>
-                </Tooltip>
-              ) : row.images.length === 1 ? (
-                <PfTruncate content={row.images[0]} />
-              ) : (
-                '-'
-              )}
-            </Td>
-            <Td dataLabel="Status">{getRuleStatus(row.status)}</Td>
-            <Td dataLabel="Message">
-              <Content>
-                <Content component="p">
-                  {row.msg != null ? (
-                    <Truncate content={row.msg} expandInline data-test="conforma-violation-msg" />
-                  ) : (
-                    '-'
-                  )}
+                  {row.solution && <Content component="small">Solution: {row.solution}</Content>}
                 </Content>
-                {row.solution && <Content component="small">Solution: {row.solution}</Content>}
-              </Content>
-            </Td>
-          </Tr>
-        );
-      })}
-    </Tbody>
-  </Table>
-);
+              </Td>
+              <Td dataLabel="Pipeline run">
+                {row.pipelineRunName ? (
+                  <Link
+                    to={PIPELINE_RUNS_SECURITY_PATH.createPath({
+                      workspaceName: namespace,
+                      applicationName: applicationName || '',
+                      pipelineRunName: row.pipelineRunName,
+                    })}
+                    data-test="conforma-pipeline-run-link"
+                  >
+                    <PfTruncate content={row.pipelineRunName} />
+                  </Link>
+                ) : (
+                  '-'
+                )}
+              </Td>
+            </Tr>
+          );
+        })}
+      </Tbody>
+    </Table>
+  );
+};
 
 export const ConformaGroupedTable: React.FC<ConformaGroupedTableProps> = ({
   groups,

--- a/src/components/Conforma/ConformaResultsTab/__tests__/ConformaGroupedTable.spec.tsx
+++ b/src/components/Conforma/ConformaResultsTab/__tests__/ConformaGroupedTable.spec.tsx
@@ -1,11 +1,18 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useNamespace } from '~/shared/providers/Namespace';
 import { CONFORMA_RESULT_STATUS } from '~/types/conforma';
 import type { ConformaResultRow } from '~/types/conforma';
-import { routerRenderer } from '~/unit-test-utils/mock-react-router';
+import { createUseParamsMock, routerRenderer } from '~/unit-test-utils/mock-react-router';
 import type { GroupedConformaRow } from '../conforma-grouping-utils';
 import { ConformaGroupedTable } from '../ConformaGroupedTable';
 import '@testing-library/jest-dom';
+
+jest.mock('~/shared/providers/Namespace', () => ({
+  useNamespace: jest.fn(),
+}));
+
+const mockUseNamespace = useNamespace as jest.Mock;
 
 const createRow = (overrides: Partial<ConformaResultRow> = {}): ConformaResultRow => ({
   title: 'Test rule',
@@ -60,9 +67,12 @@ describe('ConformaGroupedTable', () => {
     expandedGroups: new Set<string>(),
     onToggleGroup: jest.fn(),
   };
+  const useParamsMock = createUseParamsMock();
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseNamespace.mockReturnValue('test-ns');
+    useParamsMock.mockReturnValue({ applicationName: 'test-app' });
   });
 
   it('renders group rows with correct labels', () => {
@@ -385,5 +395,54 @@ describe('ConformaGroupedTable', () => {
 
     expect(screen.getByText(longMsg)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'less' })).toBeInTheDocument();
+  });
+
+  it('renders a pipeline run link with /security in href when pipelineRunName is present', () => {
+    const groupsWithPipelineRun: GroupedConformaRow[] = [
+      {
+        groupKey: 'Has pipeline run',
+        violations: 1,
+        warnings: 0,
+        successes: 0,
+        rows: [createRow({ pipelineRunName: 'my-pipelinerun' })],
+      },
+    ];
+    const expandedGroups = new Set(['Has pipeline run']);
+    routerRenderer(
+      <ConformaGroupedTable
+        {...defaultProps}
+        groups={groupsWithPipelineRun}
+        expandedGroups={expandedGroups}
+      />,
+    );
+
+    const link = screen.getByTestId('conforma-pipeline-run-link');
+    expect(link).toHaveTextContent('my-pipelinerun');
+    expect(link).toHaveAttribute(
+      'href',
+      '/ns/test-ns/applications/test-app/pipelineruns/my-pipelinerun/security',
+    );
+  });
+
+  it('renders dash when pipelineRunName is absent', () => {
+    const groupsWithoutPipelineRun: GroupedConformaRow[] = [
+      {
+        groupKey: 'No pipeline run',
+        violations: 1,
+        warnings: 0,
+        successes: 0,
+        rows: [createRow({ pipelineRunName: undefined })],
+      },
+    ];
+    const expandedGroups = new Set(['No pipeline run']);
+    routerRenderer(
+      <ConformaGroupedTable
+        {...defaultProps}
+        groups={groupsWithoutPipelineRun}
+        expandedGroups={expandedGroups}
+      />,
+    );
+
+    expect(screen.queryByTestId('conforma-pipeline-run-link')).not.toBeInTheDocument();
   });
 });

--- a/src/components/Conforma/ConformaResultsTab/__tests__/conforma-fetchers.spec.ts
+++ b/src/components/Conforma/ConformaResultsTab/__tests__/conforma-fetchers.spec.ts
@@ -292,6 +292,17 @@ describe('mapConformaResultData', () => {
     const result = mapConformaResultData([componentWithoutCode]);
     expect(result[0].code).toBeUndefined();
   });
+
+  it('sets pipelineRunName on every mapped row when passed as second arg', () => {
+    const result = mapConformaResultData([baseComponent], 'pr-1');
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.every((r) => r.pipelineRunName === 'pr-1')).toBe(true);
+  });
+
+  it('leaves pipelineRunName undefined when not passed', () => {
+    const result = mapConformaResultData([baseComponent]);
+    expect(result.every((r) => r.pipelineRunName === undefined)).toBe(true);
+  });
 });
 
 describe('filterInvalidImageConformaRows', () => {

--- a/src/components/Conforma/ConformaResultsTab/__tests__/conforma-grouping-utils.spec.ts
+++ b/src/components/Conforma/ConformaResultsTab/__tests__/conforma-grouping-utils.spec.ts
@@ -411,6 +411,78 @@ describe('conforma-grouping-utils', () => {
       expect(result).toHaveLength(1);
       expect(result[0].images).toEqual(['img@sha256:aaa', 'img@sha256:bbb']);
     });
+
+    it('keeps the first non-empty pipelineRunName when merging arch-duplicate rows', () => {
+      const rows = [
+        mockRow({
+          title: 'CVE rule',
+          msg: 'CVE-2024-001',
+          component: 'api',
+          images: ['img@sha256:aaa'],
+          pipelineRunName: 'pr-1',
+        }),
+        mockRow({
+          title: 'CVE rule',
+          msg: 'CVE-2024-001',
+          component: 'api',
+          images: ['img@sha256:bbb'],
+          pipelineRunName: undefined,
+        }),
+      ];
+
+      const result = collapseArchDuplicates(rows);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].pipelineRunName).toBe('pr-1');
+    });
+
+    it('keeps the non-empty pipelineRunName when the first row is missing it', () => {
+      const rows = [
+        mockRow({
+          title: 'CVE rule',
+          msg: 'CVE-2024-001',
+          component: 'api',
+          images: ['img@sha256:aaa'],
+          pipelineRunName: undefined,
+        }),
+        mockRow({
+          title: 'CVE rule',
+          msg: 'CVE-2024-001',
+          component: 'api',
+          images: ['img@sha256:bbb'],
+          pipelineRunName: 'pr-1',
+        }),
+      ];
+
+      const result = collapseArchDuplicates(rows);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].pipelineRunName).toBe('pr-1');
+    });
+
+    it('keeps pipelineRunName when both rows share the same value', () => {
+      const rows = [
+        mockRow({
+          title: 'CVE rule',
+          msg: 'CVE-2024-001',
+          component: 'api',
+          images: ['img@sha256:aaa'],
+          pipelineRunName: 'pr-1',
+        }),
+        mockRow({
+          title: 'CVE rule',
+          msg: 'CVE-2024-001',
+          component: 'api',
+          images: ['img@sha256:bbb'],
+          pipelineRunName: 'pr-1',
+        }),
+      ];
+
+      const result = collapseArchDuplicates(rows);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].pipelineRunName).toBe('pr-1');
+    });
   });
 
   describe('getCommonImageName', () => {

--- a/src/components/Conforma/ConformaResultsTab/__tests__/useApplicationConformaResults.spec.ts
+++ b/src/components/Conforma/ConformaResultsTab/__tests__/useApplicationConformaResults.spec.ts
@@ -702,6 +702,31 @@ describe('useApplicationConformaResults', () => {
     expect(result.current.allResults).toEqual([]);
   });
 
+  it('associates each row with the pipelineRunName of its own component, not another component', async () => {
+    const components = [createComponent('comp-a'), createComponent('comp-b')];
+    const taskRuns = [
+      createSecurityTaskRun('tr-1', 'comp-a', 'pod-1', '2026-01-01T00:00:00Z', 'pr-1'),
+      createSecurityTaskRun('tr-2', 'comp-b', 'pod-2', '2026-01-01T00:00:00Z', 'pr-2'),
+    ];
+    mockUseComponents.mockReturnValue([components, true, undefined]);
+    mockUseTaskRunsV2.mockReturnValue(createTaskRunsV2Return(taskRuns));
+    mockResolveConforma.mockResolvedValue(mockConformaResult);
+
+    const { result } = renderHook(() => useApplicationConformaResults('test-app'), {
+      wrapper: createWrapper(),
+    });
+
+    await flushEffects();
+
+    const compARows = result.current.allResults.filter((r) => r.component === 'comp-a');
+    const compBRows = result.current.allResults.filter((r) => r.component === 'comp-b');
+
+    expect(compARows.length).toBeGreaterThan(0);
+    expect(compBRows.length).toBeGreaterThan(0);
+    expect(compARows.every((r) => r.pipelineRunName === 'pr-1')).toBe(true);
+    expect(compBRows.every((r) => r.pipelineRunName === 'pr-2')).toBe(true);
+  });
+
   it('passes the Conforma security selector to useTaskRunsV2', () => {
     renderHook(() => useApplicationConformaResults('test-app'), {
       wrapper: createWrapper(),
@@ -828,5 +853,18 @@ describe('useApplicationConformaResults', () => {
     await flushEffects();
 
     expect(result.current.componentStatuses[0].pipelineRunName).toBe('pr-1');
+  });
+
+  it('sets pipelineRunName on allResults rows from TaskRun labels', async () => {
+    setupTaskRunPipeline();
+    mockResolveConforma.mockResolvedValue(mockConformaResult);
+
+    const { result } = renderHook(() => useApplicationConformaResults('test-app'), {
+      wrapper: createWrapper(),
+    });
+
+    await flushEffects();
+
+    expect(result.current.allResults[0].pipelineRunName).toBe('pr-1');
   });
 });

--- a/src/components/Conforma/ConformaResultsTab/conforma-fetchers.ts
+++ b/src/components/Conforma/ConformaResultsTab/conforma-fetchers.ts
@@ -17,6 +17,7 @@ const mapToConformaResultRow = (
   v: ConformaRule,
   compResult: ComponentConformaResult,
   status: CONFORMA_RESULT_STATUS,
+  pipelineRunName?: string,
 ): ConformaResultRow => ({
   title: v.metadata?.title,
   description: v.metadata?.description,
@@ -28,20 +29,28 @@ const mapToConformaResultRow = (
   solution: v.metadata?.solution,
   images: compResult.containerImage ? [compResult.containerImage] : [],
   code: v.metadata?.code,
+  pipelineRunName,
 });
 
 export const mapConformaResultData = (
   conformaResult: ComponentConformaResult[],
+  pipelineRunName?: string,
 ): ConformaResultRow[] => {
   return conformaResult.reduce((acc, compResult) => {
     compResult?.violations?.forEach((v) => {
-      acc.push(mapToConformaResultRow(v, compResult, CONFORMA_RESULT_STATUS.violations));
+      acc.push(
+        mapToConformaResultRow(v, compResult, CONFORMA_RESULT_STATUS.violations, pipelineRunName),
+      );
     });
     compResult?.warnings?.forEach((v) => {
-      acc.push(mapToConformaResultRow(v, compResult, CONFORMA_RESULT_STATUS.warnings));
+      acc.push(
+        mapToConformaResultRow(v, compResult, CONFORMA_RESULT_STATUS.warnings, pipelineRunName),
+      );
     });
     compResult?.successes?.forEach((v) => {
-      acc.push(mapToConformaResultRow(v, compResult, CONFORMA_RESULT_STATUS.successes));
+      acc.push(
+        mapToConformaResultRow(v, compResult, CONFORMA_RESULT_STATUS.successes, pipelineRunName),
+      );
     });
     return acc;
   }, [] as ConformaResultRow[]);

--- a/src/components/Conforma/ConformaResultsTab/conforma-grouping-utils.ts
+++ b/src/components/Conforma/ConformaResultsTab/conforma-grouping-utils.ts
@@ -177,6 +177,7 @@ export const collapseArchDuplicates = (rows: ConformaResultRow[]): ConformaResul
           existing.images = [...existing.images, image];
         }
       }
+      existing.pipelineRunName = existing.pipelineRunName || row.pipelineRunName;
     } else {
       map.set(key, { ...row, images: [...row.images] });
     }

--- a/src/components/Conforma/ConformaResultsTab/useApplicationConformaResults.ts
+++ b/src/components/Conforma/ConformaResultsTab/useApplicationConformaResults.ts
@@ -226,7 +226,11 @@ export const useApplicationConformaResults = (
 
     const allResults: ConformaResultRow[] = [];
     for (const [realComponentName, components] of conformaByComponent.entries()) {
-      const rows = mapConformaResultData(components);
+      const pipelineRunName =
+        latestPerComponent.get(realComponentName)?.metadata?.labels?.[
+          TektonResourceLabel.pipelinerun
+        ];
+      const rows = mapConformaResultData(components, pipelineRunName);
       // The EC/Conforma report assigns its own per-image `name` to each
       // components[] entry (see ComponentConformaResult), which is NOT the
       // real K8s component name and can differ across architecture images

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -120,6 +120,8 @@ export const PIPELINE_RUNS_DETAILS_PATH = PLR_LIST_PATH.extend(`:${RouterParams.
 
 export const PIPELINE_RUNS_LOG_PATH = PIPELINE_RUNS_DETAILS_PATH.extend('logs');
 
+export const PIPELINE_RUNS_SECURITY_PATH = PIPELINE_RUNS_DETAILS_PATH.extend('security');
+
 // TaskRun routes
 
 export const TASKRUN_LIST_PATH = APPLICATION_DETAILS_PATH.extend('taskruns');

--- a/src/types/conforma.ts
+++ b/src/types/conforma.ts
@@ -76,6 +76,7 @@ export type ConformaResultRow = {
   images: string[];
   /** Policy rule code — stable identifier used as primary group key. Optional for backward-compat. */
   code?: string;
+  pipelineRunName?: string;
 };
 
 export type ComponentConformaStatus = {


### PR DESCRIPTION

## Fixes 
https://redhat.atlassian.net/browse/KFLUXSE-345

## Description
Violations on the conforma board will link the pipelineruns for easy debugging.
Assisted-by: Cursor

## Type of change
- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<img width="1562" height="802" alt="image" src="https://github.com/user-attachments/assets/58953b2e-3158-4f15-9058-12fab5decd9f" />



## How to test or reproduce?
tests & local cluster



## Browser conformance: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Pipeline run** column to Conforma results.
  * Pipeline run names now link directly to their security details when available.
  * Displays `-` when no pipeline run is associated with a result.

* **Bug Fixes**
  * Preserved the correct pipeline run association when combining results across components and duplicate entries.

* **Tests**
  * Added coverage for pipeline run links, missing values, and result association behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->