### PR TITLE
refaactor(KFLUXUI-1551): GithubRedirect - add check for pipelineruns-kubearchive feature flag

### DIFF
--- a/src/components/GithubRedirect/index.ts
+++ b/src/components/GithubRedirect/index.ts
@@ -1,7 +1,8 @@
 import { LoaderFunction } from 'react-router-dom';
+import { isFeatureFlagOn } from '../../feature-flags/utils';
 import { PipelineRunModel } from '../../models';
 import { GithubRedirectRouteParams } from '../../routes/utils';
-import { QueryPipelineRun } from '../../utils/pipelinerun-utils';
+import { QueryPipelineRun, QueryPipelineRunWithKubearchive } from '../../utils/pipelinerun-utils';
 import { checkReviewAccesses } from '../../utils/rbac';
 
 export const githubRedirectLoader: LoaderFunction = async ({ params }) => {
@@ -15,10 +16,15 @@ export const githubRedirectLoader: LoaderFunction = async ({ params }) => {
   );
   if (!allowed) throw new Response('Access check Denied', { status: 403 });
   if (!params[GithubRedirectRouteParams.pipelineRunName]) return null;
-  return QueryPipelineRun(
-    params[GithubRedirectRouteParams.ns],
-    params[GithubRedirectRouteParams.pipelineRunName],
-  );
+
+  const ns = params[GithubRedirectRouteParams.ns];
+  const pipelineRunName = params[GithubRedirectRouteParams.pipelineRunName];
+
+  if (isFeatureFlagOn('pipelineruns-kubearchive')) {
+    return QueryPipelineRunWithKubearchive(ns, pipelineRunName);
+  }
+
+  return QueryPipelineRun(ns, pipelineRunName);
 };
 
 export { default as GithubRedirect } from './GithubRedirect';

--- a/src/components/GithubRedirect/index.ts
+++ b/src/components/GithubRedirect/index.ts
@@ -7,6 +7,7 @@ import { checkReviewAccesses } from '../../utils/rbac';
 
 export const githubRedirectLoader: LoaderFunction = async ({ params }) => {
   const namespace = params[GithubRedirectRouteParams.ns];
+  const pipelineRunName = params[GithubRedirectRouteParams.pipelineRunName];
   const allowed = await checkReviewAccesses(
     {
       model: PipelineRunModel,
@@ -15,16 +16,13 @@ export const githubRedirectLoader: LoaderFunction = async ({ params }) => {
     namespace,
   );
   if (!allowed) throw new Response('Access check Denied', { status: 403 });
-  if (!params[GithubRedirectRouteParams.pipelineRunName]) return null;
-
-  const ns = params[GithubRedirectRouteParams.ns];
-  const pipelineRunName = params[GithubRedirectRouteParams.pipelineRunName];
+  if (!pipelineRunName) return null;
 
   if (isFeatureFlagOn('pipelineruns-kubearchive')) {
-    return QueryPipelineRunWithKubearchive(ns, pipelineRunName);
+    return QueryPipelineRunWithKubearchive(namespace, pipelineRunName);
   }
 
-  return QueryPipelineRun(ns, pipelineRunName);
+  return QueryPipelineRun(namespace, pipelineRunName);
 };
 
 export { default as GithubRedirect } from './GithubRedirect';


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->

Fixes https://redhat.atlassian.net/browse/KFLUXUI-1551

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Prior to this patch, when navigating to a PipelineRun logs page from a GitHub Actions link, the Tekton Results API was being called even when the `pipelineruns-kubearchive` feature flag was enabled. It was happening because the `githubRedirectLoader` was not checking whether this feature flag was turned on or not.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before (notice the call to tekton-results API being made):

https://github.com/user-attachments/assets/62ca011a-dbc5-43be-b3dc-2c6d1f64c2c6

After (no tekton-results API is made):

https://github.com/user-attachments/assets/1da54f2c-def0-4db6-b89a-76eadc1f0929

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

1. Enable `pipelineruns-kubearchive` feature flag
2. Navigate to a `PipelineRun` logs page from a GitHub Actions link
3. Observe network requests - Tekton Results API is called even though kubearchive is on
4. :coffee:

## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub redirects for pipeline runs by correctly handling missing pipeline-run information.
  * Added support for retrieving pipeline-run details from the configured archive source when enabled.
  * Preserved the existing retrieval behavior when the archive feature is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->