### PR TITLE
fix(KFLUXUI-1570): re-add base url setup for non-stage runs + update images

### DIFF
--- a/.integration-tests/tasks/monitor-webhook-logs.yaml
+++ b/.integration-tests/tasks/monitor-webhook-logs.yaml
@@ -17,7 +17,7 @@ spec:
       description: 'How long to monitor (e.g., 5m, 10m, 30m)'
   steps:
     - name: setup-monitoring
-      image: registry.k8s.io/kubectl:v1.36.1@sha256:d08f476d04d0e30f426f06bc6ff6c38913aaa4591943046b77e2f74a72d3611c #1.36.1
+      image: docker.io/bitnami/kubectl@sha256:95de17e6eb92da83a58c90a9df0c4cede634f898d2e6b92ea04f4a6ee6ace08d
       env:
         - name: TEKTON_PIPELINE_RUN
           valueFrom:

--- a/.integration-tests/tasks/monitor-webhook-logs.yaml
+++ b/.integration-tests/tasks/monitor-webhook-logs.yaml
@@ -17,7 +17,7 @@ spec:
       description: 'How long to monitor (e.g., 5m, 10m, 30m)'
   steps:
     - name: setup-monitoring
-      image: docker.io/bitnami/kubectl@sha256:95de17e6eb92da83a58c90a9df0c4cede634f898d2e6b92ea04f4a6ee6ace08d
+      image: docker.io/bitnami/kubectl@sha256:95de17e6eb92da83a58c90a9df0c4cede634f898d2e6b92ea04f4a6ee6ace08d # kubectl 1.36.3
       env:
         - name: TEKTON_PIPELINE_RUN
           valueFrom:

--- a/.integration-tests/tasks/run-e2e-konflux-ui.yaml
+++ b/.integration-tests/tasks/run-e2e-konflux-ui.yaml
@@ -65,7 +65,7 @@ spec:
         - input: '$(params.job-type)'
           operator: notin
           values: ['periodic-stage']
-      image: docker.io/bitnami/kubectl@sha256:95de17e6eb92da83a58c90a9df0c4cede634f898d2e6b92ea04f4a6ee6ace08d
+      image: docker.io/bitnami/kubectl@sha256:95de17e6eb92da83a58c90a9df0c4cede634f898d2e6b92ea04f4a6ee6ace08d # kubectl 1.36.3
       volumeMounts:
         - name: kubeconfig-data
           mountPath: /shared
@@ -94,8 +94,10 @@ spec:
         SECRET_NAME="kfg-${PIPELINE_RUN_NAME}"
         echo "Looking for secret: ${SECRET_NAME}"
 
-        # Read kubeconfig from secret
-        kubectl get secret ${SECRET_NAME} -n ${NAMESPACE} -o jsonpath='{.data.kubeconfig}' | base64 -d > /shared/kubeconfig
+        # Extract kubeconfig from the secret (0600 so it is not world-readable)
+        kubectl get secret "${SECRET_NAME}" -n "${NAMESPACE}" -o jsonpath='{.data.kubeconfig}' \
+          | base64 -d \
+          | install -m 0600 /dev/stdin /shared/kubeconfig
 
         # Switch to Kind cluster context
         export KUBECONFIG=/shared/kubeconfig

--- a/.integration-tests/tasks/run-e2e-konflux-ui.yaml
+++ b/.integration-tests/tasks/run-e2e-konflux-ui.yaml
@@ -60,6 +60,63 @@ spec:
       - name: test-artifacts
         mountPath: /artifacts
   steps:
+    - name: setup-base-url
+      when:
+        - input: '$(params.job-type)'
+          operator: notin
+          values: ['periodic-stage']
+      image: docker.io/bitnami/kubectl@sha256:95de17e6eb92da83a58c90a9df0c4cede634f898d2e6b92ea04f4a6ee6ace08d
+      volumeMounts:
+        - name: kubeconfig-data
+          mountPath: /shared
+      env:
+        - name: TEKTON_PIPELINE_RUN
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['tekton.dev/pipelineRun']
+        - name: TEKTON_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        echo "=== Getting PipelineRun name and kubeconfig ==="
+
+        # Get PipelineRun name and namespace from environment variables set by Tekton
+        PIPELINE_RUN_NAME="${TEKTON_PIPELINE_RUN}"
+        NAMESPACE="${TEKTON_NAMESPACE}"
+        echo "PipelineRun name: ${PIPELINE_RUN_NAME}"
+        echo "Namespace: ${NAMESPACE}"
+
+        # Construct the secret name
+        SECRET_NAME="kfg-${PIPELINE_RUN_NAME}"
+        echo "Looking for secret: ${SECRET_NAME}"
+
+        # Read kubeconfig from secret
+        kubectl get secret ${SECRET_NAME} -n ${NAMESPACE} -o jsonpath='{.data.kubeconfig}' | base64 -d > /shared/kubeconfig
+
+        # Switch to Kind cluster context
+        export KUBECONFIG=/shared/kubeconfig
+
+        echo "=== Extracting Konflux base URL from kubeconfig ==="
+
+        KUBE_SERVER=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
+        echo "Kubernetes API server: ${KUBE_SERVER}"
+
+        # Extract IP address (remove https:// prefix and :6443 port)
+        KUBE_IP=$(echo "${KUBE_SERVER}" | sed -E 's|https?://([^:]+):.*|\1|')
+        echo "Extracted IP: ${KUBE_IP}"
+
+        CYPRESS_KONFLUX_BASE_URL="https://${KUBE_IP}:9443"
+        echo "Konflux base URL: ${CYPRESS_KONFLUX_BASE_URL}"
+
+        # Save to shared volume for next step
+        echo "${CYPRESS_KONFLUX_BASE_URL}" > /shared/base-url
+
+        echo "Setup complete. Ready for E2E tests."
+
     - name: run-e2e-test
       image: quay.io/konflux_ui_qe/konflux-ui-tests:$(params.test-image-tag)
       onError: continue
@@ -120,6 +177,11 @@ spec:
           export CYPRESS_LOCAL_CLUSTER=false
           export CYPRESS_PERIODIC_RUN_STAGE=true
         else
+          if [ ! -s /shared/base-url ]; then
+            echo "ERROR: /shared/base-url is missing or empty (setup-base-url step failed?)"
+            ls -la /shared/ || true
+            exit 1
+          fi
           export CYPRESS_KONFLUX_BASE_URL=$(cat /shared/base-url)
           export CYPRESS_LOCAL_CLUSTER=true
         fi
@@ -127,9 +189,9 @@ spec:
 
         echo "=== Running E2E tests ==="
         SPEC_FILE="$(params.spec-file)"
-        
+
         echo "Running test spec: ${SPEC_FILE}"
-   
+
         # Run tests and capture exit code (don't exit on failure)
         set +e
         yarn run cy:run --spec "${SPEC_FILE}"


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->
https://redhat.atlassian.net/browse/KFLUXUI-1570

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- Re-adds necessary base-url extraction for `run-e2e-konflux-ui` job. (removed in #1147)
- Updates image for `monitor-webhook-logs.yaml` because previous doesn't include necessary `bash`
- Both jobs use the same image (digest verified via `skopeo`), which includes `bash` and `kubectl`

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic base URL setup for end-to-end tests running against local clusters.
* **Bug Fixes**
  * Added pre-test validation to ensure the base URL is present and non-empty before Cypress starts.
  * Improved local-cluster end-to-end test reliability and configuration.
  * Updated the Kubernetes command-line tool used for webhook log monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->