### PR TITLE
fix(KFLUXUI-1532): fix inconsistencies in fold logs

### DIFF
--- a/.cursor/hooks/post-edit-checks.sh
+++ b/.cursor/hooks/post-edit-checks.sh
@@ -98,22 +98,36 @@ ${tsc_out}"
   }
 fi
 
-eslint_files=$(echo "$changed_files" | grep -E '\.(ts|tsx)$' || true)
+# Root ESLint ignores e2e-tests/* — linting those paths under --max-warnings 0
+# surfaces "File ignored..." warnings as failures. Skip them here.
+# Also skip deleted paths (eslint/xargs fail when the file is gone).
+existing_src_ts() {
+  echo "$changed_files" \
+    | grep -E '\.(ts|tsx)$' \
+    | grep -v '^e2e-tests/' \
+    | while IFS= read -r f; do
+        [[ -f "$f" ]] && printf '%s\n' "$f"
+      done
+}
+
+eslint_files=$(existing_src_ts || true)
 if [[ -n "$eslint_files" ]]; then
   lint_out=$(echo "$eslint_files" | tr '\n' '\0' | xargs -0 yarn eslint --report-unused-disable-directives --max-warnings 0 2>&1) || errors="${errors}
 === ESLint Errors ===
 ${lint_out}"
 fi
 
-scss_files=$(echo "$changed_files" | grep -E '\.scss$' || true)
+scss_files=$(echo "$changed_files" | grep -E '\.scss$' | while IFS= read -r f; do
+  [[ -f "$f" ]] && printf '%s\n' "$f"
+done || true)
 if [[ -n "$scss_files" ]]; then
   style_out=$(echo "$scss_files" | tr '\n' '\0' | xargs -0 yarn stylelint --config .stylelintrc.json 2>&1) || errors="${errors}
 === Stylelint Errors ===
 ${style_out}"
 fi
 
-# Only run test files the agent actually changed; skip source-only changes.
-test_files=$(echo "$changed_files" | grep -E '\.(spec|test)\.(ts|tsx)$' || true)
+# Only run unit test files the agent actually changed; skip e2e Cypress specs.
+test_files=$(echo "$changed_files" | grep -E '\.(spec|test)\.(ts|tsx)$' | grep -v '^e2e-tests/' || true)
 if [[ -n "$test_files" ]]; then
   test_out=$(echo "$test_files" | tr '\n' '\0' | xargs -0 yarn jest --passWithNoTests 2>&1) || {
     # Ignore "Cannot find module" failures sourced from files the agent didn't touch —

--- a/e2e-tests/support/pageObjects/createApplication-po.ts
+++ b/e2e-tests/support/pageObjects/createApplication-po.ts
@@ -1,3 +1,5 @@
+import { logViewerPO } from './logViewer-po';
+
 export const addComponentPagePO = {
   samples: 'Start with a sample.',
   addComponent: '[data-test="add-component"] > a',
@@ -83,7 +85,8 @@ export const componentsListPagePO = {
 export const buildLogModalContentPO = {
   modal: 'div[data-ouia-component-type="PF6/ModalContent"]',
   closeButton: '[aria-label="Close"]',
-  logText: '.pf-v6-c-log-viewer__text',
+  logText: logViewerPO.logText,
+  logViewerSearchInput: logViewerPO.searchInput,
   logsTasklist: 'div[data-test="logs-tasklist"]',
   failedPipelineRunLogs: 'div[class="pipeline-run-logs"] [class*="pf-m-danger"]',
   podLogNavList: '[data-ouia-component-type="PF6/Nav"]',

--- a/e2e-tests/support/pageObjects/logViewer-po.ts
+++ b/e2e-tests/support/pageObjects/logViewer-po.ts
@@ -1,0 +1,10 @@
+/** Shared selectors for the virtualized foldable log viewer (modal + drawer). */
+export const logViewerPO = {
+  viewer: '.pf-v6-c-log-viewer',
+  logText: '.pf-v6-c-log-viewer__text',
+  searchInput: 'input[name*="logViewerSearchInput"]',
+  foldHeader: '[data-test^="fold-header-"]',
+  collapsedFoldHeader: '[data-test^="fold-header-"][aria-expanded="false"]',
+  /** Expanded section header (AngleDown / aria-expanded=true). */
+  expandedFoldHeader: '[data-test^="fold-header-"][aria-expanded="true"]',
+};

--- a/e2e-tests/support/pageObjects/pages-po.ts
+++ b/e2e-tests/support/pageObjects/pages-po.ts
@@ -1,3 +1,5 @@
+import { logViewerPO } from './logViewer-po';
+
 export const applicationsPagePO = {
   filterInput: '[aria-label="name filter"]',
   appStatus: '[data-test="details__status"]',
@@ -43,7 +45,8 @@ export const pipelinerunsTabPO = {
   relatedPipelineCloseBtn: 'button[aria-label="Close"]',
 
   node: (nodeId) => `g[data-id="${nodeId}"]`,
-  logText: '.pf-v6-c-log-viewer__text',
+  logText: logViewerPO.logText,
+  logViewerSearchInput: logViewerPO.searchInput,
   drawerPanel: 'div[class*="drawer__panel-main"]',
   drawerClose: 'div[class="pf-v6-c-drawer__close"]',
   listGroup: 'div[class$="list__group"]',

--- a/e2e-tests/support/pages/ApplicationDetailPage.ts
+++ b/e2e-tests/support/pages/ApplicationDetailPage.ts
@@ -1,4 +1,5 @@
 import { Common } from '../../utils/Common';
+import { LogViewerHelper } from '../../utils/LogViewerHelper';
 import { pageTitles } from '../constants/PageTitle';
 import {
   addComponentPagePO,
@@ -16,19 +17,27 @@ export class ApplicationDetailPage {
     cy.testA11y(`${pageTitles.deploymentSettings} page`);
   }
 
-  checkBuildLog(tasklistItem: string, textToVerify: string, taskTimeout: number = 20000) {
-    cy.wait(10000);
+  checkBuildLog(
+    tasklistItem: string,
+    textToVerify: string,
+    foldStep: string,
+    taskTimeout: number = 20000,
+  ) {
     cy.get('span[class="pipeline-run-logs__namespan"]')
       .contains(tasklistItem, { timeout: taskTimeout })
       .scrollIntoView()
       .should('be.visible')
       .click();
-    cy.get(buildLogModalContentPO.logText).should('contain.text', textToVerify);
+    LogViewerHelper.revealLogText(textToVerify, { foldStep });
   }
 
-  checkPodLog(podName: string, textToVerify: string) {
-    cy.get(buildLogModalContentPO.podLogNavList).contains('a', podName).click();
-    cy.get(buildLogModalContentPO.logText).should('contain.text', textToVerify);
+  checkPodLog(podName: string, textToVerify: string, foldStep: string) {
+    cy.get(buildLogModalContentPO.podLogNavList)
+      .contains('a', podName)
+      .scrollIntoView()
+      .should('be.visible')
+      .click();
+    LogViewerHelper.revealLogText(textToVerify, { foldStep });
   }
 
   openBuildLog(componentName: string) {
@@ -47,7 +56,7 @@ export class ApplicationDetailPage {
   }
 
   closeBuildLog() {
-    cy.get(buildLogModalContentPO.closeButton).click();
+    cy.get(buildLogModalContentPO.closeButton).click({ force: true });
     cy.get(buildLogModalContentPO.modal).should('not.exist');
   }
 

--- a/e2e-tests/support/pages/ApplicationDetailPage.ts
+++ b/e2e-tests/support/pages/ApplicationDetailPage.ts
@@ -17,27 +17,22 @@ export class ApplicationDetailPage {
     cy.testA11y(`${pageTitles.deploymentSettings} page`);
   }
 
-  checkBuildLog(
-    tasklistItem: string,
-    textToVerify: string,
-    foldStep: string,
-    taskTimeout: number = 20000,
-  ) {
+  checkBuildLog(tasklistItem: string, textToVerify: string, taskTimeout: number = 20000) {
     cy.get('span[class="pipeline-run-logs__namespan"]')
       .contains(tasklistItem, { timeout: taskTimeout })
       .scrollIntoView()
       .should('be.visible')
       .click();
-    LogViewerHelper.revealLogText(textToVerify, { foldStep });
+    LogViewerHelper.revealLogText(textToVerify);
   }
 
-  checkPodLog(podName: string, textToVerify: string, foldStep: string) {
+  checkPodLog(podName: string, textToVerify: string) {
     cy.get(buildLogModalContentPO.podLogNavList)
       .contains('a', podName)
       .scrollIntoView()
       .should('be.visible')
       .click();
-    LogViewerHelper.revealLogText(textToVerify, { foldStep });
+    LogViewerHelper.revealLogText(textToVerify);
   }
 
   openBuildLog(componentName: string) {
@@ -56,7 +51,7 @@ export class ApplicationDetailPage {
   }
 
   closeBuildLog() {
-    cy.get(buildLogModalContentPO.closeButton).click({ force: true });
+    cy.get(buildLogModalContentPO.closeButton).should('be.visible').click();
     cy.get(buildLogModalContentPO.modal).should('not.exist');
   }
 

--- a/e2e-tests/support/pages/tabs/ComponentsTabPage.ts
+++ b/e2e-tests/support/pages/tabs/ComponentsTabPage.ts
@@ -13,7 +13,7 @@ export class ComponentsTabPage {
   }
 
   static openComponent(name: string) {
-    this.getComponentListItem(name).click();
+    this.getComponentListItem(name).scrollIntoView().should('be.visible').click();
     Common.waitForLoad();
     cy.contains('h2', name).scrollIntoView().should('be.visible');
   }

--- a/e2e-tests/support/pages/tabs/PipelinerunsTabPage.ts
+++ b/e2e-tests/support/pages/tabs/PipelinerunsTabPage.ts
@@ -183,8 +183,8 @@ export class DetailsTab {
     cy.get(pipelinerunsTabPO.drawerPanel).contains('button', 'Logs').click();
   }
 
-  static verifyLogs(logText: string | RegExp, foldStep: string) {
-    LogViewerHelper.revealLogText(logText, { foldStep, assertInitiallyFolded: true });
+  static verifyLogs(logText: string | RegExp) {
+    LogViewerHelper.revealLogText(logText, { assertInitiallyFolded: true });
   }
 
   static closeDrawerPanel() {

--- a/e2e-tests/support/pages/tabs/PipelinerunsTabPage.ts
+++ b/e2e-tests/support/pages/tabs/PipelinerunsTabPage.ts
@@ -1,5 +1,6 @@
 import { hacAPIEndpoints } from '../../../utils/APIEndpoints';
 import { APIHelper } from '../../../utils/APIHelper';
+import { LogViewerHelper } from '../../../utils/LogViewerHelper';
 import { UIhelper } from '../../../utils/UIhelper';
 import { pipelinerunsTabPO } from '../../pageObjects/pages-po';
 
@@ -182,11 +183,8 @@ export class DetailsTab {
     cy.get(pipelinerunsTabPO.drawerPanel).contains('button', 'Logs').click();
   }
 
-  static verifyLogs(logText: string | RegExp) {
-    cy.get(pipelinerunsTabPO.logText)
-      .contains(logText, { timeout: 80000 })
-      .scrollIntoView()
-      .should('be.visible');
+  static verifyLogs(logText: string | RegExp, foldStep: string) {
+    LogViewerHelper.revealLogText(logText, { foldStep, assertInitiallyFolded: true });
   }
 
   static closeDrawerPanel() {

--- a/e2e-tests/tests/basic-happy-path.spec.ts
+++ b/e2e-tests/tests/basic-happy-path.spec.ts
@@ -222,7 +222,11 @@ describe('Basic Happy Path', () => {
       applicationDetailPage.openBuildLog(componentName);
       applicationDetailPage.verifyBuildLogTaskslist(piplinerunlogsTasks); //TO DO : Fetch the piplinerunlogsTasks from cluster using api At runtime.
       applicationDetailPage.verifyFailedLogTasksNotExists();
-      applicationDetailPage.checkBuildLog(pipelineConfig.logCheckTask, 'Using token for quay.io');
+      applicationDetailPage.checkBuildLog(
+        pipelineConfig.logCheckTask,
+        'Using token for quay.io',
+        'STEP-PUSH',
+      );
       applicationDetailPage.closeBuildLog();
 
       cy.log('Verify deployed image exists');

--- a/e2e-tests/tests/basic-happy-path.spec.ts
+++ b/e2e-tests/tests/basic-happy-path.spec.ts
@@ -222,11 +222,7 @@ describe('Basic Happy Path', () => {
       applicationDetailPage.openBuildLog(componentName);
       applicationDetailPage.verifyBuildLogTaskslist(piplinerunlogsTasks); //TO DO : Fetch the piplinerunlogsTasks from cluster using api At runtime.
       applicationDetailPage.verifyFailedLogTasksNotExists();
-      applicationDetailPage.checkBuildLog(
-        pipelineConfig.logCheckTask,
-        'Using token for quay.io',
-        'STEP-PUSH',
-      );
+      applicationDetailPage.checkBuildLog(pipelineConfig.logCheckTask, 'Using token for quay.io');
       applicationDetailPage.closeBuildLog();
 
       cy.log('Verify deployed image exists');

--- a/e2e-tests/utils/LogViewerHelper.ts
+++ b/e2e-tests/utils/LogViewerHelper.ts
@@ -1,0 +1,56 @@
+import { logViewerPO } from '../support/pageObjects/logViewer-po';
+
+/**
+ * Helpers for the virtualized foldable log viewer.
+ *
+ * Completed steps start folded. Callers must pass `foldStep` for the section that
+ * contains the expected text so we expand only that step.
+ * PatternFly LogViewerSearch only re-runs on input change — wait until fold headers
+ * exist (logs loaded) before typing a query.
+ */
+
+const foldHeaderTestId = (foldStep: string) => `fold-header-${foldStep}`;
+
+export class LogViewerHelper {
+  static waitForFoldedSteps(timeout: number = 40000) {
+    cy.get(logViewerPO.viewer, { timeout }).should('be.visible');
+    cy.get(logViewerPO.foldHeader, { timeout }).should('have.length.at.least', 1);
+  }
+
+  /**
+   * Expand `foldStep`, optionally search, and assert `logText` is visible.
+   * When `assertInitiallyFolded`, also checks no section is expanded before revealing.
+   * Defaults to the Cypress `defaultCommandTimeout` (40s).
+   */
+  static revealLogText(
+    logText: string | RegExp,
+    options: { foldStep: string; timeout?: number; assertInitiallyFolded?: boolean },
+  ) {
+    const waitTimeout = options.timeout ?? 40000;
+    this.waitForFoldedSteps(waitTimeout);
+    if (options.assertInitiallyFolded) {
+      cy.get(logViewerPO.expandedFoldHeader).should('not.exist');
+    }
+
+    this.expandStep(options.foldStep);
+
+    if (typeof logText === 'string') {
+      cy.get(logViewerPO.searchInput, { timeout: waitTimeout }).should('be.visible');
+      cy.get(logViewerPO.searchInput).clear();
+      cy.get(logViewerPO.searchInput).type(logText, { delay: 0 });
+    }
+
+    cy.contains(logViewerPO.logText, logText, { timeout: waitTimeout }).scrollIntoView();
+    cy.contains(logViewerPO.logText, logText).should('be.visible');
+  }
+
+  /** Expand a folded log step by section name (matches `data-test="fold-header-<foldStep>"`). */
+  static expandStep(foldStep: string) {
+    const testId = foldHeaderTestId(foldStep);
+    cy.get(`[data-test="${testId}"][aria-expanded="false"]`)
+      .scrollIntoView()
+      .should('be.visible')
+      .click();
+    cy.get(`[data-test="${testId}"]`).should('have.attr', 'aria-expanded', 'true');
+  }
+}

--- a/e2e-tests/utils/LogViewerHelper.ts
+++ b/e2e-tests/utils/LogViewerHelper.ts
@@ -3,13 +3,11 @@ import { logViewerPO } from '../support/pageObjects/logViewer-po';
 /**
  * Helpers for the virtualized foldable log viewer.
  *
- * Completed steps start folded. Callers must pass `foldStep` for the section that
- * contains the expected text so we expand only that step.
+ * Search expands the folded step that contains the first match, so callers only
+ * need to type a query — no manual step expansion.
  * PatternFly LogViewerSearch only re-runs on input change — wait until fold headers
  * exist (logs loaded) before typing a query.
  */
-
-const foldHeaderTestId = (foldStep: string) => `fold-header-${foldStep}`;
 
 export class LogViewerHelper {
   static waitForFoldedSteps(timeout: number = 40000) {
@@ -18,13 +16,13 @@ export class LogViewerHelper {
   }
 
   /**
-   * Expand `foldStep`, optionally search, and assert `logText` is visible.
-   * When `assertInitiallyFolded`, also checks no section is expanded before revealing.
+   * Search for `logText` (which expands the matching folded step) and assert it is visible.
+   * When `assertInitiallyFolded`, also checks no section is expanded before searching.
    * Defaults to the Cypress `defaultCommandTimeout` (40s).
    */
   static revealLogText(
     logText: string | RegExp,
-    options: { foldStep: string; timeout?: number; assertInitiallyFolded?: boolean },
+    options: { timeout?: number; assertInitiallyFolded?: boolean } = {},
   ) {
     const waitTimeout = options.timeout ?? 40000;
     this.waitForFoldedSteps(waitTimeout);
@@ -32,25 +30,12 @@ export class LogViewerHelper {
       cy.get(logViewerPO.expandedFoldHeader).should('not.exist');
     }
 
-    this.expandStep(options.foldStep);
-
-    if (typeof logText === 'string') {
-      cy.get(logViewerPO.searchInput, { timeout: waitTimeout }).should('be.visible');
-      cy.get(logViewerPO.searchInput).clear();
-      cy.get(logViewerPO.searchInput).type(logText, { delay: 0 });
-    }
+    const searchTerm = typeof logText === 'string' ? logText : logText.source;
+    cy.get(logViewerPO.searchInput, { timeout: waitTimeout }).should('be.visible');
+    cy.get(logViewerPO.searchInput).clear();
+    cy.get(logViewerPO.searchInput).type(searchTerm);
 
     cy.contains(logViewerPO.logText, logText, { timeout: waitTimeout }).scrollIntoView();
     cy.contains(logViewerPO.logText, logText).should('be.visible');
-  }
-
-  /** Expand a folded log step by section name (matches `data-test="fold-header-<foldStep>"`). */
-  static expandStep(foldStep: string) {
-    const testId = foldHeaderTestId(foldStep);
-    cy.get(`[data-test="${testId}"][aria-expanded="false"]`)
-      .scrollIntoView()
-      .should('be.visible')
-      .click();
-    cy.get(`[data-test="${testId}"]`).should('have.attr', 'aria-expanded', 'true');
   }
 }

--- a/src/shared/components/pipeline-run-logs/__tests__/utils.spec.ts
+++ b/src/shared/components/pipeline-run-logs/__tests__/utils.spec.ts
@@ -1,0 +1,28 @@
+import type { ContainerStatus } from '../../types';
+import { isContainerStepCompleted } from '../utils';
+
+const containerStatus = (state: ContainerStatus['state']): ContainerStatus => ({
+  name: 'step',
+  state,
+  ready: false,
+  restartCount: 0,
+  image: 'img',
+  imageID: 'img-id',
+});
+
+describe('isContainerStepCompleted', () => {
+  it('should return false when the container is still running', () => {
+    expect(isContainerStepCompleted(containerStatus({ running: {} }))).toBe(false);
+  });
+
+  it('should return true for any terminated step', () => {
+    expect(
+      isContainerStepCompleted(containerStatus({ terminated: { exitCode: 0, reason: 'Completed' } })),
+    ).toBe(true);
+    expect(isContainerStepCompleted(containerStatus({ terminated: { exitCode: 1 } }))).toBe(true);
+  });
+
+  it('should return false when container status is missing', () => {
+    expect(isContainerStepCompleted(undefined)).toBe(false);
+  });
+});

--- a/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/LogViewer.tsx
@@ -213,7 +213,12 @@ const LogViewer: React.FC<Props> = ({
                 {showSearch && (
                   <ToolbarGroup>
                     <ToolbarItem>
-                      <LogViewerSearch placeholder="Search" minSearchChars={0} />
+                      <LogViewerSearch
+                        key={lines.length > 0 ? 'logs-ready' : 'logs-empty'}
+                        placeholder="Search"
+                        minSearchChars={0}
+                        name="logViewerSearchInput"
+                      />
                     </ToolbarItem>
                   </ToolbarGroup>
                 )}

--- a/src/shared/components/pipeline-run-logs/logs/Logs.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/Logs.tsx
@@ -12,7 +12,7 @@ import { WebSocketFactory } from '../../../../k8s/web-socket/WebSocketFactory';
 import { PodModel } from '../../../../models/pod';
 import { TaskRunKind } from '../../../../types';
 import { PodKind, ContainerSpec, ContainerStatus } from '../../types';
-import { containerToLogSourceStatus, LOG_SOURCE_TERMINATED } from '../utils';
+import { containerToLogSourceStatus, isContainerStepCompleted, LOG_SOURCE_TERMINATED } from '../utils';
 import LogViewer, { type Props as LogViewerProps } from './LogViewer';
 
 type LogSources = { [containerName: string]: string };
@@ -143,8 +143,9 @@ const Logs: React.FC<LogsProps> = ({
               // Gracefully handle empty logs (404) from kubearch, similar to how Tekton Results handles 404
               // When logs don't exist, both kubearch and Tekton Results return 404
               if (err?.code === 404) {
-                // Don't append any error message for missing logs - just leave it empty
-                // This matches the behavior of Tekton Results which returns empty logs for 404
+                // Mark the container as fetched with empty content so folding can evaluate
+                // it after load (and so the section still appears in the viewer).
+                appendLog(name, '');
                 return;
               }
 
@@ -211,17 +212,16 @@ const Logs: React.FC<LogsProps> = ({
   }, [containers, resource?.status?.containerStatuses]);
 
   const sections = React.useMemo<LogSection[]>(() => {
-    const allStatuses: ContainerStatus[] = resource?.status?.containerStatuses ?? [];
+    const statusByName = new Map(
+      (resource?.status?.containerStatuses ?? []).map((status) => [status.name, status]),
+    );
     return containers
-      .filter((c) => logSources[c.name])
-      .map((c) => {
-        const status = allStatuses.find((s) => s.name === c.name);
-        return {
-          containerName: c.name.toUpperCase(),
-          data: logSources[c.name],
-          isCompleted: containerToLogSourceStatus(status) === LOG_SOURCE_TERMINATED,
-        };
-      });
+      .filter((c) => c.name in logSources)
+      .map((c) => ({
+        containerName: c.name.toUpperCase(),
+        data: logSources[c.name],
+        isCompleted: isContainerStepCompleted(statusByName.get(c.name)),
+      }));
   }, [logSources, containers, resource?.status?.containerStatuses]);
 
   return (

--- a/src/shared/components/pipeline-run-logs/logs/TektonTaskRunLog.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/TektonTaskRunLog.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
+import { runStatus } from '~/consts/pipelinerun';
 import { singleLogSection } from '~/shared/components/virtualized-log-viewer/log-viewer-utils';
+import { taskRunStatus } from '~/utils/pipeline-utils';
 import { useTRTaskRunLog } from '../../../../hooks/useTektonResults';
 import { HttpError } from '../../../../k8s/error';
 import { TaskRunKind } from '../../../../types';
@@ -24,10 +26,17 @@ export const TektonTaskRunLog: React.FC<React.PropsWithChildren<TektonTaskRunLog
       ? `Logs are no longer accessible for ${taskName} task`
       : null;
 
-  const sections = React.useMemo(
-    () => (trResults ? [singleLogSection(trResults, taskName ?? 'log')] : []),
-    [trResults, taskName],
-  );
+  const sections = React.useMemo(() => {
+    if (!trResults) {
+      return [];
+    }
+
+    const status = taskRun ? taskRunStatus(taskRun) : runStatus.Unknown;
+    const inProgress =
+      status === runStatus.Running || status === runStatus.Pending || status === runStatus.Idle;
+
+    return [singleLogSection(trResults, taskName ?? 'log', trLoaded && !inProgress)];
+  }, [trResults, taskName, taskRun, trLoaded]);
 
   return (
     <LogViewer

--- a/src/shared/components/pipeline-run-logs/logs/__tests__/Logs.spec.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/__tests__/Logs.spec.tsx
@@ -9,7 +9,7 @@ import {
 } from '../../../../../k8s/k8s-utils';
 import { TaskRunKind } from '../../../../../types';
 import { ContainerStatus, PodKind, ContainerSpec } from '../../../types';
-import { containerToLogSourceStatus } from '../../utils';
+import { containerToLogSourceStatus, isContainerStepCompleted } from '../../utils';
 import Logs from '../Logs';
 
 const mockLogViewer = jest.fn();
@@ -59,6 +59,7 @@ jest.mock('~/shared/providers/Namespace');
 
 jest.mock('../../utils', () => ({
   containerToLogSourceStatus: jest.fn(),
+  isContainerStepCompleted: jest.fn(),
   LOG_SOURCE_TERMINATED: 'terminated',
   LOG_SOURCE_RUNNING: 'running',
   LOG_SOURCE_WAITING: 'waiting',
@@ -128,6 +129,9 @@ describe('Logs', () => {
     (getK8sResourceURL as jest.Mock).mockReturnValue('http://test-url');
     (getWebsocketSubProtocolAndPathPrefix as jest.Mock).mockReturnValue({});
     (containerToLogSourceStatus as jest.Mock).mockReturnValue('running');
+    (isContainerStepCompleted as jest.Mock).mockImplementation(
+      (container?: ContainerStatus) => containerToLogSourceStatus(container) === 'terminated',
+    );
   });
 
   describe('rendering', () => {
@@ -282,7 +286,7 @@ describe('Logs', () => {
       expect(lastCall.sections[1].containerName).toBe('CONTAINER1');
     });
 
-    it('should skip containers without log sources', async () => {
+    it('should include containers with empty fetched logs so folding can evaluate them', async () => {
       const terminatedContainer1: ContainerStatus = {
         name: 'container1',
         state: { terminated: { exitCode: 0 } },
@@ -323,11 +327,19 @@ describe('Logs', () => {
         await Promise.resolve();
       });
 
-      // Containers without logs are omitted from sections
+      // Empty fetched logs still create a section (e.g. 404 / no output) so fold state is consistent.
       const lastCall = mockLogViewer.mock.calls[mockLogViewer.mock.calls.length - 1][0];
-      expect(lastCall.sections).toHaveLength(1);
-      expect(lastCall.sections[0].containerName).toBe('CONTAINER1');
-      expect(lastCall.sections[0].data).toBe('has logs');
+      expect(lastCall.sections).toHaveLength(2);
+      expect(lastCall.sections[0]).toEqual({
+        containerName: 'CONTAINER1',
+        data: 'has logs',
+        isCompleted: true,
+      });
+      expect(lastCall.sections[1]).toEqual({
+        containerName: 'CONTAINER2',
+        data: '',
+        isCompleted: true,
+      });
     });
 
     it('should pass empty sections when no containers have logs', () => {

--- a/src/shared/components/pipeline-run-logs/utils.ts
+++ b/src/shared/components/pipeline-run-logs/utils.ts
@@ -1,4 +1,5 @@
 import isEmpty from 'lodash/isEmpty';
+import type { ContainerStatus } from '../types';
 
 export const LOG_SOURCE_RESTARTING = 'restarting';
 export const LOG_SOURCE_RUNNING = 'running';
@@ -21,3 +22,7 @@ export const containerToLogSourceStatus = (container): string => {
   }
   return LOG_SOURCE_RUNNING;
 };
+
+/** Terminated steps fold; only in-progress stays open. */
+export const isContainerStepCompleted = (container?: ContainerStatus): boolean =>
+  Boolean(container?.state?.terminated);

--- a/src/shared/components/virtualized-log-viewer/VirtualizedLogContent.tsx
+++ b/src/shared/components/virtualized-log-viewer/VirtualizedLogContent.tsx
@@ -114,11 +114,11 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
   });
 
   React.useEffect(() => {
-    if (!isMultiSection || !expandSearchTargetRow || expandSearchTargetRow <= 0) return;
+    if (!expandSearchTargetRow || expandSearchTargetRow <= 0) return;
     const sectionIndex = searchLineToSectionIndexRef.current.get(expandSearchTargetRow - 1);
     if (sectionIndex === undefined) return;
     expandSection(sectionIndex);
-  }, [isMultiSection, expandSearchTargetRow, expandSection]);
+  }, [expandSearchTargetRow, expandSection]);
 
   const measureCallbackRef = React.useCallback((node: HTMLDivElement | null) => {
     if (node) {
@@ -176,15 +176,16 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
   });
 
   React.useEffect(() => {
-    if (!isMultiSection || !highlightedLines) return;
+    if (!highlightedLines) return;
 
-    const sectionsToExpand = new Set<number>();
+    const expanded = new Set<number>();
     for (let line = highlightedLines.start; line <= highlightedLines.end; line++) {
       const sectionIndex = lineNumberToSectionIndexRef.current.get(line);
-      if (sectionIndex !== undefined) sectionsToExpand.add(sectionIndex);
+      if (sectionIndex === undefined || expanded.has(sectionIndex)) continue;
+      expanded.add(sectionIndex);
+      expandSection(sectionIndex);
     }
-    sectionsToExpand.forEach((sectionIndex) => expandSection(sectionIndex));
-  }, [isMultiSection, highlightedLines, expandSection]);
+  }, [highlightedLines, expandSection]);
 
   const highlightScrollTargetIndex = React.useMemo((): number | null => {
     if (!highlightedLines || rowCount === 0) return null;
@@ -217,7 +218,6 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
 
     const sectionIndex = lineNumberToSectionIndexRef.current.get(highlightedLines.start);
     const awaitingExpand =
-      isMultiSection &&
       displayIdx === undefined &&
       sectionIndex !== undefined &&
       !expandedSections.has(sectionIndex);
@@ -254,7 +254,6 @@ export const VirtualizedLogContent: React.FC<VirtualizedLogContentProps> = ({
     lineNumberToDisplayRow,
     virtualizer,
     clearScrollTracking,
-    isMultiSection,
     expandedSections,
   ]);
 

--- a/src/shared/components/virtualized-log-viewer/__tests__/VirtualizedLogContent.spec.tsx
+++ b/src/shared/components/virtualized-log-viewer/__tests__/VirtualizedLogContent.spec.tsx
@@ -38,8 +38,9 @@ jest.mock('lodash-es', () => ({
 
 describe('VirtualizedLogContent Integration Tests', () => {
   const mockData = 'line 1\nline 2\nline 3';
+  // Incomplete so the single section stays expanded and content is in the DOM for assertions.
   const defaultProps = {
-    sections: [singleLogSection(mockData)],
+    sections: [singleLogSection(mockData, 'log', false)],
     height: 600,
     width: '100%',
   };

--- a/src/shared/components/virtualized-log-viewer/__tests__/VirtualizedLogViewer.spec.tsx
+++ b/src/shared/components/virtualized-log-viewer/__tests__/VirtualizedLogViewer.spec.tsx
@@ -17,8 +17,9 @@ jest.mock('lodash-es', () => ({
 
 describe('VirtualizedLogViewer Integration Tests', () => {
   const mockData = 'line 1\nline 2\nline 3';
+  // Incomplete so the single section stays expanded and content is in the DOM for assertions.
   const defaultProps = {
-    sections: [singleLogSection(mockData)],
+    sections: [singleLogSection(mockData, 'log', false)],
     height: 600,
   };
 

--- a/src/shared/components/virtualized-log-viewer/__tests__/useSectionFold.spec.ts
+++ b/src/shared/components/virtualized-log-viewer/__tests__/useSectionFold.spec.ts
@@ -9,8 +9,15 @@ const section = (containerName: string, data: string, isCompleted?: boolean): Lo
 });
 
 describe('useSectionFold', () => {
-  it('should expand the only section for single-section logs', () => {
-    const sections = [section('task', 'log line')];
+  it('should fold a completed single-section log', () => {
+    const sections = [section('task', 'log line', true)];
+    const { result } = renderHook(() => useSectionFold(sections));
+
+    expect([...result.current.expandedSections]).toEqual([]);
+  });
+
+  it('should expand an incomplete single-section log', () => {
+    const sections = [section('task', 'log line', false)];
     const { result } = renderHook(() => useSectionFold(sections));
 
     expect([...result.current.expandedSections]).toEqual([0]);
@@ -21,6 +28,17 @@ describe('useSectionFold', () => {
     const { result } = renderHook(() => useSectionFold(sections));
 
     expect([...result.current.expandedSections]).toEqual([1]);
+  });
+
+  it('should collapse all completed sections when multiple are present', () => {
+    const sections = [
+      section('build', 'done', true),
+      section('test', 'done', true),
+      section('push', 'done', true),
+    ];
+    const { result } = renderHook(() => useSectionFold(sections));
+
+    expect([...result.current.expandedSections]).toEqual([]);
   });
 
   it('should toggle a section open and closed', () => {
@@ -50,16 +68,17 @@ describe('useSectionFold', () => {
   });
 
   it('should auto-collapse a section when it becomes completed', () => {
-    const initialSections = [section('build', 'running', false)];
+    const initialSections = [section('build', 'running', false), section('test', 'pending', false)];
     const { result, rerender } = renderHook(({ s }) => useSectionFold(s), {
       initialProps: { s: initialSections },
     });
 
     expect(result.current.expandedSections.has(0)).toBe(true);
 
-    rerender({ s: [section('build', 'done', true)] });
+    rerender({ s: [section('build', 'done', true), section('test', 'running', false)] });
 
     expect(result.current.expandedSections.has(0)).toBe(false);
+    expect(result.current.expandedSections.has(1)).toBe(true);
   });
 
   it('should expand newly added running sections', () => {
@@ -72,6 +91,87 @@ describe('useSectionFold', () => {
       s: [section('build', 'done', true), section('test', 'running', false)],
     });
 
+    expect(result.current.expandedSections.has(0)).toBe(false);
     expect(result.current.expandedSections.has(1)).toBe(true);
+  });
+
+  it('should keep completed sections folded during progressive load (single → multi)', () => {
+    // Completed steps fold immediately — including when only one section has arrived —
+    // so progressive container load does not flash open then closed.
+    const { result, rerender } = renderHook(({ s }) => useSectionFold(s), {
+      initialProps: { s: [section('build', 'done', true)] },
+    });
+
+    expect([...result.current.expandedSections]).toEqual([]);
+
+    rerender({
+      s: [section('build', 'done', true), section('test', 'done', true)],
+    });
+
+    expect([...result.current.expandedSections]).toEqual([]);
+
+    rerender({
+      s: [
+        section('build', 'done', true),
+        section('test', 'done', true),
+        section('push', 'running', false),
+      ],
+    });
+
+    expect([...result.current.expandedSections]).toEqual([2]);
+  });
+
+  it('should keep in-progress steps expanded when others complete', () => {
+    const sections = [
+      section('build', 'done', true),
+      section('test', 'running', false),
+      section('push', 'skipped', true),
+    ];
+    const { result } = renderHook(() => useSectionFold(sections));
+
+    expect([...result.current.expandedSections]).toEqual([1]);
+  });
+
+  it('should preserve a user expand override when a later step is appended', () => {
+    const { result, rerender } = renderHook(({ s }) => useSectionFold(s), {
+      initialProps: {
+        s: [section('build', 'done', true), section('test', 'done', true)],
+      },
+    });
+
+    act(() => {
+      result.current.expandSection(0);
+    });
+    expect(result.current.expandedSections.has(0)).toBe(true);
+
+    rerender({
+      s: [
+        section('build', 'done', true),
+        section('test', 'done', true),
+        section('push', 'running', false),
+      ],
+    });
+
+    expect(result.current.expandedSections.has(0)).toBe(true);
+    expect(result.current.expandedSections.has(2)).toBe(true);
+  });
+
+  it('should reset overrides when section identity changes (task switch)', () => {
+    const { result, rerender } = renderHook(({ s }) => useSectionFold(s), {
+      initialProps: {
+        s: [section('build', 'done', true), section('test', 'done', true)],
+      },
+    });
+
+    act(() => {
+      result.current.expandSection(0);
+    });
+    expect(result.current.expandedSections.has(0)).toBe(true);
+
+    rerender({
+      s: [section('clone', 'done', true), section('build', 'done', true)],
+    });
+
+    expect([...result.current.expandedSections]).toEqual([]);
   });
 });

--- a/src/shared/components/virtualized-log-viewer/log-viewer-utils.ts
+++ b/src/shared/components/virtualized-log-viewer/log-viewer-utils.ts
@@ -21,7 +21,7 @@ export function normalizeSection(section: LogSection): NormalizedLogSection {
 export function singleLogSection(
   data: string,
   containerName = 'log',
-  isCompleted = true,
+  isCompleted = false,
 ): LogSection {
   return { containerName, data, isCompleted };
 }

--- a/src/shared/components/virtualized-log-viewer/useSectionFold.ts
+++ b/src/shared/components/virtualized-log-viewer/useSectionFold.ts
@@ -2,102 +2,117 @@ import React from 'react';
 import type { LogSection } from './types';
 
 const EMPTY_EXPANDED_SECTIONS = new Set<number>();
+const EMPTY_OVERRIDES: ReadonlyMap<number, boolean> = new Map();
 
-function getInitialExpandedSections(sections: readonly LogSection[]): Set<number> {
-  if (sections.length === 1) return new Set([0]);
+/** Default: in-progress open, completed folded. */
+const isExpandedByDefault = (section: LogSection): boolean => !section.isCompleted;
 
-  const expanded = new Set<number>();
-  for (let i = 0; i < sections.length; i++) {
-    if (!sections[i].isCompleted) expanded.add(i);
+const resolveIsExpanded = (
+  sections: readonly LogSection[],
+  overrides: ReadonlyMap<number, boolean>,
+  index: number,
+): boolean => {
+  const override = overrides.get(index);
+  return override !== undefined ? override : isExpandedByDefault(sections[index]);
+};
+
+/** Stable identity key so log-content updates don't reset overrides. */
+const sectionNamesKey = (sections: readonly LogSection[]): string =>
+  sections.map((s) => s.containerName).join('\0');
+
+const isPrefixGrowth = (prev: readonly string[], next: readonly string[]): boolean =>
+  next.length >= prev.length && prev.every((name, i) => name === next[i]);
+
+/** Store only deviations from the default expand policy. */
+const withOverride = (
+  prev: ReadonlyMap<number, boolean>,
+  index: number,
+  expanded: boolean,
+  defaultExpanded: boolean,
+): ReadonlyMap<number, boolean> => {
+  if (expanded === defaultExpanded) {
+    if (!prev.has(index)) return prev;
+    const next = new Map(prev);
+    next.delete(index);
+    return next.size > 0 ? next : EMPTY_OVERRIDES;
   }
-  return expanded;
-}
+  if (prev.get(index) === expanded) return prev;
+  const next = new Map(prev);
+  next.set(index, expanded);
+  return next;
+};
 
 export const useSectionFold = (sections: readonly LogSection[]) => {
-  const hasSections = sections.length >= 1;
-
-  const [expandedSections, setExpandedSections] = React.useState<Set<number>>(() =>
-    hasSections ? getInitialExpandedSections(sections) : EMPTY_EXPANDED_SECTIONS,
-  );
-
   const sectionsRef = React.useRef(sections);
   sectionsRef.current = sections;
 
-  const prevSectionCountRef = React.useRef(sections.length);
-  const prevCompletionRef = React.useRef<boolean[]>(sections.map((s) => s.isCompleted ?? false));
+  const [overrides, setOverrides] = React.useState<ReadonlyMap<number, boolean>>(EMPTY_OVERRIDES);
+
+  const namesKey = sectionNamesKey(sections);
+  const prevNamesRef = React.useRef<string[]>(sections.map((s) => s.containerName));
 
   React.useEffect(() => {
-    if (!hasSections) {
-      prevSectionCountRef.current = 0;
-      prevCompletionRef.current = [];
-      return;
+    const prevNames = prevNamesRef.current;
+    const nextNames = namesKey === '' ? [] : namesKey.split('\0');
+
+    // Task switch: drop overrides. Progressive step append: keep them.
+    if (!isPrefixGrowth(prevNames, nextNames) && !isPrefixGrowth(nextNames, prevNames)) {
+      setOverrides(EMPTY_OVERRIDES);
+    } else if (nextNames.length < prevNames.length) {
+      setOverrides((prev) => {
+        if (prev.size === 0) return prev;
+        let changed = false;
+        const pruned = new Map<number, boolean>();
+        prev.forEach((value, index) => {
+          if (index < nextNames.length) pruned.set(index, value);
+          else changed = true;
+        });
+        if (!changed) return prev;
+        return pruned.size > 0 ? pruned : EMPTY_OVERRIDES;
+      });
     }
 
-    const currentSections = sectionsRef.current;
-    const prevCount = prevSectionCountRef.current;
-    const prevCompletion = prevCompletionRef.current;
-    const lengthChanged = currentSections.length !== prevCount;
+    prevNamesRef.current = nextNames;
+  }, [namesKey]);
 
-    setExpandedSections((prev) => {
-      let next: Set<number> | undefined;
+  const expandedSections = React.useMemo(() => {
+    if (sections.length === 0) return EMPTY_EXPANDED_SECTIONS;
 
-      if (lengthChanged && currentSections.length > 0 && prev.size === 0) {
-        next = getInitialExpandedSections(currentSections);
-      }
-
-      if (currentSections.length > prevCount && prev.size > 0) {
-        const base = next ?? prev;
-        next = new Set(base);
-        for (let i = prevCount; i < currentSections.length; i++) {
-          if (!currentSections[i].isCompleted) next.add(i);
-        }
-      }
-
-      if (prevCompletion.length > 0) {
-        const newlyCompleted: number[] = [];
-        currentSections.forEach((s, i) => {
-          if (s.isCompleted && prevCompletion[i] === false) newlyCompleted.push(i);
-        });
-        if (newlyCompleted.length > 0) {
-          const base = next ?? prev;
-          next = new Set(base);
-          newlyCompleted.forEach((i) => next.delete(i));
-        }
-      }
-
-      return next ?? prev;
-    });
-
-    prevSectionCountRef.current = currentSections.length;
-    prevCompletionRef.current = currentSections.map((s) => s.isCompleted ?? false);
-  }, [hasSections, sections]);
+    const expanded = new Set<number>();
+    for (let i = 0; i < sections.length; i++) {
+      if (resolveIsExpanded(sections, overrides, i)) expanded.add(i);
+    }
+    return expanded;
+  }, [sections, overrides]);
 
   const toggleSection = React.useCallback((sectionIndex: number) => {
-    if (sectionsRef.current.length === 0) return;
-    setExpandedSections((prev) => {
-      const next = new Set(prev);
-      if (next.has(sectionIndex)) next.delete(sectionIndex);
-      else next.add(sectionIndex);
-      return next;
+    const currentSections = sectionsRef.current;
+    if (sectionIndex < 0 || sectionIndex >= currentSections.length) return;
+
+    setOverrides((prev) => {
+      const defaultExpanded = isExpandedByDefault(currentSections[sectionIndex]);
+      const nextExpanded = !resolveIsExpanded(currentSections, prev, sectionIndex);
+      return withOverride(prev, sectionIndex, nextExpanded, defaultExpanded);
     });
   }, []);
 
   const expandSection = React.useCallback((sectionIndex: number) => {
-    if (sectionsRef.current.length === 0) return;
-    setExpandedSections((prev) => {
-      if (prev.has(sectionIndex)) return prev;
-      const next = new Set(prev);
-      next.add(sectionIndex);
-      return next;
+    const currentSections = sectionsRef.current;
+    if (sectionIndex < 0 || sectionIndex >= currentSections.length) return;
+
+    setOverrides((prev) => {
+      if (resolveIsExpanded(currentSections, prev, sectionIndex)) return prev;
+      return withOverride(
+        prev,
+        sectionIndex,
+        true,
+        isExpandedByDefault(currentSections[sectionIndex]),
+      );
     });
   }, []);
 
   return React.useMemo(
-    () => ({
-      expandedSections: hasSections ? expandedSections : EMPTY_EXPANDED_SECTIONS,
-      toggleSection,
-      expandSection,
-    }),
-    [hasSections, expandedSections, toggleSection, expandSection],
+    () => ({ expandedSections, toggleSection, expandSection }),
+    [expandedSections, toggleSection, expandSection],
   );
 };


### PR DESCRIPTION
## Fixes 
[KFLUXUI-1532](https://redhat.atlassian.net/browse/KFLUXUI-1532)


## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

[KFLUXUI-1532]: https://redhat.atlassian.net/browse/KFLUXUI-1532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Log viewer now keeps container sections represented even when the fetched container log text is empty.
  * Container/task log sections no longer show as completed prematurely while still running.
  * Improved folding/expansion so search and highlighted-line navigation reliably expands the correct sections as logs load or tasks change.

* **Tests**
  * Added/updated unit and integration coverage for completion detection and folding/expansion scenarios, including updated log-viewer search behavior in end-to-end checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->