### PR TITLE
fix(e2e): wait for logs to fully load before searching

### DIFF
--- a/e2e-tests/support/pageObjects/logViewer-po.ts
+++ b/e2e-tests/support/pageObjects/logViewer-po.ts
@@ -3,6 +3,8 @@ export const logViewerPO = {
   viewer: '.pf-v6-c-log-viewer',
   logText: '.pf-v6-c-log-viewer__text',
   searchInput: 'input[name*="logViewerSearchInput"]',
+  /** Shown while task/container logs are still being fetched. */
+  loadingSpinner: '[aria-label="Loading logs"]',
   foldHeader: '[data-test^="fold-header-"]',
   collapsedFoldHeader: '[data-test^="fold-header-"][aria-expanded="false"]',
   /** Expanded section header (AngleDown / aria-expanded=true). */

--- a/e2e-tests/support/pages/ApplicationDetailPage.ts
+++ b/e2e-tests/support/pages/ApplicationDetailPage.ts
@@ -17,13 +17,15 @@ export class ApplicationDetailPage {
     cy.testA11y(`${pageTitles.deploymentSettings} page`);
   }
 
-  checkBuildLog(tasklistItem: string, textToVerify: string, taskTimeout: number = 20000) {
+  checkBuildLog(tasklistItem: string, textToVerify: string, taskTimeout: number = 60000) {
     cy.get('span[class="pipeline-run-logs__namespan"]')
       .contains(tasklistItem, { timeout: taskTimeout })
       .scrollIntoView()
       .should('be.visible')
-      .click();
-    LogViewerHelper.revealLogText(textToVerify);
+      .click({ force: true });
+    // Wait for the selected task's logs to finish fetching before searching.
+    LogViewerHelper.waitForLogFetch(taskTimeout);
+    LogViewerHelper.revealLogText(textToVerify, { timeout: taskTimeout });
   }
 
   checkPodLog(podName: string, textToVerify: string) {
@@ -32,6 +34,7 @@ export class ApplicationDetailPage {
       .scrollIntoView()
       .should('be.visible')
       .click();
+    LogViewerHelper.waitForLogFetch();
     LogViewerHelper.revealLogText(textToVerify);
   }
 
@@ -53,6 +56,18 @@ export class ApplicationDetailPage {
   closeBuildLog() {
     cy.get(buildLogModalContentPO.closeButton).should('be.visible').click();
     cy.get(buildLogModalContentPO.modal).should('not.exist');
+  }
+
+  /** Close the build-log modal if still open (safe for afterEach cleanup). */
+  closeBuildLogIfOpen() {
+    cy.get('body').then(($body) => {
+      if ($body.find(buildLogModalContentPO.modal).length > 0) {
+        cy.get(`${buildLogModalContentPO.modal} ${buildLogModalContentPO.closeButton}`)
+          .first()
+          .click({ force: true });
+        cy.get(buildLogModalContentPO.modal).should('not.exist');
+      }
+    });
   }
 
   createdComponentExists(component: string, application: string) {

--- a/e2e-tests/support/pages/ApplicationDetailPage.ts
+++ b/e2e-tests/support/pages/ApplicationDetailPage.ts
@@ -58,18 +58,6 @@ export class ApplicationDetailPage {
     cy.get(buildLogModalContentPO.modal).should('not.exist');
   }
 
-  /** Close the build-log modal if still open (safe for afterEach cleanup). */
-  closeBuildLogIfOpen() {
-    cy.get('body').then(($body) => {
-      if ($body.find(buildLogModalContentPO.modal).length > 0) {
-        cy.get(`${buildLogModalContentPO.modal} ${buildLogModalContentPO.closeButton}`)
-          .first()
-          .click({ force: true });
-        cy.get(buildLogModalContentPO.modal).should('not.exist');
-      }
-    });
-  }
-
   createdComponentExists(component: string, application: string) {
     Common.verifyPageTitle(application);
     Common.waitForLoad();

--- a/e2e-tests/tests/basic-happy-path.spec.ts
+++ b/e2e-tests/tests/basic-happy-path.spec.ts
@@ -214,26 +214,19 @@ describe('Basic Happy Path', () => {
   });
 
   describe('Check Component', () => {
-    before(() => {
+    it('Check component build status and logs', () => {
+      cy.log('Check component build status and logs');
       Applications.goToComponentsTab();
-    });
+      Applications.checkComponentStatus(componentName, 'Build completed');
 
-    describe('Validate Build Logs', () => {
-      afterEach(() => {
-        // Always close so a failed assertion cannot leave the modal over later suites.
-        applicationDetailPage.closeBuildLog();
-      });
+      cy.log('Validate Build Logs are successful');
+      applicationDetailPage.openBuildLog(componentName);
+      applicationDetailPage.verifyBuildLogTaskslist(piplinerunlogsTasks); //TO DO : Fetch the piplinerunlogsTasks from cluster using api At runtime.
+      applicationDetailPage.verifyFailedLogTasksNotExists();
+      applicationDetailPage.checkBuildLog(pipelineConfig.logCheckTask, 'Using token for quay.io');
+      applicationDetailPage.closeBuildLog();
 
-      it('Check component build status and logs', () => {
-        Applications.checkComponentStatus(componentName, 'Build completed');
-        applicationDetailPage.openBuildLog(componentName);
-        applicationDetailPage.verifyBuildLogTaskslist(piplinerunlogsTasks); //TO DO : Fetch the piplinerunlogsTasks from cluster using api At runtime.
-        applicationDetailPage.verifyFailedLogTasksNotExists();
-        applicationDetailPage.checkBuildLog(pipelineConfig.logCheckTask, 'Using token for quay.io');
-      });
-    });
-
-    it('Verify deployed image exists', () => {
+      cy.log('Verify deployed image exists');
       ComponentsTabPage.openComponent(componentName);
       ComponentDetailsPage.checkBuildImage();
     });

--- a/e2e-tests/tests/basic-happy-path.spec.ts
+++ b/e2e-tests/tests/basic-happy-path.spec.ts
@@ -214,6 +214,11 @@ describe('Basic Happy Path', () => {
   });
 
   describe('Check Component', () => {
+    afterEach(() => {
+      // Prevent a failed log assertion from leaving the modal open over later suites.
+      applicationDetailPage.closeBuildLogIfOpen();
+    });
+
     it('Check component build status and logs', () => {
       Applications.goToComponentsTab();
       Applications.checkComponentStatus(componentName, 'Build completed');

--- a/e2e-tests/tests/basic-happy-path.spec.ts
+++ b/e2e-tests/tests/basic-happy-path.spec.ts
@@ -214,23 +214,26 @@ describe('Basic Happy Path', () => {
   });
 
   describe('Check Component', () => {
-    afterEach(() => {
-      // Prevent a failed log assertion from leaving the modal open over later suites.
-      applicationDetailPage.closeBuildLogIfOpen();
+    before(() => {
+      Applications.goToComponentsTab();
     });
 
-    it('Check component build status and logs', () => {
-      Applications.goToComponentsTab();
-      Applications.checkComponentStatus(componentName, 'Build completed');
+    describe('Validate Build Logs', () => {
+      afterEach(() => {
+        // Always close so a failed assertion cannot leave the modal over later suites.
+        applicationDetailPage.closeBuildLog();
+      });
 
-      cy.log('Validate Build Logs are successful');
-      applicationDetailPage.openBuildLog(componentName);
-      applicationDetailPage.verifyBuildLogTaskslist(piplinerunlogsTasks); //TO DO : Fetch the piplinerunlogsTasks from cluster using api At runtime.
-      applicationDetailPage.verifyFailedLogTasksNotExists();
-      applicationDetailPage.checkBuildLog(pipelineConfig.logCheckTask, 'Using token for quay.io');
-      applicationDetailPage.closeBuildLog();
+      it('Check component build status and logs', () => {
+        Applications.checkComponentStatus(componentName, 'Build completed');
+        applicationDetailPage.openBuildLog(componentName);
+        applicationDetailPage.verifyBuildLogTaskslist(piplinerunlogsTasks); //TO DO : Fetch the piplinerunlogsTasks from cluster using api At runtime.
+        applicationDetailPage.verifyFailedLogTasksNotExists();
+        applicationDetailPage.checkBuildLog(pipelineConfig.logCheckTask, 'Using token for quay.io');
+      });
+    });
 
-      cy.log('Verify deployed image exists');
+    it('Verify deployed image exists', () => {
       ComponentsTabPage.openComponent(componentName);
       ComponentDetailsPage.checkBuildImage();
     });

--- a/e2e-tests/utils/LogViewerHelper.ts
+++ b/e2e-tests/utils/LogViewerHelper.ts
@@ -16,6 +16,20 @@ export class LogViewerHelper {
   }
 
   /**
+   * Wait for the post-task-selection fetch cycle: spinner appears, then clears.
+   * Call after clicking a task/pod in the log sidebar.
+   */
+  static waitForLogFetch(timeout: number = 20000) {
+    cy.get(logViewerPO.loadingSpinner, { timeout }).should('be.visible');
+    cy.get(logViewerPO.loadingSpinner, { timeout }).should('not.exist');
+  }
+
+  /** Wait until any in-flight log fetch spinner is gone. */
+  static waitForLogsLoaded(timeout: number = 20000) {
+    cy.get(logViewerPO.loadingSpinner, { timeout }).should('not.exist');
+  }
+
+  /**
    * Search for `logText` (which expands the matching folded step) and assert it is visible.
    * When `assertInitiallyFolded`, also checks no section is expanded before searching.
    * Defaults to the Cypress `defaultCommandTimeout` (40s).
@@ -26,6 +40,7 @@ export class LogViewerHelper {
   ) {
     const waitTimeout = options.timeout ?? 40000;
     this.waitForFoldedSteps(waitTimeout);
+    this.waitForLogsLoaded(waitTimeout);
     if (options.assertInitiallyFolded) {
       cy.get(logViewerPO.expandedFoldHeader).should('not.exist');
     }


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->


## Description
Added a wait for logs to fully load before searching


## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log viewer synchronization by waiting for logs to finish loading before displaying, searching, or interacting with folded content.
  * Increased build and pod log verification reliability during slower log retrieval.
  * Extended the build-log verification timeout from 20 to 60 seconds to reduce failures caused by delayed loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->