### PR TITLE
feat(KFLUXUI-1566): skips PR message for periodic-local, adds skip param for slack message

### DIFF
--- a/.integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/.integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -55,10 +55,10 @@ spec:
       description: 'Type of job (pr-check, periodic-local, periodic-stage)'
       default: 'pr-check'
       type: string
-    - name: dry-run
-      description: 'If true, skip sending the Slack notification'
-      default: false
-      type: boolean
+    - name: skip-slack-notification
+      description: 'Skip sending the Slack notification'
+      default: 'false'
+      type: string
     - name: test-image-tag
       description: >-
         Tag for the E2E test image (quay.io/konflux_ui_qe/konflux-ui-tests:<tag>).
@@ -264,7 +264,7 @@ spec:
 
     - name: send-slack-notification
       when:
-        - input: '$(params.dry-run)'
+        - input: '$(params.skip-slack-notification)'
           operator: notin
           values: ['true']
       taskRef:

--- a/.integration-tests/pipelines/e2e-main-pipeline.yaml
+++ b/.integration-tests/pipelines/e2e-main-pipeline.yaml
@@ -55,6 +55,10 @@ spec:
       description: 'Type of job (pr-check, periodic-local, periodic-stage)'
       default: 'pr-check'
       type: string
+    - name: dry-run
+      description: 'If true, skip sending the Slack notification'
+      default: false
+      type: boolean
     - name: test-image-tag
       description: >-
         Tag for the E2E test image (quay.io/konflux_ui_qe/konflux-ui-tests:<tag>).
@@ -232,7 +236,7 @@ spec:
       when:
         - input: '$(params.job-type)'
           operator: notin
-          values: ['periodic-stage']
+          values: ['periodic-stage', 'periodic-local']
       taskRef:
         resolver: git
         params:
@@ -259,6 +263,10 @@ spec:
           value: '$(params.artifact-browser-url)'
 
     - name: send-slack-notification
+      when:
+        - input: '$(params.dry-run)'
+          operator: notin
+          values: ['true']
       taskRef:
         resolver: git
         params:


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->
https://redhat.atlassian.net/browse/KFLUXUI-1566

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a pipeline option to suppress Slack notifications by defaulting `skip-slack-notification` to `false`.
  - Updated pull request status messaging so it runs for both periodic staging and periodic local executions (not just periodic staging).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->