### PR TITLE
chore(KFLUXUI-1618): add staging PRs to release cut PR description

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -173,6 +173,36 @@ jobs:
             -d "$(pwd)" \
             -o /tmp/changelog.md
 
+      # --- Fetch staging PRs merged in the last 14 days ---
+      - name: Fetch staging PRs
+        env:
+          GH_TOKEN: ${{ secrets.INFRA_PR_PAT }}
+        run: |
+          END_DATE=$(date -d "${RELEASE_DATE} -1 day" +%Y-%m-%d 2>/dev/null \
+            || date -v-1d -j -f "%Y-%m-%d" "$RELEASE_DATE" +%Y-%m-%d)
+          START_DATE=$(date -d "${RELEASE_DATE} -14 days" +%Y-%m-%d 2>/dev/null \
+            || date -v-14d -j -f "%Y-%m-%d" "$RELEASE_DATE" +%Y-%m-%d)
+
+          echo "Fetching staging PRs merged between ${START_DATE} and ${END_DATE}"
+
+          STAGING_PRS=$(gh pr list \
+            --repo "$INFRA_REPO" \
+            --search "is:pr is:closed merged:${START_DATE}..${END_DATE} author:app/rh-tap-build-team konflux-ui update" \
+            --state closed \
+            --limit 100 \
+            --json number,url,mergedAt \
+            --jq '.[] | "- \(.mergedAt[0:10])  \(.url)"' \
+            | sort)
+
+          if [[ -z "$STAGING_PRS" ]]; then
+            echo "No staging PRs found in the last 14 days." > /tmp/staging-prs.md
+          else
+            echo "$STAGING_PRS" > /tmp/staging-prs.md
+          fi
+
+          echo "--- Staging PRs ---"
+          cat /tmp/staging-prs.md
+
       # --- Create tracking issue (before infra PR so we can include Fixes link) ---
       - name: Create tracking issue
         id: tracking
@@ -250,6 +280,11 @@ jobs:
             --title "chore: bump konflux-ui ${SHORT_OLD} => ${SHORT_NEW}" \
             --body "$(cat <<PRBODY
           Update konflux-ui production image to staging commit \`${NEW_SHA}\`.
+
+          ## Verification
+
+          Staging PRs:
+          $(cat /tmp/staging-prs.md)
 
           <details>
           <summary>What's in this release</summary>


### PR DESCRIPTION
## Fixes
Fixes: https://redhat.atlassian.net/browse/KFLUXUI-1618

## Description
Adds a "Verification > Staging PRs" section to the infra-deployments PR created by the release-prod workflow. A new step queries `gh pr list` for konflux-ui staging PRs merged in the last 14 days (from `redhat-appstudio/infra-deployments` by `app/rh-tap-build-team`) and includes the list in the PR body before the changelog details block, making it easy for reviewers to verify what was deployed to staging before promoting to production.

## Type of change
- [x] Build related changes

## Screen shots / Gifs for design review
N/A — CI workflow change only, no UI impact.

## How to test or reproduce?
1. Trigger the `Release Prod` workflow via `workflow_dispatch` (with `force: true`)
2. Verify the created infra-deployments PR body contains a `## Verification` section with staging PR links before the `<details>` changelog block

## Browser conformance:
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release deployment summaries now include staging promotion pull requests merged during the 14 days before release.
  * Added a Verification section to deployment records.
  * Improved compatibility across environments when calculating release date ranges.
  * Displays a clear message when no staging promotions are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->