### PR TITLE
fix(KFLUXUI-1506): fix watched resource updates

### DIFF
--- a/src/components/ReleaseService/ReleasePlan/TriggerRelease/__tests__/TriggerReleaseFormPage.spec.tsx
+++ b/src/components/ReleaseService/ReleasePlan/TriggerRelease/__tests__/TriggerReleaseFormPage.spec.tsx
@@ -1,6 +1,8 @@
 import { act, fireEvent, screen } from '@testing-library/react';
 import * as yup from 'yup';
-import { createK8sWatchResourceMock, namespaceRenderer } from '../../../../../utils/test-utils';
+import { mockUseNamespaceHook } from '~/unit-test-utils/mock-namespace';
+import { renderWithQueryClientAndRouter } from '~/unit-test-utils/rendering-utils';
+import { createK8sWatchResourceMock } from '~/utils/test-utils';
 import { createRelease } from '../form-utils';
 import { TriggerReleaseFormPage } from '../TriggerReleaseFormPage';
 
@@ -43,6 +45,7 @@ const watchResourceMock = createK8sWatchResourceMock();
 
 describe('TriggerReleaseFormPage', () => {
   beforeEach(() => {
+    mockUseNamespaceHook('test-ns');
     watchResourceMock.mockReturnValue([[], true]);
   });
 
@@ -52,7 +55,7 @@ describe('TriggerReleaseFormPage', () => {
       true,
     ]);
     triggerReleasePlanMock.mockResolvedValue({ metadata: { name: 'newRelease' }, spec: {} });
-    namespaceRenderer(<TriggerReleaseFormPage />, 'test-ns');
+    renderWithQueryClientAndRouter(<TriggerReleaseFormPage />);
 
     await act(() => fireEvent.click(screen.getByRole('button', { name: 'Submit' })));
 
@@ -73,7 +76,7 @@ describe('TriggerReleaseFormPage', () => {
   });
 
   it('should navigate to release list on reset', async () => {
-    namespaceRenderer(<TriggerReleaseFormPage />, 'test-ns');
+    renderWithQueryClientAndRouter(<TriggerReleaseFormPage />);
 
     await act(() => fireEvent.click(screen.getByRole('button', { name: 'Reset' })));
 

--- a/src/hooks/useK8sAndKarchResources.ts
+++ b/src/hooks/useK8sAndKarchResources.ts
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { hashKey } from '@tanstack/query-core';
+import { useQuery } from '@tanstack/react-query';
+import { createGetQueryOptions, createQueryKeys, useK8sWatchResource } from '~/k8s';
 import { useK8sQueryWatch } from '~/k8s/hooks/useK8sQueryWatch';
+import { POLLING_INTERVAL } from '~/k8s/hooks/useK8sWatchResource';
 import { WebSocketOptions } from '~/k8s/web-socket/types';
 import { fetchResourceWithK8sAndKubeArchive } from '~/kubearchive/resource-utils';
-import { createQueryKeys, useK8sWatchResource } from '../k8s';
 import { K8sResourceReadOptions } from '../k8s/k8s-fetch';
 import { TQueryOptions } from '../k8s/query/type';
 import { useKubearchiveListResourceQuery } from '../kubearchive/hooks';
@@ -255,8 +257,19 @@ export function useK8sAndKarchResource<TResource extends K8sResourceCommon>(
     watchOptions,
   );
 
+  const { data: watchedResource } = useQuery<TResource>(
+    shouldWatch
+      ? {
+          ...createGetQueryOptions<TResource>(resourceInit),
+          refetchInterval: wsError ? POLLING_INTERVAL : undefined,
+        }
+      : { queryKey: ['disabled'], enabled: false },
+  );
+
+  const data = (shouldWatch && watchedResource) || result?.resource;
+
   return {
-    data: result?.resource,
+    data,
     source: result?.source,
     isLoading,
     fetchError,

--- a/src/hooks/useK8sAndKarchResources.ts
+++ b/src/hooks/useK8sAndKarchResources.ts
@@ -260,7 +260,7 @@ export function useK8sAndKarchResource<TResource extends K8sResourceCommon>(
   const { data: watchedResource } = useQuery<TResource>(
     shouldWatch
       ? {
-          ...createGetQueryOptions<TResource>(resourceInit),
+          ...createGetQueryOptions<TResource>(resourceInit, memoizedQueryOptions),
           refetchInterval: wsError ? POLLING_INTERVAL : undefined,
         }
       : { queryKey: ['disabled'], enabled: false },

--- a/src/k8s/hooks/useK8sWatchResource.ts
+++ b/src/k8s/hooks/useK8sWatchResource.ts
@@ -12,7 +12,7 @@ import { createGetQueryOptions, createListqueryOptions, createQueryKeys } from '
 import { WebSocketOptions } from '../web-socket/types';
 import { useK8sQueryWatch } from './useK8sQueryWatch';
 
-const POLLING_INTERVAL = 10000;
+export const POLLING_INTERVAL = 10000;
 
 export const useK8sWatchResource = <R extends K8sResourceCommon | K8sResourceCommon[]>(
   resourceInit: WatchK8sResource,

--- a/src/shared/components/pipeline-run-logs/logs/MultiStreamLogs.tsx
+++ b/src/shared/components/pipeline-run-logs/logs/MultiStreamLogs.tsx
@@ -36,6 +36,7 @@ export const MultiStreamLogs: React.FC<MultiStreamLogsProps> = ({
 
   return (
     <Logs
+      key={resource?.metadata?.uid}
       resource={resource}
       containers={containers}
       allowAutoScroll


### PR DESCRIPTION
## Fixes 
<!-- For e.g Fixes: https://issues.redhat.com/browse/KFLUXUI-XXX -->

Fixes https://redhat.atlassian.net/browse/KFLUXUI-1506

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Two fixes:

1. `useK8sAndKarchResource` was setting data once on initial fetch but never picking up updates from the WebSocket watch. Now reads from the query cache so live updates surface immediately. Also adds polling fallback (10s) when the WebSocket fails, matching `useK8sWatchResource` behavior.

2. `MultiStreamLogs` didn't key the `Logs` component by pod UID. When switching between tasks, the component kept its internal state (buffers, connections), causing fetched logs to append to stale data and appear duplicated.

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Feature
- [x] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Screen shots / Gifs for design review 
<!-- If change affects UI in any way, tag relevant UX people and add screenshots/gifs  -->

Before:

https://github.com/user-attachments/assets/9f44650a-31a3-43a1-9482-6810e6943f18

After:

https://github.com/user-attachments/assets/7a14500b-0e92-45fb-a95b-36c9c03ea41a

## How to test or reproduce?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

<!-- - [ ] Test A -->
<!-- - [ ] Test B -->

<!-- **Test Configuration(s)**: -->

- enable KubeArchive feature flag and open a PipelineRun logs page - verify logs stream correctly
- switch between different tasks in the log viewer - verify logs reset cleanly without duplicates
- navigate to Release Details page - verify release data loads and updates
- navigate to Snapshot Details page - verify snapshot data loads and updates
- trigger a new PipelineRun and watch the logs - verify log lines flow in real-time
- ☕ 


## Browser conformance: 
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge


<!-- ## Checklist: -->

<!-- 
- [ ] Code follows the style guidelines
- [ ] Self-reviewed the code
- [ ] Added comments in hard-to-understand areas
- [ ] Made corresponding changes to the documentation
- [ ] Changes generate no new warnings
- [ ] Added tests that prove this fix is effective or that the feature works
- [ ] New and existing unit tests pass locally with new changes
- [ ] Any dependent changes have been merged and published in downstream modules 
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved live updates for watched cluster resources.
- Added automatic polling every 10 seconds when the live connection encounters an error.
- Ensured the latest watched data is displayed, with a fallback to previously fetched data.
- Improved pipeline log updates when streamed content changes.

## Tests

- Updated release navigation tests to use the current rendering and namespace setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->