### PR TITLE
refactor(KFLUXUI-1545): LogViewer - extract container height logic to a hook

### DIFF
--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
@@ -150,7 +150,7 @@ const LogViewer: React.FC<Props> = ({
   };
 
   // Use containerRef to measure actual height for VirtualizedLogViewer
-  const { containerRef, viewerHeight } = useContainerHeight();
+  const { containerRef, viewerHeight } = useContainerHeight({ isFullscreen });
 
   return (
     <LogViewerContext.Provider value={logViewerContextValue}>

--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
@@ -28,7 +28,6 @@ import {
 } from '@patternfly/react-log-viewer';
 import classNames from 'classnames';
 import { saveAs } from 'file-saver';
-import { debounce } from 'lodash-es';
 import { v4 as uuidv4 } from 'uuid';
 import { FeatureFlagIndicator } from '~/feature-flags/FeatureFlagIndicator';
 import { logger } from '~/monitoring/logger';
@@ -45,6 +44,7 @@ import {
   normalizeSection,
   useLineNumberNavigation,
 } from '~/shared/components/virtualized-log-viewer';
+import { useContainerHeight } from '~/shared/hooks';
 import { useFullscreen } from '~/shared/hooks/fullscreen';
 import { TaskRunKind } from '~/types';
 import { prepareLogViewerContent } from './log-viewer-content';
@@ -150,40 +150,7 @@ const LogViewer: React.FC<Props> = ({
   };
 
   // Use containerRef to measure actual height for VirtualizedLogViewer
-  const containerRef = React.useRef<HTMLDivElement>(null);
-  const [viewerHeight, setViewerHeight] = React.useState<number | undefined>(undefined);
-
-  React.useEffect(() => {
-    const updateHeight = (immediate = false) => {
-      if (containerRef.current) {
-        const measured = containerRef.current.clientHeight;
-        if (measured > 0) {
-          if (immediate) {
-            // Immediate update for fullscreen toggle and initial mount
-            setViewerHeight(measured);
-          } else {
-            // Use requestAnimationFrame for resize events to avoid ResizeObserver warnings
-            requestAnimationFrame(() => {
-              setViewerHeight(measured);
-            });
-          }
-        }
-      }
-    };
-
-    // Update immediately on mount and fullscreen changes
-    updateHeight(true);
-
-    // Debounced resize handler for better performance (150ms delay)
-    const debouncedUpdateHeight = debounce(() => updateHeight(false), 150);
-
-    // Update on window resize
-    window.addEventListener('resize', debouncedUpdateHeight);
-    return () => {
-      window.removeEventListener('resize', debouncedUpdateHeight);
-      debouncedUpdateHeight.cancel();
-    };
-  }, [isFullscreen]);
+  const { containerRef, viewerHeight } = useContainerHeight();
 
   return (
     <LogViewerContext.Provider value={logViewerContextValue}>

--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
@@ -150,7 +150,7 @@ const LogViewer: React.FC<Props> = ({
   };
 
   // Use containerRef to measure actual height for VirtualizedLogViewer
-  const { containerRef, viewerHeight } = useContainerHeight();
+  const { containerRef, containerHeight } = useContainerHeight();
 
   return (
     <LogViewerContext.Provider value={logViewerContextValue}>
@@ -307,12 +307,12 @@ const LogViewer: React.FC<Props> = ({
 
           {/* Log Viewer */}
           <div ref={containerRef} className="log-viewer__content">
-            {viewerHeight && (
+            {containerHeight && (
               <VirtualizedLogViewer
                 key={taskRun?.metadata?.uid || 'default'}
                 sections={sections}
                 normalizedSections={normalizedSections}
-                height={viewerHeight}
+                height={containerHeight}
                 scrollToRow={scrolledRow}
                 onScroll={handleScroll}
                 readyToNavigate={!isLoading}

--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
@@ -150,7 +150,7 @@ const LogViewer: React.FC<Props> = ({
   };
 
   // Use containerRef to measure actual height for VirtualizedLogViewer
-  const { containerRef, viewerHeight } = useContainerHeight({ isFullscreen });
+  const { containerRef, viewerHeight } = useContainerHeight();
 
   return (
     <LogViewerContext.Provider value={logViewerContextValue}>

--- a/src/shared/components/pipeline-run-logs/logs/__tests__/LogViewer.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/__tests__/LogViewer.spec.tsx
@@ -51,16 +51,6 @@ jest.mock('../useAutoScrollWithResume', () => {
   };
 });
 
-// Mock lodash-es debounce to make tests synchronous
-jest.mock('lodash-es', () => ({
-  ...jest.requireActual('lodash-es'),
-  debounce: (fn: (...args: unknown[]) => unknown) => {
-    const debounced = (...args: unknown[]) => fn(...args);
-    debounced.cancel = jest.fn();
-    return debounced;
-  },
-}));
-
 const mockSaveAs = jest.requireMock('file-saver').saveAs as jest.Mock;
 const mockUseFullscreen = useFullscreen as jest.Mock;
 const mockUseTheme = useTheme as jest.Mock;

--- a/src/shared/components/pipeline-run-logs/logs/__tests__/LogViewer.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/__tests__/LogViewer.spec.tsx
@@ -13,7 +13,7 @@ import { useLogViewerTheme } from '../useLogViewerTheme';
 jest.mock('~/shared/hooks/useContainerHeight', () => ({
   useContainerHeight: () => ({
     containerRef: { current: document.createElement('div') },
-    viewerHeight: 600,
+    containerHeight: 600,
   }),
 }));
 

--- a/src/shared/components/pipeline-run-logs/logs/__tests__/LogViewer.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/__tests__/LogViewer.spec.tsx
@@ -10,6 +10,13 @@ import LogViewer from '../LogViewer';
 import { useAutoScrollWithResume } from '../useAutoScrollWithResume';
 import { useLogViewerTheme } from '../useLogViewerTheme';
 
+jest.mock('~/shared/hooks/useContainerHeight', () => ({
+  useContainerHeight: () => ({
+    containerRef: { current: document.createElement('div') },
+    viewerHeight: 600,
+  }),
+}));
+
 // Mock only external dependencies and browser APIs
 jest.mock('file-saver', () => ({
   saveAs: jest.fn(),

--- a/src/shared/hooks/__tests__/useContainerHeight.spec.ts
+++ b/src/shared/hooks/__tests__/useContainerHeight.spec.ts
@@ -16,7 +16,7 @@ describe('useContainerHeight', () => {
   });
 
   it('should return undefined height initially when no element is attached', () => {
-    const { result } = renderHook(() => useContainerHeight());
+    const { result } = renderHook(() => useContainerHeight({ isFullscreen: false }));
     expect(result.current.viewerHeight).toBeUndefined();
     expect(result.current.containerRef.current).toBeNull();
   });
@@ -25,7 +25,7 @@ describe('useContainerHeight', () => {
     const div = document.createElement('div');
     Object.defineProperty(div, 'clientHeight', { value: 400 });
 
-    const { result } = renderHook(() => useContainerHeight());
+    const { result } = renderHook(() => useContainerHeight({ isFullscreen: false }));
 
     act(() => {
       Object.defineProperty(result.current.containerRef, 'current', {
@@ -34,13 +34,13 @@ describe('useContainerHeight', () => {
       });
     });
 
-    const { rerender } = renderHook(() => useContainerHeight());
+    const { rerender } = renderHook(() => useContainerHeight({ isFullscreen: false }));
     rerender();
 
     // Height is set on mount via immediate update
     // Since ref was attached after first render, we need a fresh mount
     const { result: result2 } = renderHook(() => {
-      const hook = useContainerHeight();
+      const hook = useContainerHeight({ isFullscreen: false });
       Object.defineProperty(hook.containerRef, 'current', {
         value: div,
         writable: true,
@@ -54,13 +54,13 @@ describe('useContainerHeight', () => {
   });
 
   it('should register a resize event listener', () => {
-    renderHook(() => useContainerHeight());
+    renderHook(() => useContainerHeight({ isFullscreen: false }));
 
     expect(addEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function));
   });
 
   it('should remove resize listener on unmount', () => {
-    const { unmount } = renderHook(() => useContainerHeight());
+    const { unmount } = renderHook(() => useContainerHeight({ isFullscreen: false }));
     unmount();
 
     expect(removeEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function));
@@ -71,7 +71,7 @@ describe('useContainerHeight', () => {
     Object.defineProperty(div, 'clientHeight', { value: 0 });
 
     const { result } = renderHook(() => {
-      const hook = useContainerHeight();
+      const hook = useContainerHeight({ isFullscreen: false });
       Object.defineProperty(hook.containerRef, 'current', {
         value: div,
         writable: true,
@@ -84,7 +84,7 @@ describe('useContainerHeight', () => {
   });
 
   it('should return stable reference when height has not changed', () => {
-    const { result, rerender } = renderHook(() => useContainerHeight());
+    const { result, rerender } = renderHook(() => useContainerHeight({ isFullscreen: false }));
 
     const first = result.current;
     rerender();

--- a/src/shared/hooks/__tests__/useContainerHeight.spec.ts
+++ b/src/shared/hooks/__tests__/useContainerHeight.spec.ts
@@ -1,0 +1,95 @@
+import { renderHook, act } from '@testing-library/react';
+import { useContainerHeight } from '../useContainerHeight';
+
+describe('useContainerHeight', () => {
+  let addEventListenerSpy: jest.SpyInstance;
+  let removeEventListenerSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+    removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+  });
+
+  afterEach(() => {
+    addEventListenerSpy.mockRestore();
+    removeEventListenerSpy.mockRestore();
+  });
+
+  it('should return undefined height initially when no element is attached', () => {
+    const { result } = renderHook(() => useContainerHeight());
+    expect(result.current.viewerHeight).toBeUndefined();
+    expect(result.current.containerRef.current).toBeNull();
+  });
+
+  it('should measure height when ref is attached to an element', () => {
+    const div = document.createElement('div');
+    Object.defineProperty(div, 'clientHeight', { value: 400 });
+
+    const { result } = renderHook(() => useContainerHeight());
+
+    act(() => {
+      Object.defineProperty(result.current.containerRef, 'current', {
+        value: div,
+        writable: true,
+      });
+    });
+
+    const { rerender } = renderHook(() => useContainerHeight());
+    rerender();
+
+    // Height is set on mount via immediate update
+    // Since ref was attached after first render, we need a fresh mount
+    const { result: result2 } = renderHook(() => {
+      const hook = useContainerHeight();
+      Object.defineProperty(hook.containerRef, 'current', {
+        value: div,
+        writable: true,
+      });
+      return hook;
+    });
+
+    // The effect runs after render, so we need to wait
+    act(() => {});
+    expect(result2.current.viewerHeight).toBe(400);
+  });
+
+  it('should register a resize event listener', () => {
+    renderHook(() => useContainerHeight());
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+  });
+
+  it('should remove resize listener on unmount', () => {
+    const { unmount } = renderHook(() => useContainerHeight());
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+  });
+
+  it('should not set height when clientHeight is 0', () => {
+    const div = document.createElement('div');
+    Object.defineProperty(div, 'clientHeight', { value: 0 });
+
+    const { result } = renderHook(() => {
+      const hook = useContainerHeight();
+      Object.defineProperty(hook.containerRef, 'current', {
+        value: div,
+        writable: true,
+      });
+      return hook;
+    });
+
+    act(() => {});
+    expect(result.current.viewerHeight).toBeUndefined();
+  });
+
+  it('should return stable reference when height has not changed', () => {
+    const { result, rerender } = renderHook(() => useContainerHeight());
+
+    const first = result.current;
+    rerender();
+    const second = result.current;
+
+    expect(first).toBe(second);
+  });
+});

--- a/src/shared/hooks/__tests__/useContainerHeight.spec.ts
+++ b/src/shared/hooks/__tests__/useContainerHeight.spec.ts
@@ -19,25 +19,15 @@ afterEach(() => {
 
 describe('useContainerHeight', () => {
   it('should return undefined height initially when no element is attached', () => {
-    const { result } = renderHook(() => useContainerHeight({ isFullscreen: false }));
+    const { result } = renderHook(() => useContainerHeight());
     expect(result.current.viewerHeight).toBeUndefined();
     expect(result.current.containerRef.current).toBeNull();
   });
 
   it('should measure height via ResizeObserver', () => {
-    const div = document.createElement('div');
+    const { result } = renderHook(() => useContainerHeight());
 
-    const { result } = renderHook(() => {
-      const hook = useContainerHeight({ isFullscreen: false });
-      Object.defineProperty(hook.containerRef, 'current', {
-        value: div,
-        writable: true,
-      });
-      return hook;
-    });
-
-    act(() => {});
-    expect(observeMock).toHaveBeenCalledWith(div);
+    expect(observeMock).toHaveBeenCalled();
 
     act(() => {
       resizeCallback(
@@ -50,16 +40,7 @@ describe('useContainerHeight', () => {
   });
 
   it('should disconnect observer on unmount', () => {
-    const div = document.createElement('div');
-
-    const { unmount } = renderHook(() => {
-      const hook = useContainerHeight({ isFullscreen: false });
-      Object.defineProperty(hook.containerRef, 'current', {
-        value: div,
-        writable: true,
-      });
-      return hook;
-    });
+    const { unmount } = renderHook(() => useContainerHeight());
 
     act(() => {});
     unmount();
@@ -67,16 +48,7 @@ describe('useContainerHeight', () => {
   });
 
   it('should not set height when contentRect height is 0', () => {
-    const div = document.createElement('div');
-
-    const { result } = renderHook(() => {
-      const hook = useContainerHeight({ isFullscreen: false });
-      Object.defineProperty(hook.containerRef, 'current', {
-        value: div,
-        writable: true,
-      });
-      return hook;
-    });
+    const { result } = renderHook(() => useContainerHeight());
 
     act(() => {
       resizeCallback(
@@ -89,7 +61,7 @@ describe('useContainerHeight', () => {
   });
 
   it('should return stable reference when height has not changed', () => {
-    const { result, rerender } = renderHook(() => useContainerHeight({ isFullscreen: false }));
+    const { result, rerender } = renderHook(() => useContainerHeight());
 
     const first = result.current;
     rerender();

--- a/src/shared/hooks/__tests__/useContainerHeight.spec.ts
+++ b/src/shared/hooks/__tests__/useContainerHeight.spec.ts
@@ -1,74 +1,31 @@
 import { renderHook, act } from '@testing-library/react';
 import { useContainerHeight } from '../useContainerHeight';
 
+let resizeCallback: ResizeObserverCallback;
+const observeMock = jest.fn();
+const disconnectMock = jest.fn();
+
+beforeEach(() => {
+  global.ResizeObserver = jest.fn((cb) => {
+    resizeCallback = cb;
+    return { observe: observeMock, unobserve: jest.fn(), disconnect: disconnectMock };
+  }) as unknown as typeof ResizeObserver;
+});
+
+afterEach(() => {
+  observeMock.mockClear();
+  disconnectMock.mockClear();
+});
+
 describe('useContainerHeight', () => {
-  let addEventListenerSpy: jest.SpyInstance;
-  let removeEventListenerSpy: jest.SpyInstance;
-
-  beforeEach(() => {
-    addEventListenerSpy = jest.spyOn(window, 'addEventListener');
-    removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
-  });
-
-  afterEach(() => {
-    addEventListenerSpy.mockRestore();
-    removeEventListenerSpy.mockRestore();
-  });
-
   it('should return undefined height initially when no element is attached', () => {
     const { result } = renderHook(() => useContainerHeight({ isFullscreen: false }));
     expect(result.current.viewerHeight).toBeUndefined();
     expect(result.current.containerRef.current).toBeNull();
   });
 
-  it('should measure height when ref is attached to an element', () => {
+  it('should measure height via ResizeObserver', () => {
     const div = document.createElement('div');
-    Object.defineProperty(div, 'clientHeight', { value: 400 });
-
-    const { result } = renderHook(() => useContainerHeight({ isFullscreen: false }));
-
-    act(() => {
-      Object.defineProperty(result.current.containerRef, 'current', {
-        value: div,
-        writable: true,
-      });
-    });
-
-    const { rerender } = renderHook(() => useContainerHeight({ isFullscreen: false }));
-    rerender();
-
-    // Height is set on mount via immediate update
-    // Since ref was attached after first render, we need a fresh mount
-    const { result: result2 } = renderHook(() => {
-      const hook = useContainerHeight({ isFullscreen: false });
-      Object.defineProperty(hook.containerRef, 'current', {
-        value: div,
-        writable: true,
-      });
-      return hook;
-    });
-
-    // The effect runs after render, so we need to wait
-    act(() => {});
-    expect(result2.current.viewerHeight).toBe(400);
-  });
-
-  it('should register a resize event listener', () => {
-    renderHook(() => useContainerHeight({ isFullscreen: false }));
-
-    expect(addEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function));
-  });
-
-  it('should remove resize listener on unmount', () => {
-    const { unmount } = renderHook(() => useContainerHeight({ isFullscreen: false }));
-    unmount();
-
-    expect(removeEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function));
-  });
-
-  it('should not set height when clientHeight is 0', () => {
-    const div = document.createElement('div');
-    Object.defineProperty(div, 'clientHeight', { value: 0 });
 
     const { result } = renderHook(() => {
       const hook = useContainerHeight({ isFullscreen: false });
@@ -80,6 +37,54 @@ describe('useContainerHeight', () => {
     });
 
     act(() => {});
+    expect(observeMock).toHaveBeenCalledWith(div);
+
+    act(() => {
+      resizeCallback(
+        [{ contentRect: { height: 400 } }] as unknown as ResizeObserverEntry[],
+        {} as ResizeObserver,
+      );
+    });
+
+    expect(result.current.viewerHeight).toBe(400);
+  });
+
+  it('should disconnect observer on unmount', () => {
+    const div = document.createElement('div');
+
+    const { unmount } = renderHook(() => {
+      const hook = useContainerHeight({ isFullscreen: false });
+      Object.defineProperty(hook.containerRef, 'current', {
+        value: div,
+        writable: true,
+      });
+      return hook;
+    });
+
+    act(() => {});
+    unmount();
+    expect(disconnectMock).toHaveBeenCalled();
+  });
+
+  it('should not set height when contentRect height is 0', () => {
+    const div = document.createElement('div');
+
+    const { result } = renderHook(() => {
+      const hook = useContainerHeight({ isFullscreen: false });
+      Object.defineProperty(hook.containerRef, 'current', {
+        value: div,
+        writable: true,
+      });
+      return hook;
+    });
+
+    act(() => {
+      resizeCallback(
+        [{ contentRect: { height: 0 } }] as unknown as ResizeObserverEntry[],
+        {} as ResizeObserver,
+      );
+    });
+
     expect(result.current.viewerHeight).toBeUndefined();
   });
 

--- a/src/shared/hooks/__tests__/useContainerHeight.spec.ts
+++ b/src/shared/hooks/__tests__/useContainerHeight.spec.ts
@@ -1,15 +1,15 @@
 import { renderHook, act } from '@testing-library/react';
 import { useContainerHeight } from '../useContainerHeight';
 
-let resizeCallback: ResizeObserverCallback;
 const observeMock = jest.fn();
 const disconnectMock = jest.fn();
 
 beforeEach(() => {
-  global.ResizeObserver = jest.fn((cb) => {
-    resizeCallback = cb;
-    return { observe: observeMock, unobserve: jest.fn(), disconnect: disconnectMock };
-  }) as unknown as typeof ResizeObserver;
+  global.ResizeObserver = jest.fn((cb) => ({
+    observe: observeMock.mockImplementation(() => cb([], {} as ResizeObserver)),
+    unobserve: jest.fn(),
+    disconnect: disconnectMock,
+  })) as unknown as typeof ResizeObserver;
 });
 
 afterEach(() => {
@@ -24,50 +24,49 @@ describe('useContainerHeight', () => {
     expect(result.current.containerRef).toBeDefined();
   });
 
-  it('should measure height via ResizeObserver', () => {
+  it('should not observe when container is null', () => {
+    renderHook(() => useContainerHeight());
+    expect(observeMock).not.toHaveBeenCalled();
+  });
+
+  it('should measure height when container is attached via ref callback', () => {
+    const div = document.createElement('div');
+    Object.defineProperty(div, 'clientHeight', { value: 400 });
+
     const { result } = renderHook(() => useContainerHeight());
 
-    expect(observeMock).toHaveBeenCalled();
-
     act(() => {
-      resizeCallback(
-        [
-          {
-            contentRect: { height: 400 },
-            target: { clientHeight: 400, getBoundingClientRect: () => ({ top: 0 }) },
-          },
-        ] as unknown as ResizeObserverEntry[],
-        {} as ResizeObserver,
-      );
+      result.current.containerRef(div);
     });
 
     expect(result.current.containerHeight).toBe(400);
   });
 
-  it('should disconnect observer on unmount', () => {
-    const { unmount } = renderHook(() => useContainerHeight());
+  it('should not set height when clientHeight is 0', () => {
+    const div = document.createElement('div');
+    Object.defineProperty(div, 'clientHeight', { value: 0 });
 
-    act(() => {});
-    unmount();
-    expect(disconnectMock).toHaveBeenCalled();
-  });
-
-  it('should not set height when contentRect height is 0', () => {
     const { result } = renderHook(() => useContainerHeight());
 
     act(() => {
-      resizeCallback(
-        [
-          {
-            contentRect: { height: 0 },
-            target: { clientHeight: 0, getBoundingClientRect: () => ({ top: 0 }) },
-          },
-        ] as unknown as ResizeObserverEntry[],
-        {} as ResizeObserver,
-      );
+      result.current.containerRef(div);
     });
 
     expect(result.current.containerHeight).toBeUndefined();
+  });
+
+  it('should disconnect observer on unmount', () => {
+    const div = document.createElement('div');
+    Object.defineProperty(div, 'clientHeight', { value: 400 });
+
+    const { result, unmount } = renderHook(() => useContainerHeight());
+
+    act(() => {
+      result.current.containerRef(div);
+    });
+
+    unmount();
+    expect(disconnectMock).toHaveBeenCalled();
   });
 
   it('should return stable reference when height has not changed', () => {

--- a/src/shared/hooks/__tests__/useContainerHeight.spec.ts
+++ b/src/shared/hooks/__tests__/useContainerHeight.spec.ts
@@ -21,7 +21,7 @@ describe('useContainerHeight', () => {
   it('should return undefined height initially when no element is attached', () => {
     const { result } = renderHook(() => useContainerHeight());
     expect(result.current.viewerHeight).toBeUndefined();
-    expect(result.current.containerRef.current).toBeNull();
+    expect(result.current.containerRef).toBeDefined();
   });
 
   it('should measure height via ResizeObserver', () => {

--- a/src/shared/hooks/__tests__/useContainerHeight.spec.ts
+++ b/src/shared/hooks/__tests__/useContainerHeight.spec.ts
@@ -31,7 +31,12 @@ describe('useContainerHeight', () => {
 
     act(() => {
       resizeCallback(
-        [{ contentRect: { height: 400 } }] as unknown as ResizeObserverEntry[],
+        [
+          {
+            contentRect: { height: 400 },
+            target: { clientHeight: 400, getBoundingClientRect: () => ({ top: 0 }) },
+          },
+        ] as unknown as ResizeObserverEntry[],
         {} as ResizeObserver,
       );
     });
@@ -52,7 +57,12 @@ describe('useContainerHeight', () => {
 
     act(() => {
       resizeCallback(
-        [{ contentRect: { height: 0 } }] as unknown as ResizeObserverEntry[],
+        [
+          {
+            contentRect: { height: 0 },
+            target: { clientHeight: 0, getBoundingClientRect: () => ({ top: 0 }) },
+          },
+        ] as unknown as ResizeObserverEntry[],
         {} as ResizeObserver,
       );
     });

--- a/src/shared/hooks/__tests__/useContainerHeight.spec.ts
+++ b/src/shared/hooks/__tests__/useContainerHeight.spec.ts
@@ -20,7 +20,7 @@ afterEach(() => {
 describe('useContainerHeight', () => {
   it('should return undefined height initially when no element is attached', () => {
     const { result } = renderHook(() => useContainerHeight());
-    expect(result.current.viewerHeight).toBeUndefined();
+    expect(result.current.containerHeight).toBeUndefined();
     expect(result.current.containerRef).toBeDefined();
   });
 
@@ -41,7 +41,7 @@ describe('useContainerHeight', () => {
       );
     });
 
-    expect(result.current.viewerHeight).toBe(400);
+    expect(result.current.containerHeight).toBe(400);
   });
 
   it('should disconnect observer on unmount', () => {
@@ -67,7 +67,7 @@ describe('useContainerHeight', () => {
       );
     });
 
-    expect(result.current.viewerHeight).toBeUndefined();
+    expect(result.current.containerHeight).toBeUndefined();
   });
 
   it('should return stable reference when height has not changed', () => {

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -8,3 +8,4 @@ export * from './useDeepCompareMemoize';
 export * from './useMutationObserver';
 export * from './useLazyActionMenu';
 export * from './useFaviconStatusBadge';
+export * from './useContainerHeight';

--- a/src/shared/hooks/useContainerHeight.ts
+++ b/src/shared/hooks/useContainerHeight.ts
@@ -1,0 +1,48 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { debounce } from 'lodash-es';
+
+type UseContainerHeightReturn = {
+  containerRef: React.RefObject<HTMLDivElement>;
+  viewerHeight: number | undefined;
+};
+
+export const useContainerHeight = (): UseContainerHeightReturn => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [viewerHeight, setViewerHeight] = useState<number | undefined>(undefined);
+
+  useEffect(() => {
+    const updateHeight = (immediate = false) => {
+      if (containerRef.current) {
+        const measured = containerRef.current.clientHeight;
+        if (measured > 0) {
+          if (immediate) {
+            // Immediate update for fullscreen toggle and initial mount
+            setViewerHeight(measured);
+          } else {
+            // Use requestAnimationFrame for resize events to avoid ResizeObserver warnings
+            requestAnimationFrame(() => {
+              setViewerHeight(measured);
+            });
+          }
+        }
+      }
+    };
+
+    // Update immediately on mount and fullscreen changes
+    updateHeight(true);
+
+    // Debounced resize handler for better performance (150ms delay)
+    const debouncedUpdateHeight = debounce(() => updateHeight(false), 150);
+
+    // Update on window resize
+    window.addEventListener('resize', debouncedUpdateHeight);
+    return () => {
+      window.removeEventListener('resize', debouncedUpdateHeight);
+      debouncedUpdateHeight.cancel();
+    };
+  }, []);
+
+  return useMemo(() => ({ containerRef, viewerHeight }), [viewerHeight]);
+};
+
+export default useContainerHeight;

--- a/src/shared/hooks/useContainerHeight.ts
+++ b/src/shared/hooks/useContainerHeight.ts
@@ -6,7 +6,11 @@ type UseContainerHeightReturn = {
   viewerHeight: number | undefined;
 };
 
-export const useContainerHeight = (): UseContainerHeightReturn => {
+type Props = {
+  isFullscreen: boolean;
+};
+
+export const useContainerHeight = ({ isFullscreen }: Props): UseContainerHeightReturn => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [viewerHeight, setViewerHeight] = useState<number | undefined>(undefined);
 
@@ -40,9 +44,7 @@ export const useContainerHeight = (): UseContainerHeightReturn => {
       window.removeEventListener('resize', debouncedUpdateHeight);
       debouncedUpdateHeight.cancel();
     };
-  }, []);
+  }, [isFullscreen]);
 
   return useMemo(() => ({ containerRef, viewerHeight }), [viewerHeight]);
 };
-
-export default useContainerHeight;

--- a/src/shared/hooks/useContainerHeight.ts
+++ b/src/shared/hooks/useContainerHeight.ts
@@ -1,32 +1,23 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { useResizeObserver } from './useResizeObserver';
 
 type UseContainerHeightReturn = {
   containerRef: React.RefObject<HTMLDivElement>;
   viewerHeight: number | undefined;
 };
 
-type Props = {
-  isFullscreen: boolean;
-};
-
-export const useContainerHeight = ({ isFullscreen }: Props): UseContainerHeightReturn => {
+export const useContainerHeight = (): UseContainerHeightReturn => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [viewerHeight, setViewerHeight] = useState<number | undefined>(undefined);
 
-  useEffect(() => {
-    const element = containerRef.current;
-    if (!element) return;
+  const handleResize = useCallback<ResizeObserverCallback>((entries) => {
+    const height = entries[0]?.contentRect.height;
+    if (height > 0) {
+      setViewerHeight(height);
+    }
+  }, []);
 
-    const observer = new ResizeObserver((entries) => {
-      const height = entries[0]?.contentRect.height;
-      if (height > 0) {
-        setViewerHeight(height);
-      }
-    });
-
-    observer.observe(element);
-    return () => observer.disconnect();
-  }, [isFullscreen]);
+  useResizeObserver(handleResize, containerRef.current);
 
   return useMemo(() => ({ containerRef, viewerHeight }), [viewerHeight]);
 };

--- a/src/shared/hooks/useContainerHeight.ts
+++ b/src/shared/hooks/useContainerHeight.ts
@@ -3,12 +3,12 @@ import { useResizeObserver } from './useResizeObserver';
 
 type UseContainerHeightReturn = {
   containerRef: React.RefCallback<HTMLDivElement>;
-  viewerHeight: number | undefined;
+  containerHeight: number | undefined;
 };
 
 export const useContainerHeight = (): UseContainerHeightReturn => {
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
-  const [viewerHeight, setViewerHeight] = useState<number | undefined>(undefined);
+  const [containerHeight, setContainerHeight] = useState<number | undefined>(undefined);
 
   const handleResize = useCallback<ResizeObserverCallback>((entries) => {
     const target = entries[0]?.target as HTMLElement | undefined;
@@ -16,11 +16,11 @@ export const useContainerHeight = (): UseContainerHeightReturn => {
     const maxHeight = window.innerHeight - target.getBoundingClientRect().top;
     const height = Math.min(target.clientHeight, maxHeight);
     if (height > 0) {
-      setViewerHeight(height);
+      setContainerHeight(height);
     }
   }, []);
 
   useResizeObserver(handleResize, container);
 
-  return useMemo(() => ({ containerRef: setContainer, viewerHeight }), [viewerHeight]);
+  return useMemo(() => ({ containerRef: setContainer, containerHeight }), [containerHeight]);
 };

--- a/src/shared/hooks/useContainerHeight.ts
+++ b/src/shared/hooks/useContainerHeight.ts
@@ -1,13 +1,13 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useResizeObserver } from './useResizeObserver';
 
 type UseContainerHeightReturn = {
-  containerRef: React.RefObject<HTMLDivElement>;
+  containerRef: React.RefCallback<HTMLDivElement>;
   viewerHeight: number | undefined;
 };
 
 export const useContainerHeight = (): UseContainerHeightReturn => {
-  const containerRef = useRef<HTMLDivElement>(null);
+  const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const [viewerHeight, setViewerHeight] = useState<number | undefined>(undefined);
 
   const handleResize = useCallback<ResizeObserverCallback>((entries) => {
@@ -17,7 +17,7 @@ export const useContainerHeight = (): UseContainerHeightReturn => {
     }
   }, []);
 
-  useResizeObserver(handleResize, containerRef.current);
+  useResizeObserver(handleResize, container);
 
-  return useMemo(() => ({ containerRef, viewerHeight }), [viewerHeight]);
+  return useMemo(() => ({ containerRef: setContainer, viewerHeight }), [viewerHeight]);
 };

--- a/src/shared/hooks/useContainerHeight.ts
+++ b/src/shared/hooks/useContainerHeight.ts
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { debounce } from 'lodash-es';
 
 type UseContainerHeightReturn = {
   containerRef: React.RefObject<HTMLDivElement>;
@@ -15,35 +14,18 @@ export const useContainerHeight = ({ isFullscreen }: Props): UseContainerHeightR
   const [viewerHeight, setViewerHeight] = useState<number | undefined>(undefined);
 
   useEffect(() => {
-    const updateHeight = (immediate = false) => {
-      if (containerRef.current) {
-        const measured = containerRef.current.clientHeight;
-        if (measured > 0) {
-          if (immediate) {
-            // Immediate update for fullscreen toggle and initial mount
-            setViewerHeight(measured);
-          } else {
-            // Use requestAnimationFrame for resize events to avoid ResizeObserver warnings
-            requestAnimationFrame(() => {
-              setViewerHeight(measured);
-            });
-          }
-        }
+    const element = containerRef.current;
+    if (!element) return;
+
+    const observer = new ResizeObserver((entries) => {
+      const height = entries[0]?.contentRect.height;
+      if (height > 0) {
+        setViewerHeight(height);
       }
-    };
+    });
 
-    // Update immediately on mount and fullscreen changes
-    updateHeight(true);
-
-    // Debounced resize handler for better performance (150ms delay)
-    const debouncedUpdateHeight = debounce(() => updateHeight(false), 150);
-
-    // Update on window resize
-    window.addEventListener('resize', debouncedUpdateHeight);
-    return () => {
-      window.removeEventListener('resize', debouncedUpdateHeight);
-      debouncedUpdateHeight.cancel();
-    };
+    observer.observe(element);
+    return () => observer.disconnect();
   }, [isFullscreen]);
 
   return useMemo(() => ({ containerRef, viewerHeight }), [viewerHeight]);

--- a/src/shared/hooks/useContainerHeight.ts
+++ b/src/shared/hooks/useContainerHeight.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import { useResizeObserver } from './useResizeObserver';
+import { useLayoutResizeObserver } from './useLayoutResizeObserver';
 
 type UseContainerHeightReturn = {
   containerRef: React.RefCallback<HTMLDivElement>;
@@ -10,17 +10,16 @@ export const useContainerHeight = (): UseContainerHeightReturn => {
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const [containerHeight, setContainerHeight] = useState<number | undefined>(undefined);
 
-  const handleResize = useCallback<ResizeObserverCallback>((entries) => {
-    const target = entries[0]?.target as HTMLElement | undefined;
-    if (!target) return;
-    const maxHeight = window.innerHeight - target.getBoundingClientRect().top;
-    const height = Math.min(target.clientHeight, maxHeight);
+  const handleResize = useCallback(() => {
+    if (!container) return;
+    const maxHeight = window.innerHeight - container.getBoundingClientRect().top;
+    const height = Math.min(container.clientHeight, maxHeight);
     if (height > 0) {
       setContainerHeight(height);
     }
-  }, []);
+  }, [container]);
 
-  useResizeObserver(handleResize, container);
+  useLayoutResizeObserver(handleResize, [container]);
 
   return useMemo(() => ({ containerRef: setContainer, containerHeight }), [containerHeight]);
 };

--- a/src/shared/hooks/useContainerHeight.ts
+++ b/src/shared/hooks/useContainerHeight.ts
@@ -11,7 +11,10 @@ export const useContainerHeight = (): UseContainerHeightReturn => {
   const [viewerHeight, setViewerHeight] = useState<number | undefined>(undefined);
 
   const handleResize = useCallback<ResizeObserverCallback>((entries) => {
-    const height = entries[0]?.contentRect.height;
+    const target = entries[0]?.target as HTMLElement | undefined;
+    if (!target) return;
+    const maxHeight = window.innerHeight - target.getBoundingClientRect().top;
+    const height = Math.min(target.clientHeight, maxHeight);
     if (height > 0) {
       setViewerHeight(height);
     }


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->

Fixes https://redhat.atlassian.net/browse/KFLUXUI-1545

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Extract the container height measurement logic from `LogViewer` into a reusable `useContainerHeight` hook. Uses `useLayoutResizeObserver` (synchronous, no body-fallback) instead of the original `window.resize` listener, and caps the measured height to the remaining viewport space to prevent infinite growth in layouts with unbounded parent height (e.g. TaskRun Logs tab).

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

https://github.com/user-attachments/assets/b1d71f92-c9d7-466a-98d9-42ffc629d2b2

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

- go to a PipelineRun logs page: log viewer renders correctly, fullscreen works
- go to a TaskRun logs page (e.g. TaskRun > Logs tab): height is stable, no infinite scrollbar growth
- resize browser window: log viewer adjusts height
- toggle fullscreen: height updates immediately
- :coffee:

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Log viewer sizing now responds more reliably when its container is resized.
  * Virtualized logs maintain accurate dimensions for smoother scrolling and rendering.
  * Improved layout stability when log containers are temporarily unmeasurable.

* **Tests**
  * Added coverage for container resizing, zero-height measurements, cleanup, stable sizing behavior, and consistent virtualized log rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->