### PR TITLE
fix(KFLUXUI-1572): adds dex approval for local login in e2e tests

### DIFF
--- a/e2e-tests/support/pageObjects/login-po.ts
+++ b/e2e-tests/support/pageObjects/login-po.ts
@@ -14,6 +14,8 @@ export const localKonfluxLoginPO = {
   password: '#password',
   loginButton: '#submit-login',
   dex: `button[type="submit"]`,
+  grantAccessClass: `.dex-btn-text`,
+  grantAccessText: 'Grant Access',
 };
 
 export const openshiftLoginPO = {

--- a/e2e-tests/utils/Login.ts
+++ b/e2e-tests/utils/Login.ts
@@ -36,8 +36,15 @@ export class Login {
     cy.get(localKonfluxLoginPO.password).type(password, { log: false });
     cy.get(localKonfluxLoginPO.loginButton).click();
 
-    // Dex OAuth consent (idp/approval) — Grant Access is required for local cluster
-    cy.contains(localKonfluxLoginPO.grantAccessClass, localKonfluxLoginPO.grantAccessText).click();
+    // Grant Access appears on some deploys
+    cy.get('body', { timeout: 30000 }).then(($body) => {
+      if ($body.find(localKonfluxLoginPO.grantAccessClass).length > 0) {
+        cy.contains(
+          localKonfluxLoginPO.grantAccessClass,
+          localKonfluxLoginPO.grantAccessText,
+        ).click();
+      }
+    });
 
     this.waitForApps();
   }

--- a/e2e-tests/utils/Login.ts
+++ b/e2e-tests/utils/Login.ts
@@ -35,6 +35,10 @@ export class Login {
     cy.get(localKonfluxLoginPO.username).type(username);
     cy.get(localKonfluxLoginPO.password).type(password, { log: false });
     cy.get(localKonfluxLoginPO.loginButton).click();
+
+    // Dex OAuth consent (idp/approval) — Grant Access is required for local cluster
+    cy.contains(localKonfluxLoginPO.grantAccessClass, localKonfluxLoginPO.grantAccessText).click();
+
     this.waitForApps();
   }
 


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->
https://redhat.atlassian.net/browse/KFLUXUI-1572

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Consents to Dex while loging in locally in e2e tests.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [X] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->
<img width="1920" height="993" alt="Create an Application with a component -- before all hook (failed)" src="https://github.com/user-attachments/assets/e9e25cf1-b147-4bad-b48a-d6a8bb0ad42e" />


## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the local login flow by handling the Dex OAuth “Grant Access” consent step automatically.
  * End-to-end tests now continue reliably after authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->