### PR TITLE
feat(KFLUXUI-1145): show tailed logs from KubeArchive with per-section full download and view

### DIFF
--- a/docs/kubearchive.md
+++ b/docs/kubearchive.md
@@ -264,4 +264,13 @@ const handleScroll = useCallback(() => {
 
 ---
 
+## 7. Log tailing
+
+When viewing logs from KubeArchive, only the **last 500 lines** per container are fetched. This keeps the initial load fast for large logs.
+
+- Tailed sections show a **"showing last N lines"** label in the section header.
+- Each tailed section has a **"Download full logs"** button that fetches the complete log (without the tail limit) and saves it as a file.
+- This only applies to **archive source** logs. Cluster logs (live or terminated) are fetched in full.
+- The tail limit is configured via `KUBEARCHIVE_TAIL_LINES` in `src/kubearchive/const.ts`.
+
 Happy archiving! 📚 

--- a/docs/kubearchive.md
+++ b/docs/kubearchive.md
@@ -270,6 +270,7 @@ When viewing logs from KubeArchive, only the **last 500 lines** per container ar
 
 - Tailed sections show a **"showing last N lines"** label in the section header.
 - Each tailed section has a **"Download full logs"** button that fetches the complete log (without the tail limit) and saves it as a file.
+- Each tailed section also has a **"View full logs"** button (with an external link icon) that opens the complete log in a new browser tab via the KubeArchive API.
 - This only applies to **archive source** logs. Cluster logs (live or terminated) are fetched in full.
 - The tail limit is configured via `KUBEARCHIVE_TAIL_LINES` in `src/kubearchive/const.ts`.
 

--- a/src/kubearchive/const.ts
+++ b/src/kubearchive/const.ts
@@ -1,2 +1,3 @@
 export const KUBEARCHIVE_PATH_PREFIX = 'plugins/kubearchive';
 export const KUBEARCHIVE_RESOURCE_LIMIT = 30;
+export const KUBEARCHIVE_TAIL_LINES = 500;

--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
@@ -40,6 +40,7 @@ import { LoadingInline } from '~/shared/components/status-box/StatusBox';
 import {
   VirtualizedLogViewer,
   type LogSection,
+  type NormalizedLogSection,
   normalizeSection,
   useLineNumberNavigation,
 } from '~/shared/components/virtualized-log-viewer';
@@ -62,7 +63,8 @@ const LOG_VIEWER_SHORTCUTS: ShortcutEntry[] = [
 
 export type Props = {
   showSearch?: boolean;
-  sections: LogSection[];
+  sections?: LogSection[];
+  normalizedSections?: NormalizedLogSection[];
   allowAutoScroll?: boolean;
   downloadAllLabel?: string;
   onDownloadAll?: () => Promise<Error>;
@@ -80,6 +82,7 @@ const LogViewer: React.FC<Props> = ({
   showSearch = true,
   allowAutoScroll,
   sections,
+  normalizedSections: normalizedSectionsProp,
   downloadAllLabel,
   onDownloadAll,
   taskRun,
@@ -91,7 +94,10 @@ const LogViewer: React.FC<Props> = ({
   const [logTheme, setLogTheme] = useLogViewerTheme();
   const themeCheckboxId = React.useId();
 
-  const normalizedSections = React.useMemo(() => sections.map(normalizeSection), [sections]);
+  const normalizedSections = React.useMemo(
+    () => normalizedSectionsProp ?? sections?.map(normalizeSection) ?? [],
+    [normalizedSectionsProp, sections],
+  );
 
   const lines = React.useMemo(
     () => prepareLogViewerContent(normalizedSections),
@@ -120,10 +126,12 @@ const LogViewer: React.FC<Props> = ({
     useFullscreen<HTMLDivElement>();
 
   const downloadData = React.useMemo(() => {
-    return sections
-      .map((s) => (s.containerName ? `${s.containerName}\n${s.data}` : s.data))
+    return normalizedSections
+      .map((s) =>
+        s.containerName ? `${s.containerName}\n${s.lines.join('\n')}` : s.lines.join('\n'),
+      )
       .join('\n\n');
-  }, [sections]);
+  }, [normalizedSections]);
 
   const [downloadAllStatus, setDownloadAllStatus] = React.useState(false);
 
@@ -341,7 +349,7 @@ const LogViewer: React.FC<Props> = ({
             {viewerHeight && (
               <VirtualizedLogViewer
                 key={taskRun?.metadata?.uid || 'default'}
-                sections={sections}
+                sections={sections ?? []}
                 normalizedSections={normalizedSections}
                 height={viewerHeight}
                 scrollToRow={scrolledRow}

--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
@@ -69,6 +69,7 @@ export type Props = {
   downloadAllLabel?: string;
   onDownloadAll?: () => Promise<Error>;
   onDownloadFullLogs?: (sectionIndex: number) => Promise<void>;
+  onViewFullLogs?: (sectionIndex: number) => void;
   taskRun: TaskRunKind | null;
   isLoading: boolean;
   errorMessage: string | null;
@@ -87,6 +88,7 @@ const LogViewer: React.FC<Props> = ({
   downloadAllLabel,
   onDownloadAll,
   onDownloadFullLogs,
+  onViewFullLogs,
   taskRun,
   isLoading,
   errorMessage,
@@ -358,6 +360,7 @@ const LogViewer: React.FC<Props> = ({
                 onScroll={handleScroll}
                 readyToNavigate={!isLoading}
                 onDownloadFullLogs={onDownloadFullLogs}
+                onViewFullLogs={onViewFullLogs}
               />
             )}
           </div>

--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
@@ -68,6 +68,7 @@ export type Props = {
   allowAutoScroll?: boolean;
   downloadAllLabel?: string;
   onDownloadAll?: () => Promise<Error>;
+  onDownloadFullLogs?: (sectionIndex: number) => Promise<void>;
   taskRun: TaskRunKind | null;
   isLoading: boolean;
   errorMessage: string | null;
@@ -85,6 +86,7 @@ const LogViewer: React.FC<Props> = ({
   normalizedSections: normalizedSectionsProp,
   downloadAllLabel,
   onDownloadAll,
+  onDownloadFullLogs,
   taskRun,
   isLoading,
   errorMessage,
@@ -355,6 +357,7 @@ const LogViewer: React.FC<Props> = ({
                 scrollToRow={scrolledRow}
                 onScroll={handleScroll}
                 readyToNavigate={!isLoading}
+                onDownloadFullLogs={onDownloadFullLogs}
               />
             )}
           </div>

--- a/src/shared/components/pipeline-run-logs/logs/Logs.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/Logs.tsx
@@ -261,15 +261,15 @@ const Logs: React.FC<LogsProps> = ({
 
   const isArchiveSource = isKubearchiveEnabled && source === ResourceSource.Archive;
 
-  const handleDownloadFullLogs = React.useCallback(
-    async (sectionIndex: number) => {
+  const getFullLogUrl = React.useCallback(
+    (sectionIndex: number) => {
       const section = sections[sectionIndex];
-      if (!section) return;
+      if (!section) return null;
 
       const containerName = containers.find(
         (c) => c.name.toUpperCase() === section.containerName,
       )?.name;
-      if (!containerName) return;
+      if (!containerName) return null;
 
       const urlOpts = {
         ns: resNamespace,
@@ -277,13 +277,31 @@ const Logs: React.FC<LogsProps> = ({
         path: 'log',
         queryParams: { container: containerName, follow: 'false' },
       };
-      const url = getK8sResourceURL(PodModel, undefined, urlOpts);
-
-      const text = await commonFetchText(url, { pathPrefix: KUBEARCHIVE_PATH_PREFIX });
-      const blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
-      saveAs(blob, `${containerName}.log`);
+      return { url: getK8sResourceURL(PodModel, undefined, urlOpts), containerName };
     },
     [sections, containers, resNamespace, resName],
+  );
+
+  const handleDownloadFullLogs = React.useCallback(
+    async (sectionIndex: number) => {
+      const result = getFullLogUrl(sectionIndex);
+      if (!result) return;
+
+      const text = await commonFetchText(result.url, { pathPrefix: KUBEARCHIVE_PATH_PREFIX });
+      const blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
+      saveAs(blob, `${result.containerName}.log`);
+    },
+    [getFullLogUrl],
+  );
+
+  const handleViewFullLogs = React.useCallback(
+    (sectionIndex: number) => {
+      const result = getFullLogUrl(sectionIndex);
+      if (!result) return;
+
+      window.open(`/api/k8s/${KUBEARCHIVE_PATH_PREFIX}${result.url}`, '_blank');
+    },
+    [getFullLogUrl],
   );
 
   return (
@@ -294,6 +312,7 @@ const Logs: React.FC<LogsProps> = ({
       downloadAllLabel={downloadAllLabel}
       onDownloadAll={onDownloadAll}
       onDownloadFullLogs={isArchiveSource ? handleDownloadFullLogs : undefined}
+      onViewFullLogs={isArchiveSource ? handleViewFullLogs : undefined}
       taskRun={taskRun}
       isLoading={isLoading || isFetchingLogs}
       errorMessage={error ? t('An error occurred while retrieving the requested logs.') : null}

--- a/src/shared/components/pipeline-run-logs/logs/Logs.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/Logs.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { saveAs } from 'file-saver';
 import { Base64 } from 'js-base64';
 import { useIsOnFeatureFlag } from '~/feature-flags/hooks';
-import { KUBEARCHIVE_PATH_PREFIX } from '~/kubearchive/const';
+import { KUBEARCHIVE_PATH_PREFIX, KUBEARCHIVE_TAIL_LINES } from '~/kubearchive/const';
 import { type NormalizedLogSection } from '~/shared/components/virtualized-log-viewer';
 import { LineBuffer } from '~/shared/utils/line-buffer';
 import { ResourceSource } from '~/types/k8s';
@@ -22,7 +22,6 @@ import {
 import LogViewer, { type Props as LogViewerProps } from './LogViewer';
 
 const WEB_SOCKET_RETRY_COUNT = 5;
-const KUBEARCHIVE_TAIL_LINES = 500;
 
 const retryWebSocket = (
   watchURL: string,

--- a/src/shared/components/pipeline-run-logs/logs/Logs.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/Logs.tsx
@@ -103,6 +103,13 @@ const Logs: React.FC<LogsProps> = ({
     }
   }, []);
 
+  React.useEffect(
+    () => () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    },
+    [],
+  );
+
   // loops through the containers and initiates fetching for each one
   React.useEffect(() => {
     const activeConnections = connectionManagerRef.current;

--- a/src/shared/components/pipeline-run-logs/logs/Logs.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/Logs.tsx
@@ -3,7 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { Base64 } from 'js-base64';
 import { useIsOnFeatureFlag } from '~/feature-flags/hooks';
 import { KUBEARCHIVE_PATH_PREFIX } from '~/kubearchive/const';
-import { type LogSection } from '~/shared/components/virtualized-log-viewer';
+import { type NormalizedLogSection } from '~/shared/components/virtualized-log-viewer';
+import { LineBuffer } from '~/shared/utils/line-buffer';
 import { ResourceSource } from '~/types/k8s';
 import { commonFetchText } from '../../../../k8s';
 import { getK8sResourceURL, getWebsocketSubProtocolAndPathPrefix } from '../../../../k8s/k8s-utils';
@@ -18,8 +19,6 @@ import {
   LOG_SOURCE_TERMINATED,
 } from '../utils';
 import LogViewer, { type Props as LogViewerProps } from './LogViewer';
-
-type LogSources = { [containerName: string]: string };
 
 const WEB_SOCKET_RETRY_COUNT = 5;
 
@@ -76,8 +75,9 @@ const Logs: React.FC<LogsProps> = ({
   const { metadata = {} } = resource;
   const { name: resName, namespace: resNamespace } = metadata;
 
-  // state to hold the logs for each container individually
-  const [logSources, setLogSources] = React.useState<LogSources>({});
+  const buffersRef = React.useRef(new Map<string, LineBuffer>());
+  const [renderTick, forceRender] = React.useReducer((x: number) => x + 1, 0);
+  const rafRef = React.useRef(0);
   const [error, setError] = React.useState<boolean>(false);
   const pendingFetchesRef = React.useRef(0);
   const [isFetchingLogs, setIsFetchingLogs] = React.useState(false);
@@ -85,10 +85,19 @@ const Logs: React.FC<LogsProps> = ({
   const connectionManagerRef = React.useRef(new Map<string, () => void>());
 
   const appendLog = React.useCallback((containerName: string, message: string) => {
-    setLogSources((prev) => ({
-      ...prev,
-      [containerName]: (prev[containerName] || '') + message,
-    }));
+    let buf = buffersRef.current.get(containerName);
+    if (!buf) {
+      buf = new LineBuffer();
+      buffersRef.current.set(containerName, buf);
+    }
+    buf.append(message);
+
+    if (!rafRef.current) {
+      rafRef.current = requestAnimationFrame(() => {
+        rafRef.current = 0;
+        forceRender();
+      });
+    }
   }, []);
 
   // loops through the containers and initiates fetching for each one
@@ -215,22 +224,26 @@ const Logs: React.FC<LogsProps> = ({
     return allTerminated;
   }, [containers, resource?.status?.containerStatuses]);
 
-  const sections = React.useMemo<LogSection[]>(() => {
+  const sections = React.useMemo<NormalizedLogSection[]>(() => {
+    void renderTick;
     const statusByName = new Map(
       (resource?.status?.containerStatuses ?? []).map((status) => [status.name, status]),
     );
     return containers
-      .filter((c) => c.name in logSources)
-      .map((c) => ({
-        containerName: c.name.toUpperCase(),
-        data: logSources[c.name],
-        isCompleted: isContainerStepCompleted(statusByName.get(c.name)),
-      }));
-  }, [logSources, containers, resource?.status?.containerStatuses]);
+      .filter((c) => buffersRef.current.has(c.name))
+      .map((c) => {
+        const buf = buffersRef.current.get(c.name);
+        return {
+          containerName: c.name.toUpperCase(),
+          lines: buf?.getLines() ?? [],
+          isCompleted: isContainerStepCompleted(statusByName.get(c.name)),
+        };
+      });
+  }, [renderTick, resource?.status?.containerStatuses, containers]);
 
   return (
     <LogViewer
-      sections={sections}
+      normalizedSections={sections}
       allowAutoScroll={allowAutoScroll && !allLogsTerminated}
       onScroll={onScroll}
       downloadAllLabel={downloadAllLabel}

--- a/src/shared/components/pipeline-run-logs/logs/Logs.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/Logs.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+import { saveAs } from 'file-saver';
 import { Base64 } from 'js-base64';
 import { useIsOnFeatureFlag } from '~/feature-flags/hooks';
 import { KUBEARCHIVE_PATH_PREFIX } from '~/kubearchive/const';
@@ -21,6 +22,7 @@ import {
 import LogViewer, { type Props as LogViewerProps } from './LogViewer';
 
 const WEB_SOCKET_RETRY_COUNT = 5;
+const KUBEARCHIVE_TAIL_LINES = 500;
 
 const retryWebSocket = (
   watchURL: string,
@@ -76,6 +78,7 @@ const Logs: React.FC<LogsProps> = ({
   const { name: resName, namespace: resNamespace } = metadata;
 
   const buffersRef = React.useRef(new Map<string, LineBuffer>());
+  const tailedContainersRef = React.useRef(new Set<string>());
   const [renderTick, forceRender] = React.useReducer((x: number) => x + 1, 0);
   const rafRef = React.useRef(0);
   const [error, setError] = React.useState<boolean>(false);
@@ -128,6 +131,7 @@ const Logs: React.FC<LogsProps> = ({
       const status = allStatuses.find((c) => c.name === name);
       const resourceStatus = containerToLogSourceStatus(status);
 
+      const isArchiveSource = isKubearchiveEnabled && source === ResourceSource.Archive;
       const urlOpts = {
         ns: resNamespace,
         name: resName,
@@ -135,6 +139,7 @@ const Logs: React.FC<LogsProps> = ({
         queryParams: {
           container: name,
           follow: resourceStatus === LOG_SOURCE_TERMINATED ? 'false' : 'true',
+          ...(isArchiveSource ? { tailLines: String(KUBEARCHIVE_TAIL_LINES) } : undefined),
         },
       };
       const watchURL = getK8sResourceURL(PodModel, undefined, urlOpts);
@@ -146,11 +151,17 @@ const Logs: React.FC<LogsProps> = ({
         markFetchStarted();
         commonFetchText(watchURL, {
           signal,
-          ...(isKubearchiveEnabled && source === ResourceSource.Archive
-            ? { pathPrefix: KUBEARCHIVE_PATH_PREFIX }
-            : undefined),
+          ...(isArchiveSource ? { pathPrefix: KUBEARCHIVE_PATH_PREFIX } : undefined),
         })
-          .then((res) => appendLog(name, res))
+          .then((res) => {
+            appendLog(name, res);
+            if (isArchiveSource) {
+              const buf = buffersRef.current.get(name);
+              if (buf && buf.length() >= KUBEARCHIVE_TAIL_LINES) {
+                tailedContainersRef.current.add(name);
+              }
+            }
+          })
           .catch((err) => {
             if (err.name !== 'AbortError') {
               // Gracefully handle empty logs (404) from kubearch, similar to how Tekton Results handles 404
@@ -237,9 +248,37 @@ const Logs: React.FC<LogsProps> = ({
           containerName: c.name.toUpperCase(),
           lines: buf?.getLines() ?? [],
           isCompleted: isContainerStepCompleted(statusByName.get(c.name)),
+          isTailed: tailedContainersRef.current.has(c.name),
         };
       });
   }, [renderTick, resource?.status?.containerStatuses, containers]);
+
+  const isArchiveSource = isKubearchiveEnabled && source === ResourceSource.Archive;
+
+  const handleDownloadFullLogs = React.useCallback(
+    async (sectionIndex: number) => {
+      const section = sections[sectionIndex];
+      if (!section) return;
+
+      const containerName = containers.find(
+        (c) => c.name.toUpperCase() === section.containerName,
+      )?.name;
+      if (!containerName) return;
+
+      const urlOpts = {
+        ns: resNamespace,
+        name: resName,
+        path: 'log',
+        queryParams: { container: containerName, follow: 'false' },
+      };
+      const url = getK8sResourceURL(PodModel, undefined, urlOpts);
+
+      const text = await commonFetchText(url, { pathPrefix: KUBEARCHIVE_PATH_PREFIX });
+      const blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
+      saveAs(blob, `${containerName}.log`);
+    },
+    [sections, containers, resNamespace, resName],
+  );
 
   return (
     <LogViewer
@@ -248,6 +287,7 @@ const Logs: React.FC<LogsProps> = ({
       onScroll={onScroll}
       downloadAllLabel={downloadAllLabel}
       onDownloadAll={onDownloadAll}
+      onDownloadFullLogs={isArchiveSource ? handleDownloadFullLogs : undefined}
       taskRun={taskRun}
       isLoading={isLoading || isFetchingLogs}
       errorMessage={error ? t('An error occurred while retrieving the requested logs.') : null}

--- a/src/shared/components/pipeline-run-logs/logs/TektonTaskRunLog.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/TektonTaskRunLog.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { runStatus } from '~/consts/pipelinerun';
-import { singleLogSection } from '~/shared/components/virtualized-log-viewer/log-viewer-utils';
-import { taskRunStatus } from '~/utils/pipeline-utils';
+import { normalizeLogLines } from '~/shared/components/virtualized-log-viewer/log-viewer-utils';
+import type { NormalizedLogSection } from '~/shared/components/virtualized-log-viewer/types';
 import { useTRTaskRunLog } from '../../../../hooks/useTektonResults';
 import { HttpError } from '../../../../k8s/error';
 import { TaskRunKind } from '../../../../types';
@@ -26,21 +25,23 @@ export const TektonTaskRunLog: React.FC<React.PropsWithChildren<TektonTaskRunLog
       ? `Logs are no longer accessible for ${taskName} task`
       : null;
 
-  const sections = React.useMemo(() => {
-    if (!trResults) {
-      return [];
-    }
-
-    const status = taskRun ? taskRunStatus(taskRun) : runStatus.Unknown;
-    const inProgress =
-      status === runStatus.Running || status === runStatus.Pending || status === runStatus.Idle;
-
-    return [singleLogSection(trResults, taskName ?? 'log', trLoaded && !inProgress)];
-  }, [trResults, taskName, taskRun, trLoaded]);
+  const normalizedSections = React.useMemo<NormalizedLogSection[]>(
+    () =>
+      trResults
+        ? [
+            {
+              containerName: taskName ?? 'log',
+              lines: normalizeLogLines(trResults),
+              isCompleted: true,
+            },
+          ]
+        : [],
+    [trResults, taskName],
+  );
 
   return (
     <LogViewer
-      sections={sections}
+      normalizedSections={normalizedSections}
       downloadAllLabel={downloadAllLabel}
       onDownloadAll={onDownloadAll}
       taskRun={taskRun}

--- a/src/shared/components/pipeline-run-logs/logs/TektonTaskRunLog.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/TektonTaskRunLog.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
+import { runStatus } from '~/consts/pipelinerun';
 import { normalizeLogLines } from '~/shared/components/virtualized-log-viewer/log-viewer-utils';
 import type { NormalizedLogSection } from '~/shared/components/virtualized-log-viewer/types';
+import { taskRunStatus } from '~/utils/pipeline-utils';
 import { useTRTaskRunLog } from '../../../../hooks/useTektonResults';
 import { HttpError } from '../../../../k8s/error';
 import { TaskRunKind } from '../../../../types';
@@ -25,19 +27,21 @@ export const TektonTaskRunLog: React.FC<React.PropsWithChildren<TektonTaskRunLog
       ? `Logs are no longer accessible for ${taskName} task`
       : null;
 
-  const normalizedSections = React.useMemo<NormalizedLogSection[]>(
-    () =>
-      trResults
-        ? [
-            {
-              containerName: taskName ?? 'log',
-              lines: normalizeLogLines(trResults),
-              isCompleted: true,
-            },
-          ]
-        : [],
-    [trResults, taskName],
-  );
+  const normalizedSections = React.useMemo<NormalizedLogSection[]>(() => {
+    if (!trResults) return [];
+
+    const status = taskRun ? taskRunStatus(taskRun) : runStatus.Unknown;
+    const inProgress =
+      status === runStatus.Running || status === runStatus.Pending || status === runStatus.Idle;
+
+    return [
+      {
+        containerName: taskName ?? 'log',
+        lines: normalizeLogLines(trResults),
+        isCompleted: trLoaded && !inProgress,
+      },
+    ];
+  }, [trResults, taskName, taskRun, trLoaded]);
 
   return (
     <LogViewer

--- a/src/shared/components/pipeline-run-logs/logs/__tests__/Logs.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/__tests__/Logs.spec.tsx
@@ -1350,6 +1350,7 @@ describe('Logs', () => {
       });
 
       (commonFetchText as jest.Mock).mockClear();
+      (saveAs as jest.Mock).mockClear();
 
       const onDownloadFullLogs = getLastOnDownloadFullLogs();
       await act(async () => {

--- a/src/shared/components/pipeline-run-logs/logs/__tests__/Logs.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/__tests__/Logs.spec.tsx
@@ -16,15 +16,23 @@ const mockLogViewer = jest.fn();
 
 const getLastSectionsData = (): string => {
   const lastCall = mockLogViewer.mock.calls[mockLogViewer.mock.calls.length - 1][0];
-  return (lastCall.sections || []).map((s: { data: string }) => s.data).join('\n');
+  return (lastCall.normalizedSections || [])
+    .map((s: { lines: string[] }) => s.lines.join('\n'))
+    .join('\n');
 };
 
 jest.mock('../LogViewer', () => {
   return function MockLogViewer(props: {
-    sections: Array<{ containerName: string; data: string; isCompleted?: boolean }>;
+    normalizedSections: Array<{
+      containerName: string;
+      lines: string[];
+      isCompleted?: boolean;
+      isTailed?: boolean;
+    }>;
     allowAutoScroll: boolean;
     isLoading?: boolean;
     onScroll?: () => void;
+    onDownloadFullLogs?: (sectionIndex: number) => Promise<void>;
   }) {
     mockLogViewer(props);
     return <div data-test="mock-log-viewer" />;
@@ -71,10 +79,10 @@ jest.mock('react-i18next', () => ({
   }),
 }));
 
-// Mock Base64 decoding
+// Mock Base64 decoding (append newline so LineBuffer.append flushes the line from the tail)
 jest.mock('js-base64', () => ({
   Base64: {
-    decode: jest.fn((str: string) => `decoded-${str}`),
+    decode: jest.fn((str: string) => `decoded-${str}\n`),
   },
 }));
 
@@ -146,7 +154,7 @@ describe('Logs', () => {
 
       expect(mockLogViewer).toHaveBeenCalledWith(
         expect.objectContaining({
-          sections: expect.any(Array),
+          normalizedSections: expect.any(Array),
           allowAutoScroll: true,
           onScroll: undefined,
         }),
@@ -179,7 +187,7 @@ describe('Logs', () => {
         expect(screen.getByTestId('mock-log-viewer')).toBeInTheDocument();
         expect(mockLogViewer).toHaveBeenCalledWith(
           expect.objectContaining({
-            sections: [],
+            normalizedSections: [],
           }),
         );
       });
@@ -215,8 +223,8 @@ describe('Logs', () => {
 
       (containerToLogSourceStatus as jest.Mock).mockReturnValue('terminated');
       (commonFetchText as jest.Mock)
-        .mockResolvedValueOnce('log line 1\nlog line 2')
-        .mockResolvedValueOnce('log line 3\nlog line 4');
+        .mockResolvedValueOnce('log line 1\nlog line 2\n')
+        .mockResolvedValueOnce('log line 3\nlog line 4\n');
 
       render(
         <Logs
@@ -226,18 +234,24 @@ describe('Logs', () => {
         />,
       );
 
-      await act(async () => {
-        await Promise.resolve();
+      await waitFor(() => {
+        expect(mockLogViewer).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            normalizedSections: expect.arrayContaining([
+              expect.objectContaining({
+                containerName: 'CONTAINER1',
+                lines: ['log line 1', 'log line 2'],
+                isCompleted: true,
+              }),
+              expect.objectContaining({
+                containerName: 'CONTAINER2',
+                lines: ['log line 3', 'log line 4'],
+                isCompleted: true,
+              }),
+            ]),
+          }),
+        );
       });
-
-      expect(mockLogViewer).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          sections: expect.arrayContaining([
-            { containerName: 'CONTAINER1', data: 'log line 1\nlog line 2', isCompleted: true },
-            { containerName: 'CONTAINER2', data: 'log line 3\nlog line 4', isCompleted: true },
-          ]),
-        }),
-      );
     });
 
     it('should preserve container ordering from containers prop', async () => {
@@ -267,7 +281,9 @@ describe('Logs', () => {
       };
 
       (containerToLogSourceStatus as jest.Mock).mockReturnValue('terminated');
-      (commonFetchText as jest.Mock).mockResolvedValueOnce('first').mockResolvedValueOnce('second');
+      (commonFetchText as jest.Mock)
+        .mockResolvedValueOnce('first\n')
+        .mockResolvedValueOnce('second\n');
 
       render(
         <Logs
@@ -277,13 +293,11 @@ describe('Logs', () => {
         />,
       );
 
-      await act(async () => {
-        await Promise.resolve();
+      await waitFor(() => {
+        const lastCall = mockLogViewer.mock.calls[mockLogViewer.mock.calls.length - 1][0];
+        expect(lastCall.normalizedSections[0].containerName).toBe('CONTAINER2');
+        expect(lastCall.normalizedSections[1].containerName).toBe('CONTAINER1');
       });
-
-      const lastCall = mockLogViewer.mock.calls[mockLogViewer.mock.calls.length - 1][0];
-      expect(lastCall.sections[0].containerName).toBe('CONTAINER2');
-      expect(lastCall.sections[1].containerName).toBe('CONTAINER1');
     });
 
     it('should include containers with empty fetched logs so folding can evaluate them', async () => {
@@ -313,7 +327,7 @@ describe('Logs', () => {
       };
 
       (containerToLogSourceStatus as jest.Mock).mockReturnValue('terminated');
-      (commonFetchText as jest.Mock).mockResolvedValueOnce('has logs').mockResolvedValueOnce(''); // container2 returns empty string (no logs)
+      (commonFetchText as jest.Mock).mockResolvedValueOnce('has logs\n').mockResolvedValueOnce(''); // container2 returns empty string (no logs)
 
       render(
         <Logs
@@ -323,22 +337,14 @@ describe('Logs', () => {
         />,
       );
 
-      await act(async () => {
-        await Promise.resolve();
-      });
-
-      // Empty fetched logs still create a section (e.g. 404 / no output) so fold state is consistent.
-      const lastCall = mockLogViewer.mock.calls[mockLogViewer.mock.calls.length - 1][0];
-      expect(lastCall.sections).toHaveLength(2);
-      expect(lastCall.sections[0]).toEqual({
-        containerName: 'CONTAINER1',
-        data: 'has logs',
-        isCompleted: true,
-      });
-      expect(lastCall.sections[1]).toEqual({
-        containerName: 'CONTAINER2',
-        data: '',
-        isCompleted: true,
+      await waitFor(() => {
+        // Both containers appear in sections; container2 has an empty buffer
+        const lastCall = mockLogViewer.mock.calls[mockLogViewer.mock.calls.length - 1][0];
+        expect(lastCall.normalizedSections).toHaveLength(2);
+        expect(lastCall.normalizedSections[0].containerName).toBe('CONTAINER1');
+        expect(lastCall.normalizedSections[0].lines).toEqual(['has logs']);
+        expect(lastCall.normalizedSections[1].containerName).toBe('CONTAINER2');
+        expect(lastCall.normalizedSections[1].lines).toEqual([]);
       });
     });
 
@@ -347,7 +353,7 @@ describe('Logs', () => {
 
       expect(mockLogViewer).toHaveBeenCalledWith(
         expect.objectContaining({
-          sections: [],
+          normalizedSections: [],
         }),
       );
     });
@@ -942,7 +948,7 @@ describe('Logs', () => {
       expect(mockLogViewer).toHaveBeenCalledWith(
         expect.objectContaining({
           isLoading: false,
-          sections: [],
+          normalizedSections: [],
         }),
       );
     });

--- a/src/shared/components/pipeline-run-logs/logs/__tests__/Logs.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/__tests__/Logs.spec.tsx
@@ -1,6 +1,8 @@
 import { render, screen, act, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { saveAs } from 'file-saver';
 import { useIsOnFeatureFlag } from '~/feature-flags/hooks';
+import { KUBEARCHIVE_TAIL_LINES } from '~/kubearchive/const';
 import { ResourceSource } from '~/types/k8s';
 import { commonFetchText } from '../../../../../k8s';
 import {
@@ -20,6 +22,15 @@ const getLastSectionsData = (): string => {
     .map((s: { lines: string[] }) => s.lines.join('\n'))
     .join('\n');
 };
+
+const getLastOnDownloadFullLogs = (): ((sectionIndex: number) => Promise<void>) | undefined => {
+  const lastCall = mockLogViewer.mock.calls[mockLogViewer.mock.calls.length - 1][0];
+  return lastCall.onDownloadFullLogs;
+};
+
+jest.mock('file-saver', () => ({
+  saveAs: jest.fn(),
+}));
 
 jest.mock('../LogViewer', () => {
   return function MockLogViewer(props: {
@@ -984,5 +995,416 @@ describe('Logs', () => {
         }),
       }),
     );
+  });
+
+  describe('tailed container detection', () => {
+    it('should mark container as tailed when log lines reach KUBEARCHIVE_TAIL_LINES', async () => {
+      const terminatedContainer: ContainerStatus = {
+        name: 'container1',
+        state: { terminated: { exitCode: 0 } },
+        ready: false,
+        restartCount: 0,
+        image: 'test-image',
+        imageID: 'test-image-id',
+      };
+
+      const resourceWithStatus: PodKind = {
+        ...mockResource,
+        status: {
+          phase: 'Succeeded',
+          containerStatuses: [terminatedContainer],
+        },
+      };
+
+      // Generate log text with KUBEARCHIVE_TAIL_LINES lines
+      const lines = Array.from({ length: KUBEARCHIVE_TAIL_LINES }, (_, i) => `line ${i}`).join(
+        '\n',
+      );
+
+      (containerToLogSourceStatus as jest.Mock).mockReturnValue('terminated');
+      (useIsOnFeatureFlag as jest.Mock).mockReturnValue(true);
+      (commonFetchText as jest.Mock).mockResolvedValue(`${lines}\n`);
+
+      render(
+        <Logs
+          {...defaultProps}
+          resource={resourceWithStatus}
+          containers={[{ name: 'container1' }]}
+          source={ResourceSource.Archive}
+        />,
+      );
+
+      await waitFor(() => {
+        const lastCall = mockLogViewer.mock.calls[mockLogViewer.mock.calls.length - 1][0];
+        expect(lastCall.normalizedSections[0].isTailed).toBe(true);
+      });
+    });
+
+    it('should not mark container as tailed when log lines are below KUBEARCHIVE_TAIL_LINES', async () => {
+      const terminatedContainer: ContainerStatus = {
+        name: 'container1',
+        state: { terminated: { exitCode: 0 } },
+        ready: false,
+        restartCount: 0,
+        image: 'test-image',
+        imageID: 'test-image-id',
+      };
+
+      const resourceWithStatus: PodKind = {
+        ...mockResource,
+        status: {
+          phase: 'Succeeded',
+          containerStatuses: [terminatedContainer],
+        },
+      };
+
+      (containerToLogSourceStatus as jest.Mock).mockReturnValue('terminated');
+      (useIsOnFeatureFlag as jest.Mock).mockReturnValue(true);
+      (commonFetchText as jest.Mock).mockResolvedValue('short log\n');
+
+      render(
+        <Logs
+          {...defaultProps}
+          resource={resourceWithStatus}
+          containers={[{ name: 'container1' }]}
+          source={ResourceSource.Archive}
+        />,
+      );
+
+      await waitFor(() => {
+        const lastCall = mockLogViewer.mock.calls[mockLogViewer.mock.calls.length - 1][0];
+        expect(lastCall.normalizedSections[0].isTailed).toBe(false);
+      });
+    });
+
+    it('should not mark container as tailed for cluster source', async () => {
+      const terminatedContainer: ContainerStatus = {
+        name: 'container1',
+        state: { terminated: { exitCode: 0 } },
+        ready: false,
+        restartCount: 0,
+        image: 'test-image',
+        imageID: 'test-image-id',
+      };
+
+      const resourceWithStatus: PodKind = {
+        ...mockResource,
+        status: {
+          phase: 'Succeeded',
+          containerStatuses: [terminatedContainer],
+        },
+      };
+
+      const lines = Array.from({ length: KUBEARCHIVE_TAIL_LINES }, (_, i) => `line ${i}`).join(
+        '\n',
+      );
+
+      (containerToLogSourceStatus as jest.Mock).mockReturnValue('terminated');
+      (useIsOnFeatureFlag as jest.Mock).mockReturnValue(true);
+      (commonFetchText as jest.Mock).mockResolvedValue(`${lines}\n`);
+
+      render(
+        <Logs
+          {...defaultProps}
+          resource={resourceWithStatus}
+          containers={[{ name: 'container1' }]}
+          source={ResourceSource.Cluster}
+        />,
+      );
+
+      await waitFor(() => {
+        const lastCall = mockLogViewer.mock.calls[mockLogViewer.mock.calls.length - 1][0];
+        expect(lastCall.normalizedSections[0].isTailed).toBe(false);
+      });
+    });
+  });
+
+  describe('kubearchive tailLines query param', () => {
+    it('should include tailLines query param for archive source', () => {
+      const terminatedContainer: ContainerStatus = {
+        name: 'container1',
+        state: { terminated: { exitCode: 0 } },
+        ready: false,
+        restartCount: 0,
+        image: 'test-image',
+        imageID: 'test-image-id',
+      };
+
+      const resourceWithStatus: PodKind = {
+        ...mockResource,
+        status: {
+          phase: 'Succeeded',
+          containerStatuses: [terminatedContainer],
+        },
+      };
+
+      (containerToLogSourceStatus as jest.Mock).mockReturnValue('terminated');
+      (useIsOnFeatureFlag as jest.Mock).mockReturnValue(true);
+      (commonFetchText as jest.Mock).mockResolvedValue('logs');
+
+      render(
+        <Logs
+          {...defaultProps}
+          resource={resourceWithStatus}
+          containers={[{ name: 'container1' }]}
+          source={ResourceSource.Archive}
+        />,
+      );
+
+      expect(getK8sResourceURL as jest.Mock).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'Pod' }),
+        undefined,
+        expect.objectContaining({
+          queryParams: expect.objectContaining({
+            tailLines: String(KUBEARCHIVE_TAIL_LINES),
+          }),
+        }),
+      );
+    });
+
+    it('should not include tailLines query param for cluster source', () => {
+      const terminatedContainer: ContainerStatus = {
+        name: 'container1',
+        state: { terminated: { exitCode: 0 } },
+        ready: false,
+        restartCount: 0,
+        image: 'test-image',
+        imageID: 'test-image-id',
+      };
+
+      const resourceWithStatus: PodKind = {
+        ...mockResource,
+        status: {
+          phase: 'Succeeded',
+          containerStatuses: [terminatedContainer],
+        },
+      };
+
+      (containerToLogSourceStatus as jest.Mock).mockReturnValue('terminated');
+      (useIsOnFeatureFlag as jest.Mock).mockReturnValue(false);
+      (commonFetchText as jest.Mock).mockResolvedValue('logs');
+
+      render(
+        <Logs
+          {...defaultProps}
+          resource={resourceWithStatus}
+          containers={[{ name: 'container1' }]}
+          source={ResourceSource.Cluster}
+        />,
+      );
+
+      expect(getK8sResourceURL as jest.Mock).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'Pod' }),
+        undefined,
+        expect.objectContaining({
+          queryParams: expect.not.objectContaining({
+            tailLines: expect.anything(),
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('handleDownloadFullLogs', () => {
+    it('should pass onDownloadFullLogs when source is archive', async () => {
+      const terminatedContainer: ContainerStatus = {
+        name: 'container1',
+        state: { terminated: { exitCode: 0 } },
+        ready: false,
+        restartCount: 0,
+        image: 'test-image',
+        imageID: 'test-image-id',
+      };
+
+      const resourceWithStatus: PodKind = {
+        ...mockResource,
+        status: {
+          phase: 'Succeeded',
+          containerStatuses: [terminatedContainer],
+        },
+      };
+
+      (containerToLogSourceStatus as jest.Mock).mockReturnValue('terminated');
+      (useIsOnFeatureFlag as jest.Mock).mockReturnValue(true);
+      (commonFetchText as jest.Mock).mockResolvedValue('log data\n');
+
+      render(
+        <Logs
+          {...defaultProps}
+          resource={resourceWithStatus}
+          containers={[{ name: 'container1' }]}
+          source={ResourceSource.Archive}
+        />,
+      );
+
+      await waitFor(() => {
+        const onDownloadFullLogs = getLastOnDownloadFullLogs();
+        expect(onDownloadFullLogs).toBeDefined();
+      });
+    });
+
+    it('should not pass onDownloadFullLogs when source is cluster', () => {
+      (containerToLogSourceStatus as jest.Mock).mockReturnValue('terminated');
+      (useIsOnFeatureFlag as jest.Mock).mockReturnValue(false);
+
+      render(
+        <Logs
+          {...defaultProps}
+          containers={[{ name: 'container1' }]}
+          source={ResourceSource.Cluster}
+        />,
+      );
+
+      const onDownloadFullLogs = getLastOnDownloadFullLogs();
+      expect(onDownloadFullLogs).toBeUndefined();
+    });
+
+    it('should fetch full logs and save file when onDownloadFullLogs is called', async () => {
+      const terminatedContainer: ContainerStatus = {
+        name: 'container1',
+        state: { terminated: { exitCode: 0 } },
+        ready: false,
+        restartCount: 0,
+        image: 'test-image',
+        imageID: 'test-image-id',
+      };
+
+      const resourceWithStatus: PodKind = {
+        ...mockResource,
+        status: {
+          phase: 'Succeeded',
+          containerStatuses: [terminatedContainer],
+        },
+      };
+
+      (containerToLogSourceStatus as jest.Mock).mockReturnValue('terminated');
+      (useIsOnFeatureFlag as jest.Mock).mockReturnValue(true);
+      const tailedLog = `${Array.from({ length: KUBEARCHIVE_TAIL_LINES }, (_, i) => `line ${i}`).join('\n')}\n`;
+      (commonFetchText as jest.Mock).mockResolvedValue(tailedLog);
+
+      render(
+        <Logs
+          {...defaultProps}
+          resource={resourceWithStatus}
+          containers={[{ name: 'container1' }]}
+          source={ResourceSource.Archive}
+        />,
+      );
+
+      await waitFor(() => {
+        const lastCall = mockLogViewer.mock.calls[mockLogViewer.mock.calls.length - 1][0];
+        expect(lastCall.normalizedSections).toHaveLength(1);
+        expect(lastCall.onDownloadFullLogs).toBeDefined();
+      });
+
+      (commonFetchText as jest.Mock).mockResolvedValue('full log content for download');
+
+      const onDownloadFullLogs = getLastOnDownloadFullLogs();
+      await act(async () => {
+        await onDownloadFullLogs?.(0);
+      });
+
+      expect(commonFetchText as jest.Mock).toHaveBeenCalledWith(
+        'http://test-url',
+        expect.objectContaining({
+          pathPrefix: 'plugins/kubearchive',
+        }),
+      );
+      expect(saveAs).toHaveBeenCalledWith(expect.any(Blob), 'container1.log');
+    });
+
+    it('should not save file when section index is invalid', async () => {
+      const terminatedContainer: ContainerStatus = {
+        name: 'container1',
+        state: { terminated: { exitCode: 0 } },
+        ready: false,
+        restartCount: 0,
+        image: 'test-image',
+        imageID: 'test-image-id',
+      };
+
+      const resourceWithStatus: PodKind = {
+        ...mockResource,
+        status: {
+          phase: 'Succeeded',
+          containerStatuses: [terminatedContainer],
+        },
+      };
+
+      (containerToLogSourceStatus as jest.Mock).mockReturnValue('terminated');
+      (useIsOnFeatureFlag as jest.Mock).mockReturnValue(true);
+      (commonFetchText as jest.Mock).mockResolvedValue('log data\n');
+
+      render(
+        <Logs
+          {...defaultProps}
+          resource={resourceWithStatus}
+          containers={[{ name: 'container1' }]}
+          source={ResourceSource.Archive}
+        />,
+      );
+
+      await waitFor(() => {
+        const onDownloadFullLogs = getLastOnDownloadFullLogs();
+        expect(onDownloadFullLogs).toBeDefined();
+      });
+
+      (commonFetchText as jest.Mock).mockClear();
+
+      const onDownloadFullLogs = getLastOnDownloadFullLogs();
+      await act(async () => {
+        await onDownloadFullLogs?.(999); // invalid index
+      });
+
+      // Should not have fetched anything for an invalid section index
+      expect(commonFetchText).not.toHaveBeenCalled();
+      expect(saveAs).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('rAF cleanup', () => {
+    it('should cancel pending animation frame on unmount', () => {
+      const cancelAnimationFrameSpy = jest.spyOn(window, 'cancelAnimationFrame');
+
+      const runningContainer: ContainerStatus = {
+        name: 'container1',
+        state: { running: { startedAt: new Date().toISOString() } },
+        ready: true,
+        restartCount: 0,
+        image: 'test-image',
+        imageID: 'test-image-id',
+      };
+
+      const resourceWithStatus: PodKind = {
+        ...mockResource,
+        status: {
+          phase: 'Running',
+          containerStatuses: [runningContainer],
+        },
+      };
+
+      (containerToLogSourceStatus as jest.Mock).mockReturnValue('running');
+
+      const { unmount } = render(
+        <Logs
+          {...defaultProps}
+          resource={resourceWithStatus}
+          containers={[{ name: 'container1' }]}
+        />,
+      );
+
+      // Simulate a websocket message to trigger rAF scheduling
+      const messageHandler = mockWebSocketInstance.onMessage.mock.calls[0][0];
+      act(() => {
+        messageHandler('dGVzdA==');
+      });
+
+      unmount();
+
+      // cancelAnimationFrame should have been called during cleanup
+      expect(cancelAnimationFrameSpy).toHaveBeenCalled();
+
+      cancelAnimationFrameSpy.mockRestore();
+    });
   });
 });

--- a/src/shared/components/virtualized-log-viewer/SectionLogUI.tsx
+++ b/src/shared/components/virtualized-log-viewer/SectionLogUI.tsx
@@ -82,7 +82,7 @@ export const SectionHeaderButton: React.FC<{
                 onClick={onViewFullLogs}
                 data-test={`view-full-logs-${row.sectionName}`}
               >
-                {!isDownloading && <ExternalLinkAltIcon className="pf-v6-u-mr-xs" />}
+                <ExternalLinkAltIcon className="pf-v6-u-mr-xs" />
                 View full logs
               </Button>
             </FlexItem>

--- a/src/shared/components/virtualized-log-viewer/SectionLogUI.tsx
+++ b/src/shared/components/virtualized-log-viewer/SectionLogUI.tsx
@@ -1,33 +1,75 @@
 import React from 'react';
-import { Button, Flex, FlexItem, Content } from '@patternfly/react-core';
+import { Button, Flex, FlexItem, Content, Label } from '@patternfly/react-core';
 import { AngleDownIcon } from '@patternfly/react-icons/dist/esm/icons/angle-down-icon';
 import { AngleRightIcon } from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
+import { DownloadIcon } from '@patternfly/react-icons/dist/esm/icons/download-icon';
 import type { SectionHeaderRow } from './types';
 
 import './SectionLogUI.scss';
 import './VirtualizedLogContent.scss';
 
-export const SectionHeaderButton: React.FC<{ row: SectionHeaderRow; onToggle: () => void }> = ({
-  row,
-  onToggle,
-}) => (
-  <Button
-    variant="plain"
-    className="pf-v6-u-p-0 log-content__section-header-btn"
-    onClick={onToggle}
-    aria-expanded={row.isExpanded}
-    data-test={`fold-header-${row.sectionName}`}
-  >
+export const SectionHeaderButton: React.FC<{
+  row: SectionHeaderRow;
+  onToggle: () => void;
+  onDownloadFullLogs?: () => Promise<void>;
+}> = ({ row, onToggle, onDownloadFullLogs }) => {
+  const [isDownloading, setIsDownloading] = React.useState(false);
+
+  const handleDownload = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!onDownloadFullLogs || isDownloading) return;
+    setIsDownloading(true);
+    void onDownloadFullLogs().finally(() => setIsDownloading(false));
+  };
+
+  return (
     <Flex alignItems={{ default: 'alignItemsCenter' }} spaceItems={{ default: 'spaceItemsXs' }}>
       <FlexItem>
-        {row.isExpanded ? <AngleDownIcon aria-hidden /> : <AngleRightIcon aria-hidden />}
+        <Button
+          variant="plain"
+          className="pf-v6-u-p-0 log-content__section-header-btn"
+          onClick={onToggle}
+          aria-expanded={row.isExpanded}
+          data-test={`fold-header-${row.sectionName}`}
+        >
+          <Flex
+            alignItems={{ default: 'alignItemsCenter' }}
+            spaceItems={{ default: 'spaceItemsXs' }}
+          >
+            <FlexItem>
+              {row.isExpanded ? <AngleDownIcon aria-hidden /> : <AngleRightIcon aria-hidden />}
+            </FlexItem>
+            <FlexItem className="pf-v6-c-log-viewer__text pf-v6-u-font-weight-bold">
+              {row.sectionName}
+            </FlexItem>
+          </Flex>
+        </Button>
       </FlexItem>
-      <FlexItem className="pf-v6-c-log-viewer__text pf-v6-u-font-weight-bold">
-        {row.sectionName}
-      </FlexItem>
+      {row.isTailed && (
+        <>
+          <FlexItem>
+            <Label isCompact>showing last {row.lineCount} lines</Label>
+          </FlexItem>
+          {onDownloadFullLogs && (
+            <FlexItem>
+              <Button
+                variant="link"
+                isInline
+                isDisabled={isDownloading}
+                isLoading={isDownloading}
+                onClick={handleDownload}
+                data-test={`download-full-logs-${row.sectionName}`}
+              >
+                {!isDownloading && <DownloadIcon className="pf-v6-u-mr-xs" />}
+                Download full logs
+              </Button>
+            </FlexItem>
+          )}
+        </>
+      )}
     </Flex>
-  </Button>
-);
+  );
+};
 
 export const FoldIndicatorLine: React.FC<{ lineCount: number }> = ({ lineCount }) => (
   <Content component="small" className="pf-v6-c-log-viewer__text log-content__fold-indicator">
@@ -41,7 +83,8 @@ export const StickySectionHeaderBar: React.FC<{
   itemSize: number;
   onToggle: () => void;
   onLineClick: (lineNumber: number, event: React.MouseEvent) => void;
-}> = ({ row, pushUpOffset, itemSize, onToggle, onLineClick }) => (
+  onDownloadFullLogs?: () => Promise<void>;
+}> = ({ row, pushUpOffset, itemSize, onToggle, onLineClick, onDownloadFullLogs }) => (
   <div
     className="log-content__sticky-header"
     style={{
@@ -71,7 +114,7 @@ export const StickySectionHeaderBar: React.FC<{
       className="log-content__row-content log-content__sticky-header-content pf-v6-c-log-viewer__list-item"
       style={{ height: `${itemSize}px` }}
     >
-      <SectionHeaderButton row={row} onToggle={onToggle} />
+      <SectionHeaderButton row={row} onToggle={onToggle} onDownloadFullLogs={onDownloadFullLogs} />
     </div>
   </div>
 );

--- a/src/shared/components/virtualized-log-viewer/SectionLogUI.tsx
+++ b/src/shared/components/virtualized-log-viewer/SectionLogUI.tsx
@@ -3,6 +3,7 @@ import { Button, Flex, FlexItem, Content, Label } from '@patternfly/react-core';
 import { AngleDownIcon } from '@patternfly/react-icons/dist/esm/icons/angle-down-icon';
 import { AngleRightIcon } from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
 import { DownloadIcon } from '@patternfly/react-icons/dist/esm/icons/download-icon';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 import { logger } from '~/monitoring/logger';
 import type { SectionHeaderRow } from './types';
 
@@ -13,7 +14,8 @@ export const SectionHeaderButton: React.FC<{
   row: SectionHeaderRow;
   onToggle: () => void;
   onDownloadFullLogs?: () => Promise<void>;
-}> = ({ row, onToggle, onDownloadFullLogs }) => {
+  onViewFullLogs?: () => void;
+}> = ({ row, onToggle, onDownloadFullLogs, onViewFullLogs }) => {
   const [isDownloading, setIsDownloading] = React.useState(false);
 
   const handleDownload = (e: React.MouseEvent) => {
@@ -54,11 +56,11 @@ export const SectionHeaderButton: React.FC<{
       </FlexItem>
       {row.isTailed && (
         <>
-          <FlexItem>
+          <FlexItem className="pf-v6-u-ml-md">
             <Label isCompact>showing last {row.lineCount} lines</Label>
           </FlexItem>
           {onDownloadFullLogs && (
-            <FlexItem>
+            <FlexItem className="pf-v6-u-ml-md">
               <Button
                 variant="link"
                 isInline
@@ -69,6 +71,19 @@ export const SectionHeaderButton: React.FC<{
               >
                 {!isDownloading && <DownloadIcon className="pf-v6-u-mr-xs" />}
                 Download full logs
+              </Button>
+            </FlexItem>
+          )}
+          {onViewFullLogs && (
+            <FlexItem className="pf-v6-u-ml-md">
+              <Button
+                variant="link"
+                isInline
+                onClick={onViewFullLogs}
+                data-test={`view-full-logs-${row.sectionName}`}
+              >
+                {!isDownloading && <ExternalLinkAltIcon className="pf-v6-u-mr-xs" />}
+                View full logs
               </Button>
             </FlexItem>
           )}
@@ -91,7 +106,16 @@ export const StickySectionHeaderBar: React.FC<{
   onToggle: () => void;
   onLineClick: (lineNumber: number, event: React.MouseEvent) => void;
   onDownloadFullLogs?: () => Promise<void>;
-}> = ({ row, pushUpOffset, itemSize, onToggle, onLineClick, onDownloadFullLogs }) => (
+  onViewFullLogs?: () => void;
+}> = ({
+  row,
+  pushUpOffset,
+  itemSize,
+  onToggle,
+  onLineClick,
+  onDownloadFullLogs,
+  onViewFullLogs,
+}) => (
   <div
     className="log-content__sticky-header"
     style={{
@@ -121,7 +145,12 @@ export const StickySectionHeaderBar: React.FC<{
       className="log-content__row-content log-content__sticky-header-content pf-v6-c-log-viewer__list-item"
       style={{ height: `${itemSize}px` }}
     >
-      <SectionHeaderButton row={row} onToggle={onToggle} onDownloadFullLogs={onDownloadFullLogs} />
+      <SectionHeaderButton
+        row={row}
+        onToggle={onToggle}
+        onDownloadFullLogs={onDownloadFullLogs}
+        onViewFullLogs={onViewFullLogs}
+      />
     </div>
   </div>
 );

--- a/src/shared/components/virtualized-log-viewer/SectionLogUI.tsx
+++ b/src/shared/components/virtualized-log-viewer/SectionLogUI.tsx
@@ -3,6 +3,7 @@ import { Button, Flex, FlexItem, Content, Label } from '@patternfly/react-core';
 import { AngleDownIcon } from '@patternfly/react-icons/dist/esm/icons/angle-down-icon';
 import { AngleRightIcon } from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
 import { DownloadIcon } from '@patternfly/react-icons/dist/esm/icons/download-icon';
+import { logger } from '~/monitoring/logger';
 import type { SectionHeaderRow } from './types';
 
 import './SectionLogUI.scss';
@@ -19,7 +20,13 @@ export const SectionHeaderButton: React.FC<{
     e.stopPropagation();
     if (!onDownloadFullLogs || isDownloading) return;
     setIsDownloading(true);
-    void onDownloadFullLogs().finally(() => setIsDownloading(false));
+    void onDownloadFullLogs()
+      .catch((err: unknown) => {
+        logger.warn('Failed to download full logs', {
+          error: err instanceof Error ? err.message : '',
+        });
+      })
+      .finally(() => setIsDownloading(false));
   };
 
   return (

--- a/src/shared/components/virtualized-log-viewer/SectionedVirtualRow.tsx
+++ b/src/shared/components/virtualized-log-viewer/SectionedVirtualRow.tsx
@@ -28,6 +28,7 @@ type SectionedVirtualRowProps = {
   measureElement: Virtualizer<HTMLDivElement, Element>['measureElement'];
   isLineHighlighted: (lineNumber: number) => boolean;
   onToggleSection: (sectionIndex: number) => void;
+  onDownloadFullLogs?: (sectionIndex: number) => Promise<void>;
   renderLogLine: (flatLineIndex: number) => React.ReactNode;
   onLineClick: (lineNumber: number, event: React.MouseEvent) => void;
 };
@@ -39,6 +40,7 @@ export const SectionedVirtualRow: React.FC<SectionedVirtualRowProps> = ({
   measureElement,
   isLineHighlighted,
   onToggleSection,
+  onDownloadFullLogs,
   renderLogLine,
   onLineClick,
 }) => {
@@ -84,7 +86,15 @@ export const SectionedVirtualRow: React.FC<SectionedVirtualRowProps> = ({
       <div {...rowProps}>
         {gutterCell}
         <div className="log-content__row-content">
-          <SectionHeaderButton row={row} onToggle={() => onToggleSection(row.sectionIndex)} />
+          <SectionHeaderButton
+            row={row}
+            onToggle={() => onToggleSection(row.sectionIndex)}
+            onDownloadFullLogs={
+              row.isTailed && onDownloadFullLogs
+                ? () => onDownloadFullLogs(row.sectionIndex)
+                : undefined
+            }
+          />
         </div>
       </div>
     );

--- a/src/shared/components/virtualized-log-viewer/SectionedVirtualRow.tsx
+++ b/src/shared/components/virtualized-log-viewer/SectionedVirtualRow.tsx
@@ -29,6 +29,7 @@ type SectionedVirtualRowProps = {
   isLineHighlighted: (lineNumber: number) => boolean;
   onToggleSection: (sectionIndex: number) => void;
   onDownloadFullLogs?: (sectionIndex: number) => Promise<void>;
+  onViewFullLogs?: (sectionIndex: number) => void;
   renderLogLine: (flatLineIndex: number) => React.ReactNode;
   onLineClick: (lineNumber: number, event: React.MouseEvent) => void;
 };
@@ -41,6 +42,7 @@ export const SectionedVirtualRow: React.FC<SectionedVirtualRowProps> = ({
   isLineHighlighted,
   onToggleSection,
   onDownloadFullLogs,
+  onViewFullLogs,
   renderLogLine,
   onLineClick,
 }) => {
@@ -93,6 +95,9 @@ export const SectionedVirtualRow: React.FC<SectionedVirtualRowProps> = ({
               row.isTailed && onDownloadFullLogs
                 ? () => onDownloadFullLogs(row.sectionIndex)
                 : undefined
+            }
+            onViewFullLogs={
+              row.isTailed && onViewFullLogs ? () => onViewFullLogs(row.sectionIndex) : undefined
             }
           />
         </div>

--- a/src/shared/components/virtualized-log-viewer/VirtualizedLogContent.tsx
+++ b/src/shared/components/virtualized-log-viewer/VirtualizedLogContent.tsx
@@ -65,14 +65,16 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
   const [itemSize, setItemSize] = React.useState(VIRTUALIZATION_CONFIG.FALLBACK_LINE_HEIGHT);
   const charsPerLineRef = React.useRef(VIRTUALIZATION_CONFIG.FALLBACK_CHARS_PER_LINE);
 
-  const isMultiSection = sections.length > 1;
-  const { expandedSections, toggleSection, expandSection } = useSectionFold(sections);
-
   const internalNormalizedSections = React.useMemo(
     () => (normalizedSectionsProp ? null : sections.map(normalizeSection)),
     [normalizedSectionsProp, sections],
   );
   const effectiveNormalizedSections = normalizedSectionsProp ?? internalNormalizedSections ?? [];
+
+  const isMultiSection = effectiveNormalizedSections.length > 1;
+  const { expandedSections, toggleSection, expandSection } = useSectionFold(
+    effectiveNormalizedSections,
+  );
 
   const {
     displayRows,

--- a/src/shared/components/virtualized-log-viewer/VirtualizedLogContent.tsx
+++ b/src/shared/components/virtualized-log-viewer/VirtualizedLogContent.tsx
@@ -48,6 +48,7 @@ export interface VirtualizedLogContentProps {
    */
   readyToNavigate?: boolean;
   onDownloadFullLogs?: (sectionIndex: number) => Promise<void>;
+  onViewFullLogs?: (sectionIndex: number) => void;
 }
 
 export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
@@ -62,6 +63,7 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
   currentSearchMatch,
   readyToNavigate = true,
   onDownloadFullLogs,
+  onViewFullLogs,
 }) => {
   const scrollRef = React.useRef<HTMLDivElement | null>(null);
   const [itemSize, setItemSize] = React.useState(VIRTUALIZATION_CONFIG.FALLBACK_LINE_HEIGHT);
@@ -326,6 +328,7 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
                 isLineHighlighted={isLineHighlighted}
                 onToggleSection={toggleSection}
                 onDownloadFullLogs={onDownloadFullLogs}
+                onViewFullLogs={onViewFullLogs}
                 renderLogLine={renderLine}
                 onLineClick={handleLineClick}
               />
@@ -344,6 +347,11 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
           onDownloadFullLogs={
             stickyRow.isTailed && onDownloadFullLogs
               ? () => onDownloadFullLogs(stickyRow.sectionIndex)
+              : undefined
+          }
+          onViewFullLogs={
+            stickyRow.isTailed && onViewFullLogs
+              ? () => onViewFullLogs(stickyRow.sectionIndex)
               : undefined
           }
         />

--- a/src/shared/components/virtualized-log-viewer/VirtualizedLogContent.tsx
+++ b/src/shared/components/virtualized-log-viewer/VirtualizedLogContent.tsx
@@ -47,6 +47,7 @@ export interface VirtualizedLogContentProps {
    * true.
    */
   readyToNavigate?: boolean;
+  onDownloadFullLogs?: (sectionIndex: number) => Promise<void>;
 }
 
 export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
@@ -60,6 +61,7 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
   searchText = '',
   currentSearchMatch,
   readyToNavigate = true,
+  onDownloadFullLogs,
 }) => {
   const scrollRef = React.useRef<HTMLDivElement | null>(null);
   const [itemSize, setItemSize] = React.useState(VIRTUALIZATION_CONFIG.FALLBACK_LINE_HEIGHT);
@@ -323,6 +325,7 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
                 measureElement={virtualizer.measureElement}
                 isLineHighlighted={isLineHighlighted}
                 onToggleSection={toggleSection}
+                onDownloadFullLogs={onDownloadFullLogs}
                 renderLogLine={renderLine}
                 onLineClick={handleLineClick}
               />
@@ -338,6 +341,11 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
           itemSize={itemSize}
           onToggle={() => toggleSection(stickyRow.sectionIndex)}
           onLineClick={handleLineClick}
+          onDownloadFullLogs={
+            stickyRow.isTailed && onDownloadFullLogs
+              ? () => onDownloadFullLogs(stickyRow.sectionIndex)
+              : undefined
+          }
         />
       )}
     </div>

--- a/src/shared/components/virtualized-log-viewer/VirtualizedLogViewer.tsx
+++ b/src/shared/components/virtualized-log-viewer/VirtualizedLogViewer.tsx
@@ -23,6 +23,7 @@ export interface VirtualizedLogViewerProps {
    * Defaults to true.
    */
   readyToNavigate?: boolean;
+  onDownloadFullLogs?: (sectionIndex: number) => Promise<void>;
 }
 
 export const VirtualizedLogViewer: React.FC<VirtualizedLogViewerProps> = ({
@@ -33,6 +34,7 @@ export const VirtualizedLogViewer: React.FC<VirtualizedLogViewerProps> = ({
   scrollToRow,
   onScroll,
   readyToNavigate = true,
+  onDownloadFullLogs,
 }) => {
   const toolbarContext = React.useContext(LogViewerToolbarContext);
   const searchedInput =
@@ -83,6 +85,7 @@ export const VirtualizedLogViewer: React.FC<VirtualizedLogViewerProps> = ({
         searchText={searchedInput}
         currentSearchMatch={rowInFocus}
         readyToNavigate={readyToNavigate}
+        onDownloadFullLogs={onDownloadFullLogs}
       />
     </div>
   );

--- a/src/shared/components/virtualized-log-viewer/VirtualizedLogViewer.tsx
+++ b/src/shared/components/virtualized-log-viewer/VirtualizedLogViewer.tsx
@@ -24,6 +24,7 @@ export interface VirtualizedLogViewerProps {
    */
   readyToNavigate?: boolean;
   onDownloadFullLogs?: (sectionIndex: number) => Promise<void>;
+  onViewFullLogs?: (sectionIndex: number) => void;
 }
 
 export const VirtualizedLogViewer: React.FC<VirtualizedLogViewerProps> = ({
@@ -35,6 +36,7 @@ export const VirtualizedLogViewer: React.FC<VirtualizedLogViewerProps> = ({
   onScroll,
   readyToNavigate = true,
   onDownloadFullLogs,
+  onViewFullLogs,
 }) => {
   const toolbarContext = React.useContext(LogViewerToolbarContext);
   const searchedInput =
@@ -86,6 +88,7 @@ export const VirtualizedLogViewer: React.FC<VirtualizedLogViewerProps> = ({
         currentSearchMatch={rowInFocus}
         readyToNavigate={readyToNavigate}
         onDownloadFullLogs={onDownloadFullLogs}
+        onViewFullLogs={onViewFullLogs}
       />
     </div>
   );

--- a/src/shared/components/virtualized-log-viewer/__tests__/SectionLogUI.spec.tsx
+++ b/src/shared/components/virtualized-log-viewer/__tests__/SectionLogUI.spec.tsx
@@ -1,0 +1,233 @@
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { logger } from '~/monitoring/logger';
+import { SectionHeaderButton, FoldIndicatorLine, StickySectionHeaderBar } from '../SectionLogUI';
+import type { SectionHeaderRow } from '../types';
+
+jest.mock('~/monitoring/logger', () => ({
+  logger: { warn: jest.fn() },
+}));
+
+const makeRow = (overrides?: Partial<SectionHeaderRow>): SectionHeaderRow => ({
+  kind: 'section-header',
+  sectionName: 'BUILD',
+  sectionIndex: 0,
+  lineNumber: 1,
+  lineCount: 500,
+  isExpanded: true,
+  isTailed: false,
+  ...overrides,
+});
+
+describe('SectionHeaderButton', () => {
+  it('should render section name and toggle button', () => {
+    const onToggle = jest.fn();
+    render(<SectionHeaderButton row={makeRow()} onToggle={onToggle} />);
+
+    expect(screen.getByText('BUILD')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('fold-header-BUILD'));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('should set aria-expanded based on row.isExpanded', () => {
+    render(<SectionHeaderButton row={makeRow({ isExpanded: false })} onToggle={jest.fn()} />);
+    expect(screen.getByTestId('fold-header-BUILD')).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('should not show tailed indicator when isTailed is false', () => {
+    render(<SectionHeaderButton row={makeRow({ isTailed: false })} onToggle={jest.fn()} />);
+
+    expect(screen.queryByText(/showing last/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Download full logs')).not.toBeInTheDocument();
+  });
+
+  it('should show tailed indicator with line count when isTailed is true', () => {
+    render(
+      <SectionHeaderButton
+        row={makeRow({ isTailed: true, lineCount: 500 })}
+        onToggle={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText('showing last 500 lines')).toBeInTheDocument();
+  });
+
+  it('should show download button when isTailed and onDownloadFullLogs provided', () => {
+    const onDownload = jest.fn().mockResolvedValue(undefined);
+    render(
+      <SectionHeaderButton
+        row={makeRow({ isTailed: true })}
+        onToggle={jest.fn()}
+        onDownloadFullLogs={onDownload}
+      />,
+    );
+
+    expect(screen.getByText('Download full logs')).toBeInTheDocument();
+    expect(screen.getByTestId('download-full-logs-BUILD')).toBeInTheDocument();
+  });
+
+  it('should not show download button when isTailed but no onDownloadFullLogs', () => {
+    render(<SectionHeaderButton row={makeRow({ isTailed: true })} onToggle={jest.fn()} />);
+
+    expect(screen.getByText(/showing last/)).toBeInTheDocument();
+    expect(screen.queryByText('Download full logs')).not.toBeInTheDocument();
+  });
+
+  it('should call onDownloadFullLogs and show loading state on click', async () => {
+    let resolveFn: () => void;
+    const downloadPromise = new Promise<void>((resolve) => {
+      resolveFn = resolve;
+    });
+    const onDownload = jest.fn().mockReturnValue(downloadPromise);
+
+    render(
+      <SectionHeaderButton
+        row={makeRow({ isTailed: true })}
+        onToggle={jest.fn()}
+        onDownloadFullLogs={onDownload}
+      />,
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('download-full-logs-BUILD'));
+    });
+
+    expect(onDownload).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('download-full-logs-BUILD')).toBeDisabled();
+
+    await act(async () => {
+      resolveFn();
+      await downloadPromise;
+    });
+
+    expect(screen.getByTestId('download-full-logs-BUILD')).not.toBeDisabled();
+  });
+
+  it('should log warning and reset state on download failure', async () => {
+    const onDownload = jest.fn().mockRejectedValue(new Error('network error'));
+
+    render(
+      <SectionHeaderButton
+        row={makeRow({ isTailed: true })}
+        onToggle={jest.fn()}
+        onDownloadFullLogs={onDownload}
+      />,
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('download-full-logs-BUILD'));
+    });
+
+    await waitFor(() => {
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(logger.warn).toHaveBeenCalledWith('Failed to download full logs', {
+        error: 'network error',
+      });
+      expect(screen.getByTestId('download-full-logs-BUILD')).not.toBeDisabled();
+    });
+  });
+
+  it('should not trigger download when already downloading', () => {
+    const onDownload = jest.fn().mockReturnValue(new Promise<void>(() => {}));
+
+    render(
+      <SectionHeaderButton
+        row={makeRow({ isTailed: true })}
+        onToggle={jest.fn()}
+        onDownloadFullLogs={onDownload}
+      />,
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('download-full-logs-BUILD'));
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('download-full-logs-BUILD'));
+    });
+
+    expect(onDownload).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('FoldIndicatorLine', () => {
+  it('should show plural form for multiple lines', () => {
+    render(<FoldIndicatorLine lineCount={42} />);
+    expect(screen.getByText('··· 42 lines hidden')).toBeInTheDocument();
+  });
+
+  it('should show singular form for one line', () => {
+    render(<FoldIndicatorLine lineCount={1} />);
+    expect(screen.getByText('··· 1 line hidden')).toBeInTheDocument();
+  });
+});
+
+describe('StickySectionHeaderBar', () => {
+  it('should render section header with line number and toggle', () => {
+    const onToggle = jest.fn();
+    const onLineClick = jest.fn();
+
+    render(
+      <StickySectionHeaderBar
+        row={makeRow()}
+        pushUpOffset={0}
+        itemSize={20}
+        onToggle={onToggle}
+        onLineClick={onLineClick}
+      />,
+    );
+
+    expect(screen.getByTestId('sticky-header-BUILD')).toBeInTheDocument();
+    expect(screen.getByText('BUILD')).toBeInTheDocument();
+    expect(screen.getByLabelText('Jump to line 1')).toBeInTheDocument();
+  });
+
+  it('should pass onDownloadFullLogs to SectionHeaderButton', () => {
+    const onDownload = jest.fn().mockResolvedValue(undefined);
+
+    render(
+      <StickySectionHeaderBar
+        row={makeRow({ isTailed: true })}
+        pushUpOffset={0}
+        itemSize={20}
+        onToggle={jest.fn()}
+        onLineClick={jest.fn()}
+        onDownloadFullLogs={onDownload}
+      />,
+    );
+
+    expect(screen.getByText('Download full logs')).toBeInTheDocument();
+  });
+
+  it('should apply transform and height styles', () => {
+    render(
+      <StickySectionHeaderBar
+        row={makeRow()}
+        pushUpOffset={-10}
+        itemSize={24}
+        onToggle={jest.fn()}
+        onLineClick={jest.fn()}
+      />,
+    );
+
+    const header = screen.getByTestId('sticky-header-BUILD');
+    expect(header).toHaveStyle({ transform: 'translateY(-10px)', height: '24px' });
+  });
+
+  it('should call onLineClick when line number is clicked', () => {
+    const onLineClick = jest.fn();
+
+    render(
+      <StickySectionHeaderBar
+        row={makeRow()}
+        pushUpOffset={0}
+        itemSize={20}
+        onToggle={jest.fn()}
+        onLineClick={onLineClick}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('Jump to line 1'));
+    expect(onLineClick).toHaveBeenCalledWith(1, expect.any(Object));
+  });
+});

--- a/src/shared/components/virtualized-log-viewer/__tests__/SectionLogUI.spec.tsx
+++ b/src/shared/components/virtualized-log-viewer/__tests__/SectionLogUI.spec.tsx
@@ -1,12 +1,13 @@
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { logger } from '~/monitoring/logger';
 import { SectionHeaderButton, FoldIndicatorLine, StickySectionHeaderBar } from '../SectionLogUI';
 import type { SectionHeaderRow } from '../types';
 
 jest.mock('~/monitoring/logger', () => ({
   logger: { warn: jest.fn() },
 }));
+
+const { logger } = jest.requireMock<{ logger: { warn: jest.Mock } }>('~/monitoring/logger');
 
 const makeRow = (overrides?: Partial<SectionHeaderRow>): SectionHeaderRow => ({
   kind: 'section-header',
@@ -119,7 +120,6 @@ describe('SectionHeaderButton', () => {
     });
 
     await waitFor(() => {
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(logger.warn).toHaveBeenCalledWith('Failed to download full logs', {
         error: 'network error',
       });

--- a/src/shared/components/virtualized-log-viewer/__tests__/SectionLogUI.spec.tsx
+++ b/src/shared/components/virtualized-log-viewer/__tests__/SectionLogUI.spec.tsx
@@ -148,6 +148,40 @@ describe('SectionHeaderButton', () => {
 
     expect(onDownload).toHaveBeenCalledTimes(1);
   });
+
+  it('should show view full logs button when isTailed and onViewFullLogs provided', () => {
+    render(
+      <SectionHeaderButton
+        row={makeRow({ isTailed: true })}
+        onToggle={jest.fn()}
+        onViewFullLogs={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText('View full logs')).toBeInTheDocument();
+    expect(screen.getByTestId('view-full-logs-BUILD')).toBeInTheDocument();
+  });
+
+  it('should not show view full logs button when onViewFullLogs is not provided', () => {
+    render(<SectionHeaderButton row={makeRow({ isTailed: true })} onToggle={jest.fn()} />);
+
+    expect(screen.queryByText('View full logs')).not.toBeInTheDocument();
+  });
+
+  it('should call onViewFullLogs on click', () => {
+    const onView = jest.fn();
+
+    render(
+      <SectionHeaderButton
+        row={makeRow({ isTailed: true })}
+        onToggle={jest.fn()}
+        onViewFullLogs={onView}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('view-full-logs-BUILD'));
+    expect(onView).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('FoldIndicatorLine', () => {
@@ -197,6 +231,21 @@ describe('StickySectionHeaderBar', () => {
     );
 
     expect(screen.getByText('Download full logs')).toBeInTheDocument();
+  });
+
+  it('should pass onViewFullLogs to SectionHeaderButton', () => {
+    render(
+      <StickySectionHeaderBar
+        row={makeRow({ isTailed: true })}
+        pushUpOffset={0}
+        itemSize={20}
+        onToggle={jest.fn()}
+        onLineClick={jest.fn()}
+        onViewFullLogs={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText('View full logs')).toBeInTheDocument();
   });
 
   it('should apply transform and height styles', () => {

--- a/src/shared/components/virtualized-log-viewer/log-viewer-utils.ts
+++ b/src/shared/components/virtualized-log-viewer/log-viewer-utils.ts
@@ -15,7 +15,11 @@ export function normalizeLogLines(data: string): string[] {
 }
 
 export function normalizeSection(section: LogSection): NormalizedLogSection {
-  return { containerName: section.containerName, lines: normalizeLogLines(section.data) };
+  return {
+    containerName: section.containerName,
+    lines: normalizeLogLines(section.data),
+    isCompleted: section.isCompleted,
+  };
 }
 
 export function singleLogSection(

--- a/src/shared/components/virtualized-log-viewer/types.ts
+++ b/src/shared/components/virtualized-log-viewer/types.ts
@@ -29,6 +29,7 @@ export interface NormalizedLogSection {
   containerName: string;
   lines: string[];
   isCompleted?: boolean;
+  isTailed?: boolean;
 }
 
 export type SectionHeaderRow = {
@@ -38,6 +39,7 @@ export type SectionHeaderRow = {
   readonly lineNumber: number;
   readonly lineCount: number;
   readonly isExpanded: boolean;
+  readonly isTailed: boolean;
 };
 
 export type ContentRow = {

--- a/src/shared/components/virtualized-log-viewer/types.ts
+++ b/src/shared/components/virtualized-log-viewer/types.ts
@@ -28,6 +28,7 @@ export interface LogSection {
 export interface NormalizedLogSection {
   containerName: string;
   lines: string[];
+  isCompleted?: boolean;
 }
 
 export type SectionHeaderRow = {

--- a/src/shared/components/virtualized-log-viewer/useSectionFold.ts
+++ b/src/shared/components/virtualized-log-viewer/useSectionFold.ts
@@ -1,14 +1,18 @@
 import React from 'react';
-import type { LogSection } from './types';
+
+interface FoldableSection {
+  containerName: string;
+  isCompleted?: boolean;
+}
 
 const EMPTY_EXPANDED_SECTIONS = new Set<number>();
 const EMPTY_OVERRIDES: ReadonlyMap<number, boolean> = new Map();
 
 /** Default: in-progress open, completed folded. */
-const isExpandedByDefault = (section: LogSection): boolean => !section.isCompleted;
+const isExpandedByDefault = (section: FoldableSection): boolean => !section.isCompleted;
 
 const resolveIsExpanded = (
-  sections: readonly LogSection[],
+  sections: readonly FoldableSection[],
   overrides: ReadonlyMap<number, boolean>,
   index: number,
 ): boolean => {
@@ -17,7 +21,7 @@ const resolveIsExpanded = (
 };
 
 /** Stable identity key so log-content updates don't reset overrides. */
-const sectionNamesKey = (sections: readonly LogSection[]): string =>
+const sectionNamesKey = (sections: readonly FoldableSection[]): string =>
   sections.map((s) => s.containerName).join('\0');
 
 const isPrefixGrowth = (prev: readonly string[], next: readonly string[]): boolean =>
@@ -42,7 +46,7 @@ const withOverride = (
   return next;
 };
 
-export const useSectionFold = (sections: readonly LogSection[]) => {
+export const useSectionFold = (sections: readonly FoldableSection[]) => {
   const sectionsRef = React.useRef(sections);
   sectionsRef.current = sections;
 

--- a/src/shared/components/virtualized-log-viewer/useSectionFold.ts
+++ b/src/shared/components/virtualized-log-viewer/useSectionFold.ts
@@ -1,9 +1,7 @@
 import React from 'react';
+import type { NormalizedLogSection } from './types';
 
-interface FoldableSection {
-  containerName: string;
-  isCompleted?: boolean;
-}
+type FoldableSection = Pick<NormalizedLogSection, 'containerName' | 'isCompleted'>;
 
 const EMPTY_EXPANDED_SECTIONS = new Set<number>();
 const EMPTY_OVERRIDES: ReadonlyMap<number, boolean> = new Map();

--- a/src/shared/components/virtualized-log-viewer/useSectionFold.ts
+++ b/src/shared/components/virtualized-log-viewer/useSectionFold.ts
@@ -48,10 +48,7 @@ const withOverride = (
 
 export const useSectionFold = (sections: readonly FoldableSection[]) => {
   const sectionsRef = React.useRef(sections);
-
-  React.useEffect(() => {
-    sectionsRef.current = sections;
-  }, [sections]);
+  sectionsRef.current = sections;
 
   const [overrides, setOverrides] = React.useState<ReadonlyMap<number, boolean>>(EMPTY_OVERRIDES);
 

--- a/src/shared/components/virtualized-log-viewer/useSectionFold.ts
+++ b/src/shared/components/virtualized-log-viewer/useSectionFold.ts
@@ -48,7 +48,10 @@ const withOverride = (
 
 export const useSectionFold = (sections: readonly FoldableSection[]) => {
   const sectionsRef = React.useRef(sections);
-  sectionsRef.current = sections;
+
+  React.useEffect(() => {
+    sectionsRef.current = sections;
+  }, [sections]);
 
   const [overrides, setOverrides] = React.useState<ReadonlyMap<number, boolean>>(EMPTY_OVERRIDES);
 

--- a/src/shared/components/virtualized-log-viewer/useSectionRows.ts
+++ b/src/shared/components/virtualized-log-viewer/useSectionRows.ts
@@ -56,6 +56,7 @@ export const useSectionRows = (
         lineNumber: globalLineNumber,
         lineCount: sectionLines.length,
         isExpanded,
+        isTailed: sections[i].isTailed ?? false,
       });
       searchToDisplay.set(searchLine, headerDisplayIdx);
       searchToSection.set(searchLine, i);

--- a/src/shared/utils/__tests__/line-buffer.spec.ts
+++ b/src/shared/utils/__tests__/line-buffer.spec.ts
@@ -1,0 +1,98 @@
+import { LineBuffer } from '../line-buffer';
+
+describe('LineBuffer', () => {
+  describe('append', () => {
+    it('should split text into lines on newline boundaries', () => {
+      const buf = new LineBuffer();
+      buf.append('line1\nline2\nline3\n');
+      expect(buf.getLines()).toEqual(['line1', 'line2', 'line3']);
+    });
+
+    it('should include trailing content without a final newline', () => {
+      const buf = new LineBuffer();
+      buf.append('line1\nline2');
+      expect(buf.getLines()).toEqual(['line1', 'line2']);
+    });
+
+    it('should accumulate across multiple append calls', () => {
+      const buf = new LineBuffer();
+      buf.append('first\n');
+      buf.append('second\n');
+      expect(buf.getLines()).toEqual(['first', 'second']);
+    });
+
+    it('should join partial lines across append calls', () => {
+      const buf = new LineBuffer();
+      buf.append('hel');
+      buf.append('lo\nworld\n');
+      expect(buf.getLines()).toEqual(['hello', 'world']);
+    });
+
+    it('should strip ANSI escape codes', () => {
+      const buf = new LineBuffer();
+      buf.append('\x1b[31mred text\x1b[0m\n');
+      expect(buf.getLines()).toEqual(['red text']);
+    });
+
+    it('should handle empty string', () => {
+      const buf = new LineBuffer();
+      buf.append('');
+      expect(buf.getLines()).toEqual([]);
+    });
+
+    it('should handle text with only newlines', () => {
+      const buf = new LineBuffer();
+      buf.append('\n\n');
+      expect(buf.getLines()).toEqual(['', '']);
+    });
+
+    it('should report correct length', () => {
+      const buf = new LineBuffer();
+      buf.append('a\nb\nc\n');
+      expect(buf.length()).toBe(3);
+    });
+
+    it('should be O(message) not O(total) for large buffers', () => {
+      const buf = new LineBuffer();
+      const bigChunk = `${'x'.repeat(1000)}\n`;
+      for (let i = 0; i < 50000; i++) {
+        buf.append(bigChunk);
+      }
+      const start = performance.now();
+      buf.append('one more line\n');
+      const elapsed = performance.now() - start;
+      expect(elapsed).toBeLessThan(10);
+      expect(buf.length()).toBe(50001);
+    });
+  });
+
+  describe('getLines', () => {
+    it('should return empty array for fresh buffer', () => {
+      const buf = new LineBuffer();
+      expect(buf.getLines()).toEqual([]);
+    });
+
+    it('should include incomplete trailing line', () => {
+      const buf = new LineBuffer();
+      buf.append('complete\nincomplete');
+      const lines = buf.getLines();
+      expect(lines).toEqual(['complete', 'incomplete']);
+    });
+
+    it('should not include trailing line when it is empty', () => {
+      const buf = new LineBuffer();
+      buf.append('line1\nline2\n');
+      expect(buf.getLines()).toEqual(['line1', 'line2']);
+    });
+  });
+
+  describe('clear', () => {
+    it('should reset buffer and tail', () => {
+      const buf = new LineBuffer();
+      buf.append('some\ndata');
+      buf.clear();
+      expect(buf.getLines()).toEqual([]);
+      expect(buf.length()).toBe(0);
+    });
+  });
+});

--- a/src/shared/utils/__tests__/line-buffer.spec.ts
+++ b/src/shared/utils/__tests__/line-buffer.spec.ts
@@ -8,10 +8,10 @@ describe('LineBuffer', () => {
       expect(buf.getLines()).toEqual(['line1', 'line2', 'line3']);
     });
 
-    it('should include trailing content without a final newline', () => {
+    it('should keep trailing content without a final newline in tail, not in lines', () => {
       const buf = new LineBuffer();
       buf.append('line1\nline2');
-      expect(buf.getLines()).toEqual(['line1', 'line2']);
+      expect(buf.getLines()).toEqual(['line1']);
     });
 
     it('should accumulate across multiple append calls', () => {
@@ -72,11 +72,10 @@ describe('LineBuffer', () => {
       expect(buf.getLines()).toEqual([]);
     });
 
-    it('should include incomplete trailing line', () => {
+    it('should not include incomplete trailing content', () => {
       const buf = new LineBuffer();
       buf.append('complete\nincomplete');
-      const lines = buf.getLines();
-      expect(lines).toEqual(['complete', 'incomplete']);
+      expect(buf.getLines()).toEqual(['complete']);
     });
 
     it('should not include trailing line when it is empty', () => {

--- a/src/shared/utils/line-buffer.ts
+++ b/src/shared/utils/line-buffer.ts
@@ -42,6 +42,10 @@ export class LineBuffer {
   }
 
   getLines(): string[] {
+    if (this._tail) {
+      this._buffer.push(this._tail);
+      this._tail = '';
+    }
     return this._buffer;
   }
 
@@ -75,12 +79,5 @@ export class LineBuffer {
         this._tail = next;
       }
     }
-  }
-
-  replace(newLines: string[]): number {
-    const prevCount = this._buffer.length;
-    this._buffer = newLines;
-    this._tail = '';
-    return prevCount;
   }
 }

--- a/src/shared/utils/line-buffer.ts
+++ b/src/shared/utils/line-buffer.ts
@@ -42,10 +42,6 @@ export class LineBuffer {
   }
 
   getLines(): string[] {
-    if (this._tail) {
-      this._buffer.push(this._tail);
-      this._tail = '';
-    }
     return this._buffer;
   }
 

--- a/src/shared/utils/line-buffer.ts
+++ b/src/shared/utils/line-buffer.ts
@@ -2,6 +2,8 @@ import truncate from 'lodash/truncate';
 
 export const LINE_PATTERN = /^.*(\n|$)/gm;
 const TRUNCATE_LENGTH = 1024;
+// eslint-disable-next-line no-control-regex
+const ANSI_ESCAPE_REGEX = /\u001b\[[0-9;]*m/g;
 
 export class LineBuffer {
   private _buffer: string[];
@@ -57,5 +59,28 @@ export class LineBuffer {
 
   length(): number {
     return this._buffer.length;
+  }
+
+  append(text: string): void {
+    const stripped = text.replace(ANSI_ESCAPE_REGEX, '');
+    const lines = stripped.match(LINE_PATTERN);
+    if (!lines) return;
+
+    for (const line of lines) {
+      const next = this._tail + line;
+      if (/\n$/.test(line)) {
+        this._buffer.push(next.trimEnd());
+        this._tail = '';
+      } else {
+        this._tail = next;
+      }
+    }
+  }
+
+  replace(newLines: string[]): number {
+    const prevCount = this._buffer.length;
+    this._buffer = newLines;
+    this._tail = '';
+    return prevCount;
   }
 }

--- a/src/shared/utils/line-buffer.ts
+++ b/src/shared/utils/line-buffer.ts
@@ -16,6 +16,7 @@ export class LineBuffer {
     this._hasTruncated = false;
   }
 
+  /** Accumulate text for download — truncates lines at 1024 chars. */
   ingest(text): number {
     const lines = text.match(LINE_PATTERN);
     let lineCount = 0;
@@ -61,6 +62,7 @@ export class LineBuffer {
     return this._buffer.length;
   }
 
+  /** Accumulate text for display — strips ANSI codes, no truncation. */
   append(text: string): void {
     const stripped = text.replace(ANSI_ESCAPE_REGEX, '');
     const lines = stripped.match(LINE_PATTERN);

--- a/src/shared/utils/line-buffer.ts
+++ b/src/shared/utils/line-buffer.ts
@@ -62,9 +62,9 @@ export class LineBuffer {
     return this._buffer.length;
   }
 
-  /** Accumulate text for display — strips ANSI codes, no truncation. */
+  /** Accumulate text for display — normalizes line endings, strips ANSI codes, no truncation. */
   append(text: string): void {
-    const stripped = text.replace(ANSI_ESCAPE_REGEX, '');
+    const stripped = text.replace(/\r\n?/g, '\n').replace(ANSI_ESCAPE_REGEX, '');
     const lines = stripped.match(LINE_PATTERN);
     if (!lines) return;
 


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->

Fixes https://redhat.atlassian.net/browse/KFLUXUI-1145

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

KubeArchive log fetches now request only the last 500 lines per container. Containers whose logs were tailed show a "showing last N lines" label and a "Download full logs" button in the section header (including sticky header). Clicking it fetches the complete log and saves it as a file, with a spinner while the download is in progress.

A "View full logs" button (with an external link icon) opens the complete log in a new browser tab via the KubeArchive API.

Additionally, log accumulation in `Logs.tsx` was changed from string concatenation (`string += message`, which copies the entire log on every WebSocket message) to `LineBuffer.append()` (appends only the new chunk). Sections are now passed as pre-split `string[]` instead of raw strings, skipping redundant ANSI stripping.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

https://github.com/user-attachments/assets/35aebd2a-daf0-4b16-aebf-40f53fd4ed8f

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

- open a pipeline run with KubeArchive logs - sections show "showing last N lines" label
- containers with fewer than 500 lines do NOT show the label
- click "Download full logs" - file downloads, button shows spinner during fetch
- click "View full logs" - opens raw log in a new tab via KubeArchive API
- sticky section header also shows the label and download button
- non-KubeArchive logs (live streaming, cluster source) behave unchanged
- search, folding, line selection, auto-scroll, download, fullscreen all work as before

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KubeArchive log views initially load the latest **500 lines per container**.
  * Tailed sections display a “showing last N lines” indicator and offer **Download full logs**.
  * Live and terminated cluster logs continue loading without a tail limit.
* **Documentation**
  * Added guidance on tail behavior, full-log downloads, archive-only scope, and configuration.
* **Bug Fixes / Improvements**
  * Improved log streaming, rendering, ANSI handling, and section status indicators.
  * Expanded coverage for log buffering, tailing, downloads, and viewer interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->