### PR TITLE
Update .codecov.yml: add ignore patterns for non-code files

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,6 +17,13 @@ coverage:
 
 ignore:
   - "**/*__data__*/*.ts"
+  - ".agents/**"
+  - ".claude/**"
+  - ".cursor/**"
+  - "skills/**"
+  - "docs/**"
+  - "*.md"
+  - "*.toml"
 
 comment:
   layout: "reach,diff,flags,files,footer"


### PR DESCRIPTION
## Summary

Adds ignore patterns to `.codecov.yml` for non-executable files that inflate the coverage denominator:

- `.agents/**` — AI agent configurations
- `.claude/**` — Claude AI workspace settings
- `.cursor/**` — Cursor AI settings
- `skills/**` — AI skill definitions
- `docs/**` — Documentation files
- `*.md` — Markdown files
- `*.toml` — TOML configuration files

Existing ignore patterns (`**/*__data__*/*.ts`) and all coverage settings are preserved.

## Why

Non-executable files are counted as "uncovered lines" by Codecov, dragging down patch coverage even though they can't be tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated coverage analysis exclusions for configuration, documentation, Markdown, TOML, and related support files.
  * No end-user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->